### PR TITLE
Import cache from sympy.core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ doc/api-python
 psydac/core/bsp-f2py*
 psydac/core/bspmodule.c
 psydac/core/*.so
+__*pyccel__
+.env

--- a/psydac/api/tests/test_api_2d_scalar.py
+++ b/psydac/api/tests/test_api_2d_scalar.py
@@ -664,9 +664,9 @@ def test_poisson_2d_dir0_1234_parallel():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
+++ b/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
@@ -1,10 +1,10 @@
-import pytest      
-                
+import pytest
+
 from sympy.core.containers import Tuple
-from sympy import Matrix               
-from sympy import Function                                
-from sympy import pi, cos, sin, exp                        
-      
+from sympy import Matrix
+from sympy import Function
+from sympy import pi, cos, sin, exp
+
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, rot, div
 from sympde.calculus import laplace, bracket, convect
@@ -20,12 +20,12 @@ from sympde.topology import Square
 from sympde.topology import ElementDomain
 from sympde.topology import Area
 from sympde.topology import IdentityMapping, PolarMapping
-                         
+
 from sympde.expr.expr import LinearExpr
 from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral              
-from sympde.expr.expr import Functional, Norm                       
-from sympde.expr.expr import linearize                      
+from sympde.expr.expr import integral
+from sympde.expr.expr import Functional, Norm
+from sympde.expr.expr import linearize
 from sympde.expr.evaluation import TerminalExpr
 from psydac.api.discretization import discretize
 from sympde.expr     import find, EssentialBC
@@ -62,17 +62,17 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     #+++++++++++++++++++++++++++++++
     # 2. Discretization
     #+++++++++++++++++++++++++++++++
-    
+
     domain_h = discretize(domain, ncells=ncells)
     Vh       = discretize(V, domain_h, degree=degree)
-    
+
     equation_h = discretize(equation, domain_h, [Vh, Vh])
 
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
 
     x  = equation_h.solve()
-    
+
     uh = FemField( Vh , x)
 
     l2_error = l2norm_h.assemble(u=uh)
@@ -108,10 +108,10 @@ def test_poisson_2d_analytical_mapping_0():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 

--- a/psydac/api/tests/test_api_2d_scalar_backends.py
+++ b/psydac/api/tests/test_api_2d_scalar_backends.py
@@ -360,9 +360,9 @@ def test_poisson_2d_dir0_1234_parallel_numba():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_2d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_2d_scalar_mapping.py
@@ -1080,9 +1080,9 @@ def test_poisson_2d_identity_dir0_1234_parallel():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
@@ -1,10 +1,10 @@
-import pytest      
-                
+import pytest
+
 from sympy.core.containers import Tuple
-from sympy import Matrix               
-from sympy import Function                                
-from sympy import pi, cos, sin, exp                        
-      
+from sympy import Matrix
+from sympy import Function
+from sympy import pi, cos, sin, exp
+
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, rot, div
 from sympde.calculus import laplace, bracket, convect
@@ -20,12 +20,12 @@ from sympde.topology import Square
 from sympde.topology import ElementDomain
 from sympde.topology import Area
 from sympde.topology import IdentityMapping, PolarMapping
-                         
+
 from sympde.expr.expr import LinearExpr
 from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral              
-from sympde.expr.expr import Functional, Norm                       
-from sympde.expr.expr import linearize                      
+from sympde.expr.expr import integral
+from sympde.expr.expr import Functional, Norm
+from sympde.expr.expr import linearize
 from sympde.expr.evaluation import TerminalExpr
 from psydac.api.discretization import discretize
 from sympde.expr     import find, EssentialBC
@@ -80,10 +80,10 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     #+++++++++++++++++++++++++++++++
     # 2. Discretization
     #+++++++++++++++++++++++++++++++
-    
+
     domain_h = discretize(domain, ncells=ncells, comm=comm)
     Vh       = discretize(V, domain_h, degree=degree)
-    
+
     equation_h = discretize(equation, domain_h, [Vh, Vh])
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
@@ -232,10 +232,10 @@ def test_poisson_2d_2_patch_dirichlet_parallel_0():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 

--- a/psydac/api/tests/test_api_2d_scalar_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_multi_patch.py
@@ -1,10 +1,10 @@
-import pytest      
-                
+import pytest
+
 from sympy.core.containers import Tuple
-from sympy import Matrix               
-from sympy import Function                                
-from sympy import pi, cos, sin, exp                        
-      
+from sympy import Matrix
+from sympy import Function
+from sympy import pi, cos, sin, exp
+
 from sympde.core import Constant
 from sympde.calculus import grad, dot, inner, rot, div
 from sympde.calculus import laplace, bracket, convect
@@ -19,12 +19,12 @@ from sympde.topology import trace_1
 from sympde.topology import Square
 from sympde.topology import ElementDomain
 from sympde.topology import Area
-                         
+
 from sympde.expr.expr import LinearExpr
 from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral              
-from sympde.expr.expr import Functional, Norm                       
-from sympde.expr.expr import linearize                      
+from sympde.expr.expr import integral
+from sympde.expr.expr import Functional, Norm
+from sympde.expr.expr import linearize
 from sympde.expr.evaluation import TerminalExpr
 from psydac.api.discretization import discretize
 from sympde.expr     import find, EssentialBC
@@ -76,17 +76,17 @@ def run_poisson_2d(solution, f, domain, ncells, degree):
     #+++++++++++++++++++++++++++++++
     # 2. Discretization
     #+++++++++++++++++++++++++++++++
-    
+
     domain_h = discretize(domain, ncells=ncells)
     Vh       = discretize(V, domain_h, degree=degree)
-    
+
     equation_h = discretize(equation, domain_h, [Vh, Vh])
 
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
 
     x  = equation_h.solve()
-    
+
     uh = VectorFemField( Vh )
 
     for i in range(len(uh.coeffs[:])):
@@ -145,10 +145,10 @@ def test_poisson_2d_2_patch_dirichlet_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 

--- a/psydac/api/tests/test_api_2d_system.py
+++ b/psydac/api/tests/test_api_2d_system.py
@@ -123,7 +123,7 @@ def run_system_1_2d_dir(Fe, Ge, f0, f1, ncells, degree):
 def test_api_system_1_2d_dir_1():
 
     from sympy import symbols
-    
+
     x1,x2 = symbols('x1, x2')
 
     Fe = Tuple(sin(pi*x1)*sin(pi*x2), sin(pi*x1)*sin(pi*x2))
@@ -150,9 +150,9 @@ def test_api_system_1_2d_dir_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_2d_vector.py
+++ b/psydac/api/tests/test_api_2d_vector.py
@@ -107,9 +107,9 @@ def test_api_vector_poisson_2d_dir_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_2d_vector_mapping.py
+++ b/psydac/api/tests/test_api_2d_vector_mapping.py
@@ -51,7 +51,7 @@ def run_vector_poisson_2d_dir(filename, solution, f):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     expr = inner(grad(v), grad(u))
     a = BilinearForm((v,u), int_0(expr))
 
@@ -149,9 +149,9 @@ def test_api_vector_poisson_2d_dir_collela():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_3d_scalar.py
+++ b/psydac/api/tests/test_api_3d_scalar.py
@@ -334,9 +334,9 @@ def test_api_poisson_3d_dir_1_parallel():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_3d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_3d_scalar_mapping.py
@@ -538,9 +538,9 @@ def test_api_poisson_3d_dir_collela():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_3d_vector.py
+++ b/psydac/api/tests/test_api_3d_vector.py
@@ -31,7 +31,7 @@ def run_vector_poisson_3d_dir(solution, f, ncells, degree):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     expr = inner(grad(v), grad(u))
     a = BilinearForm((v,u), int_0(expr))
 
@@ -109,9 +109,9 @@ def test_api_vector_poisson_3d_dir_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_3d_vector_mapping.py
+++ b/psydac/api/tests/test_api_3d_vector_mapping.py
@@ -41,7 +41,7 @@ def run_vector_poisson_3d_dir(filename, solution, f):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     expr = inner(grad(v), grad(u))
     a = BilinearForm((v,u), int_0(expr))
 
@@ -142,9 +142,9 @@ def test_api_vector_poisson_3d_dir_collela():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_feec_3d.py
+++ b/psydac/api/tests/test_api_feec_3d.py
@@ -35,7 +35,7 @@ def splitting_integrator_scipy(e0, b0, M1, M2, CURL, dt, niter):
         y1 = M2.dot(b)
         y2 = CURL_T.dot(y1)
         return M1_solver.solve(y2)
-    
+
     e_history = [e0]
     b_history = [b0]
 
@@ -76,7 +76,7 @@ def splitting_integrator_stencil(e0, b0, M1, M2, CURL, dt, niter):
 
 def evaluation_all_times(fields, x, y, z):
     ak_value = np.empty(len(fields), dtype = 'float')
-    
+
     for i in range(len(fields)):
         ak_value[i] = fields[i](x,y,z)
     return ak_value
@@ -130,7 +130,7 @@ def run_maxwell_3d_scipy(logical_domain, mapping, e_ex, b_ex, ncells, degree, pe
     b0_3 = lambda x, y, z : b_ex[2](0, x, y, z)
 
     b0   = (b0_1, b0_2, b0_3)
-    
+
     # project initial conditions
     e0_coeff = P1(e0).coeffs
 
@@ -340,10 +340,10 @@ def test_maxwell_3d_2():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 

--- a/psydac/api/tests/test_api_glt_2d_scalar.py
+++ b/psydac/api/tests/test_api_glt_2d_scalar.py
@@ -43,7 +43,7 @@ def run_poisson_2d_dir(ncells, degree, comm=None):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     a = BilinearForm((v,u), int_0(dot(grad(v), grad(u))))
 
     glt_a = GltExpr(a)
@@ -98,7 +98,7 @@ def run_field_2d_dir(ncells, degree, comm=None):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     a  = BilinearForm((v,u), int_0(dot(grad(v), grad(u)) + F*u*v))
     ae = BilinearForm((v,u), int_0(dot(grad(v), grad(u)) + u*v))
 
@@ -164,7 +164,7 @@ def run_variable_coeff_2d_dir(ncells, degree, comm=None):
     c = Constant('c', real=True)
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     expr = (1 + c*sin(pi*(x+y)))*dx1(u)*dx2(v) + (1 + c*sin(pi*(x-y)))*dx1(u)*dx2(v)
     a = BilinearForm((v,u), int_0(expr))
     glt_a = GltExpr(a)
@@ -233,9 +233,9 @@ def test_api_glt_variable_coeff_2d_dir_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()

--- a/psydac/api/tests/test_api_glt_2d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_glt_2d_scalar_mapping.py
@@ -109,11 +109,11 @@ def test_api_glt_poisson_2d_dir_quarter_annulus():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 #test_api_glt_poisson_2d_dir_identity()

--- a/psydac/api/tests/test_api_glt_2d_vector.py
+++ b/psydac/api/tests/test_api_glt_2d_vector.py
@@ -29,7 +29,7 @@ def run_vector_poisson_2d_dir(ncells, degree):
     u = element_of(V, name='u')
 
     int_0 = lambda expr: integral(domain , expr)
-    
+
     a = BilinearForm((v,u), int_0(inner(grad(v), grad(u))))
 
     glt_a = GltExpr(a)
@@ -83,9 +83,9 @@ def test_api_glt_vector_poisson_2d_dir_1():
 #==============================================================================
 
 def teardown_module():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()
 
 def teardown_function():
-    from sympy import cache
+    from sympy.core import cache
     cache.clear_cache()


### PR DESCRIPTION
in order to work with Sympy version 1.7 or newer, we must now write explicitly `from sympy.core import cache`, because `from sympy import cache` does not work anymore. This closes #82.