### PR TITLE
Fix Travis-CI build button on GitHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,10 +38,10 @@ Uninstall
 
     python3 -m pip uninstall spl
     
-.. |build-devel| image:: https://travis-ci.org/pyccel/psydac.svg?branch=devel
+.. |build-devel| image:: https://travis-ci.com/pyccel/psydac.svg?branch=devel
     :alt: devel status
     :scale: 100%
-    :target: https://travis-ci.org/pyccel/psydac
+    :target: https://travis-ci.com/pyccel/psydac
 
 .. |docs| image:: https://readthedocs.org/projects/spl/badge/?version=latest
     :alt: Documentation Status


### PR DESCRIPTION
Fix build button status and link, which were broken after migration from travis-ci.org to travis-ci.com