### PR TITLE
Add Pyccel and Numba backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,11 @@ before_install:
   - python -m pip uninstall -y pyccel
   - python -m pip uninstall -y gelato
   - python -m pip install -r requirements.txt
-  - python -m pip install numba
 
 # command to install project
 install:
   - python -m pip install .
+  - python -m pip install numba
   - python -m pip freeze
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: python
 
 # which python versions to test
 python:
-  - 3.5
   - 3.6
   - 3.7
+  - 3.8
 
 # Cache directory $HOME/.cache/pip
 cache: pip
@@ -25,6 +25,7 @@ before_install:
   - python -m pip uninstall -y pyccel
   - python -m pip uninstall -y gelato
   - python -m pip install -r requirements.txt
+  - python -m pip install numba
 
 # command to install project
 install:

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -52,7 +52,8 @@ from sympde.topology.derivatives import _logical_partial_derivatives
 from sympde.topology.derivatives import get_max_logical_partial_derivatives
 from sympde.topology.mapping     import InterfaceMapping
 
-from pyccel.ast.core  import _atomic
+from pyccel.ast.core          import _atomic
+from psydac.api.ast.utilities import variables
 
 from .nodes import index_quad
 from .nodes import index_element
@@ -61,6 +62,7 @@ from .nodes import index_dof_trial
 
 from collections import OrderedDict
 from itertools   import groupby
+
 
 
 #==============================================================================
@@ -453,7 +455,7 @@ def _create_ast_bilinear_form(terminal_expr, atomic_expr, atomic_expr_field,
 
     """
 
-    pads   = symbols('pad1, pad2, pad3')[:dim]
+    pads   = variables(('pad1, pad2, pad3'), dtype='int')[:dim]
     g_quad = GlobalTensorQuadrature()
     l_quad = LocalTensorQuadrature()
 
@@ -626,7 +628,7 @@ def _create_ast_linear_form(terminal_expr, atomic_expr, atomic_expr_field, tests
         represents the a function definition node that computes the assembly
 
     """
-    pads   = symbols('pad1, pad2, pad3')[:dim]
+    pads   = variables(('pad1, pad2, pad3'), dtype='int')[:dim]
     g_quad = GlobalTensorQuadrature()
     l_quad = LocalTensorQuadrature()
 
@@ -781,7 +783,7 @@ def _create_ast_functional_form(terminal_expr, atomic_expr, tests, d_tests, cons
 
     """
 
-    pads   = symbols('pad1, pad2, pad3')[:dim]
+    pads   = variables(('pad1, pad2, pad3'), dtype='int')[:dim]
     g_quad = GlobalTensorQuadrature()
     l_quad = LocalTensorQuadrature()
 

--- a/psydac/api/printing/pycode.py
+++ b/psydac/api/printing/pycode.py
@@ -70,9 +70,6 @@ class PythonCodePrinter(PyccelPythonCodePrinter):
     #        SYMPY objects
     # .........................................................
     def _print_AppliedUndef(self, expr):
-        if not expr._imp_:
-            raise ValueError('_imp_ not impltemented')
-
         args = ','.join(self._print(i) for i in expr.args)
         fname = self._print(expr.func.__name__)
         return '{fname}({args})'.format(fname=fname, args=args)

--- a/psydac/api/tests/test_api_2d_scalar_backends.py
+++ b/psydac/api/tests/test_api_2d_scalar_backends.py
@@ -310,6 +310,12 @@ def test_poisson_2d_dir0_1234_numba():
     assert( abs(l2_error - expected_l2_error) < 1.e-7)
     assert( abs(h1_error - expected_h1_error) < 1.e-7)
 
+###############################################################################
+#            PARALLEL TESTS
+###############################################################################
+
+#==============================================================================
+
 @pytest.mark.parallel
 def test_poisson_2d_dir0_1234_parallel_pyccel():
 
@@ -347,6 +353,8 @@ def test_poisson_2d_dir0_1234_parallel_numba():
 
     assert( abs(l2_error - expected_l2_error) < 1.e-7)
     assert( abs(h1_error - expected_h1_error) < 1.e-7)
+
+
 #==============================================================================
 # CLEAN UP SYMPY NAMESPACE
 #==============================================================================

--- a/psydac/api/tests/test_api_2d_scalar_backends.py
+++ b/psydac/api/tests/test_api_2d_scalar_backends.py
@@ -309,6 +309,44 @@ def test_poisson_2d_dir0_1234_numba():
 
     assert( abs(l2_error - expected_l2_error) < 1.e-7)
     assert( abs(h1_error - expected_h1_error) < 1.e-7)
+
+@pytest.mark.parallel
+def test_poisson_2d_dir0_1234_parallel_pyccel():
+
+    solution = sin(pi*x)*sin(pi*y)
+    f        = 2*pi**2*sin(pi*x)*sin(pi*y)
+
+    dir_zero_boundary    = get_boundaries(1, 2, 3, 4)
+    dir_nonzero_boundary = get_boundaries()
+
+    l2_error, h1_error = run_poisson_2d(solution, f, dir_zero_boundary,
+            dir_nonzero_boundary, ncells=[2**3, 2**3], degree=[2, 2],
+            comm=MPI.COMM_WORLD, backend=PSYDAC_BACKEND_GPYCCEL)
+
+    expected_l2_error =  0.00021808678604760232
+    expected_h1_error =  0.013023570720360362
+
+    assert( abs(l2_error - expected_l2_error) < 1.e-7)
+    assert( abs(h1_error - expected_h1_error) < 1.e-7)
+
+@pytest.mark.parallel
+def test_poisson_2d_dir0_1234_parallel_numba():
+
+    solution = sin(pi*x)*sin(pi*y)
+    f        = 2*pi**2*sin(pi*x)*sin(pi*y)
+
+    dir_zero_boundary    = get_boundaries(1, 2, 3, 4)
+    dir_nonzero_boundary = get_boundaries()
+
+    l2_error, h1_error = run_poisson_2d(solution, f, dir_zero_boundary,
+            dir_nonzero_boundary, ncells=[2**3, 2**3], degree=[2, 2],
+            comm=MPI.COMM_WORLD, backend=PSYDAC_BACKEND_NUMBA)
+
+    expected_l2_error =  0.00021808678604760232
+    expected_h1_error =  0.013023570720360362
+
+    assert( abs(l2_error - expected_l2_error) < 1.e-7)
+    assert( abs(h1_error - expected_h1_error) < 1.e-7)
 #==============================================================================
 # CLEAN UP SYMPY NAMESPACE
 #==============================================================================

--- a/psydac/api/tests/test_api_2d_scalar_backends.py
+++ b/psydac/api/tests/test_api_2d_scalar_backends.py
@@ -1,0 +1,322 @@
+# -*- coding: UTF-8 -*-
+
+from mpi4py import MPI
+from sympy import pi, cos, sin, symbols
+from sympy.utilities.lambdify import implemented_function
+import pytest
+
+from sympde.calculus import grad, dot
+from sympde.calculus import laplace
+from sympde.topology import ScalarFunctionSpace
+from sympde.topology import element_of
+from sympde.topology import NormalVector
+from sympde.topology import Square
+from sympde.topology import Union
+from sympde.expr     import BilinearForm, LinearForm, integral
+from sympde.expr     import Norm
+from sympde.expr     import find, EssentialBC
+
+from psydac.fem.basic          import FemField
+from psydac.api.discretization import discretize
+
+from psydac.api.settings import PSYDAC_BACKEND_GPYCCEL, PSYDAC_BACKEND_NUMBA
+
+x,y,z = symbols('x1, x2, x3')
+#==============================================================================
+def get_boundaries(*args):
+
+    if not args:
+        return ()
+    else:
+        assert all(1 <= a <= 4 for a in args)
+        assert len(set(args)) == len(args)
+
+    boundaries = {1: {'axis': 0, 'ext': -1},
+                  2: {'axis': 0, 'ext':  1},
+                  3: {'axis': 1, 'ext': -1},
+                  4: {'axis': 1, 'ext':  1}}
+
+    return tuple(boundaries[i] for i in args)
+
+#==============================================================================
+def run_poisson_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
+        ncells, degree, backend=None, comm=None):
+
+    assert isinstance(dir_zero_boundary   , (list, tuple))
+    assert isinstance(dir_nonzero_boundary, (list, tuple))
+
+    #+++++++++++++++++++++++++++++++
+    # 1. Abstract model
+    #+++++++++++++++++++++++++++++++
+    domain = Square()
+
+    B_dirichlet_0 = Union(*[domain.get_boundary(**kw) for kw in dir_zero_boundary])
+    B_dirichlet_i = Union(*[domain.get_boundary(**kw) for kw in dir_nonzero_boundary])
+    B_dirichlet   = Union(B_dirichlet_0, B_dirichlet_i)
+    B_neumann = domain.boundary.complement(B_dirichlet)
+
+    V  = ScalarFunctionSpace('V', domain)
+    u  = element_of(V, name='u')
+    v  = element_of(V, name='v')
+    nn = NormalVector('nn')
+
+    # Bilinear form a: V x V --> R
+    a = BilinearForm((u, v), integral(domain, dot(grad(u), grad(v))))
+
+    # Linear form l: V --> R
+    l0 = LinearForm(v, integral(domain, f * v))
+    if B_neumann:
+        l1 = LinearForm(v, integral(B_neumann, v * dot(grad(solution), nn)))
+        l  = LinearForm(v, l0(v) + l1(v))
+    else:
+        l = l0
+
+    # Dirichlet boundary conditions
+    bc = []
+    if B_dirichlet_0:  bc += [EssentialBC(u,        0, B_dirichlet_0)]
+    if B_dirichlet_i:  bc += [EssentialBC(u, solution, B_dirichlet_i)]
+
+    # Variational model
+    equation = find(u, forall=v, lhs=a(u, v), rhs=l(v), bc=bc)
+
+    # Error norms
+    error  = u - solution
+    l2norm = Norm(error, domain, kind='l2')
+    h1norm = Norm(error, domain, kind='h1')
+
+    #+++++++++++++++++++++++++++++++
+    # 2. Discretization
+    #+++++++++++++++++++++++++++++++
+
+    # Create computational domain from topological domain
+    domain_h = discretize(domain, ncells=ncells, comm=comm)
+
+    # Discrete spaces
+    Vh = discretize(V, domain_h, degree=degree)
+
+    # Discretize equation using Dirichlet bc
+    equation_h = discretize(equation, domain_h, [Vh, Vh], backend=backend)
+
+    # Discretize error norms
+    l2norm_h = discretize(l2norm, domain_h, Vh, backend=backend)
+    h1norm_h = discretize(h1norm, domain_h, Vh, backend=backend)
+
+    #+++++++++++++++++++++++++++++++
+    # 3. Solution
+    #+++++++++++++++++++++++++++++++
+
+    # Solve linear system
+    x  = equation_h.solve()
+    uh = FemField( Vh, x )
+
+    # Compute error norms
+    l2_error = l2norm_h.assemble(u=uh)
+    h1_error = h1norm_h.assemble(u=uh)
+
+    return l2_error, h1_error
+
+#==============================================================================
+def run_laplace_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
+        ncells, degree, comm=None):
+
+    assert isinstance(dir_zero_boundary   , (list, tuple))
+    assert isinstance(dir_nonzero_boundary, (list, tuple))
+
+    #+++++++++++++++++++++++++++++++
+    # 1. Abstract model
+    #+++++++++++++++++++++++++++++++
+    domain = Square()
+
+    B_dirichlet_0 = Union(*[domain.get_boundary(**kw) for kw in dir_zero_boundary])
+    B_dirichlet_i = Union(*[domain.get_boundary(**kw) for kw in dir_nonzero_boundary])
+    B_dirichlet   = Union(B_dirichlet_0, B_dirichlet_i)
+    B_neumann = domain.boundary.complement(B_dirichlet)
+
+    V  = ScalarFunctionSpace('V', domain)
+    u  = element_of(V, name='u')
+    v  = element_of(V, name='v')
+    nn = NormalVector('nn')
+
+    # Bilinear form a: V x V --> R
+    a = BilinearForm((u, v), integral(domain, dot(grad(u), grad(v)) + u * v))
+
+    # Linear form l: V --> R
+    l0 = LinearForm(v, integral(domain, f * v))
+    if B_neumann:
+        l1 = LinearForm(v, integral(B_neumann, v * dot(grad(solution), nn)))
+        l  = LinearForm(v, l0(v) + l1(v))
+    else:
+        l = l0
+
+    # Dirichlet boundary conditions
+    bc = []
+    if B_dirichlet_0:  bc += [EssentialBC(u,        0, B_dirichlet_0)]
+    if B_dirichlet_i:  bc += [EssentialBC(u, solution, B_dirichlet_i)]
+
+    # Variational model
+    equation = find(u, forall=v, lhs=a(u, v), rhs=l(v), bc=bc)
+
+    # Error norms
+    error  = u - solution
+    l2norm = Norm(error, domain, kind='l2')
+    h1norm = Norm(error, domain, kind='h1')
+
+    #+++++++++++++++++++++++++++++++
+    # 2. Discretization
+    #+++++++++++++++++++++++++++++++
+
+    # Create computational domain from topological domain
+    domain_h = discretize(domain, ncells=ncells, comm=comm)
+
+    # Discrete spaces
+    Vh = discretize(V, domain_h, degree=degree)
+
+    # Discretize equation using Dirichlet bc
+    equation_h = discretize(equation, domain_h, [Vh, Vh])
+
+    # Discretize error norms
+    l2norm_h = discretize(l2norm, domain_h, Vh)
+    h1norm_h = discretize(h1norm, domain_h, Vh)
+
+    #+++++++++++++++++++++++++++++++
+    # 3. Solution
+    #+++++++++++++++++++++++++++++++
+
+    # Solve linear system
+    x  = equation_h.solve()
+    uh = FemField( Vh, x )
+
+    # Compute error norms
+    l2_error = l2norm_h.assemble(u=uh)
+    h1_error = h1norm_h.assemble(u=uh)
+
+    return l2_error, h1_error
+
+#==============================================================================
+def run_biharmonic_2d_dir(solution, f, dir_zero_boundary, ncells, degree, comm=None):
+
+    assert isinstance(dir_zero_boundary, (list, tuple))
+
+    #+++++++++++++++++++++++++++++++
+    # 1. Abstract model
+    #+++++++++++++++++++++++++++++++
+    domain = Square()
+
+    B_dirichlet_0 = Union(*[domain.get_boundary(**kw) for kw in dir_zero_boundary])
+    B_dirichlet_i = domain.boundary.complement(B_dirichlet_0)
+
+    V  = ScalarFunctionSpace('V', domain)
+    u  = element_of(V, name='u')
+    v  = element_of(V, name='v')
+    nn = NormalVector('nn')
+
+    # Bilinear form a: V x V --> R
+    a = BilinearForm((u, v), integral(domain, laplace(u) * laplace(v)))
+
+    # Linear form l: V --> R
+    l = LinearForm(v, integral(domain, f * v))
+
+    # Essential boundary conditions
+    dn = lambda a: dot(grad(a), nn)
+    bc = []
+    if B_dirichlet_0:
+        bc += [EssentialBC(   u , 0, B_dirichlet_0)]
+        bc += [EssentialBC(dn(u), 0, B_dirichlet_0)]
+    if B_dirichlet_i:
+        bc += [EssentialBC(   u ,    solution , B_dirichlet_i)]
+        bc += [EssentialBC(dn(u), dn(solution), B_dirichlet_i)]
+
+    # Variational model
+    equation = find(u, forall=v, lhs=a(u, v), rhs=l(v), bc=bc)
+
+    # Error norms
+    error  = u - solution
+    l2norm = Norm(error, domain, kind='l2')
+    h1norm = Norm(error, domain, kind='h1')
+    h2norm = Norm(error, domain, kind='h2')
+
+    #+++++++++++++++++++++++++++++++
+    # 2. Discretization
+    #+++++++++++++++++++++++++++++++
+
+    # Create computational domain from topological domain
+    domain_h = discretize(domain, ncells=ncells, comm=comm)
+
+    # Discrete spaces
+    Vh = discretize(V, domain_h, degree=degree)
+
+    # Discretize equation using Dirichlet bc
+    equation_h = discretize(equation, domain_h, [Vh, Vh])
+
+    # Discretize error norms
+    l2norm_h = discretize(l2norm, domain_h, Vh)
+    h1norm_h = discretize(h1norm, domain_h, Vh)
+    h2norm_h = discretize(h2norm, domain_h, Vh)
+
+    #+++++++++++++++++++++++++++++++
+    # 3. Solution
+    #+++++++++++++++++++++++++++++++
+
+    # Solve linear system
+    x  = equation_h.solve()
+    uh = FemField( Vh, x )
+
+    # Compute error norms
+    l2_error = l2norm_h.assemble(u=uh)
+    h1_error = h1norm_h.assemble(u=uh)
+    h2_error = h2norm_h.assemble(u=uh)
+
+    return l2_error, h1_error, h2_error
+
+###############################################################################
+#            SERIAL TESTS
+###############################################################################
+
+#==============================================================================
+# 2D Poisson's equation
+#==============================================================================
+def test_poisson_2d_dir0_1234_gpyccel():
+
+    solution = sin(pi*x)*sin(pi*y)
+    f        = 2*pi**2*sin(pi*x)*sin(pi*y)
+
+    dir_zero_boundary    = get_boundaries(1, 2, 3, 4)
+    dir_nonzero_boundary = get_boundaries()
+
+    l2_error, h1_error = run_poisson_2d(solution, f, dir_zero_boundary,
+            dir_nonzero_boundary, ncells=[2**3, 2**3], degree=[2, 2], backend=PSYDAC_BACKEND_GPYCCEL)
+
+    expected_l2_error =  0.00021808678604760232
+    expected_h1_error =  0.013023570720360362
+
+    assert( abs(l2_error - expected_l2_error) < 1.e-7)
+    assert( abs(h1_error - expected_h1_error) < 1.e-7)
+
+
+def test_poisson_2d_dir0_1234_numba():
+
+    solution = sin(pi*x)*sin(pi*y)
+    f        = 2*pi**2*sin(pi*x)*sin(pi*y)
+
+    dir_zero_boundary    = get_boundaries(1, 2, 3, 4)
+    dir_nonzero_boundary = get_boundaries()
+
+    l2_error, h1_error = run_poisson_2d(solution, f, dir_zero_boundary,
+            dir_nonzero_boundary, ncells=[2**3, 2**3], degree=[2, 2], backend=PSYDAC_BACKEND_NUMBA)
+
+    expected_l2_error =  0.00021808678604760232
+    expected_h1_error =  0.013023570720360362
+
+    assert( abs(l2_error - expected_l2_error) < 1.e-7)
+    assert( abs(h1_error - expected_h1_error) < 1.e-7)
+#==============================================================================
+# CLEAN UP SYMPY NAMESPACE
+#==============================================================================
+
+def teardown_module():
+    from sympy import cache
+    cache.clear_cache()
+
+def teardown_function():
+    from sympy import cache
+    cache.clear_cache()

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ install_requires = [
 
     # Our packages from PyPi
     'sympde',
-    'pyccel==0.10.0',
+    'pyccel==0.10.1',
     'gelato',
 
     # In addition, we depend on mpi4py and h5py (MPI version).


### PR DESCRIPTION
Psydac now can use Pyccel and Numba to accelerate its pure Python kernels. In addition:

- Drop Python-3.5 support, because Numba does not support it
- Add Python-3.8
- Add parallel tests