### PR TITLE
FEEC with Dirichlet BCs.

### DIFF
--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1456,24 +1456,26 @@ class Parser(object):
         # update with product statements if available
         body = list(p_inits) + list(geo_stmts) + list(stmts)
         mask = expr.mask
+
         if mask:
             axis   = mask.axis
             index  = indices.pop(axis)
             length = lengths.pop(axis)
             init   = inits.pop(axis)
             mask_init = [Assign(index, 0), *init]
-
         for index, length, init in zip(indices[::-1], lengths[::-1], inits[::-1]):
 
             body = list(init) + body
             body = [For(index, Range(length), body)]
         # ...
         # remove the list and return the For Node only
-        body = body[0]
 
         if mask:
-            body = CodeBlock([*mask_init, body])
-
+            body = CodeBlock([*mask_init, *body])
+        elif len(body) > 1:
+            body = CodeBlock(body)
+        elif len(body) == 1:
+            body = body[0]
         return body
 
     # ....................................................

--- a/psydac/api/essential_bc.py
+++ b/psydac/api/essential_bc.py
@@ -102,16 +102,23 @@ def apply_essential_bc_1d_StencilMatrix(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 1D """
 
     # assumes a 1D spline space
-    # add asserts on the space if it is periodic
+    # TODO: add asserts on the space if it is periodic
+    # TODO: verify if V argument is really needed
+
+    s1, = a.codomain.starts
+    e1, = a.codomain.ends
+    n1, = a.codomain.npts
 
     # get order
     order = bc.order
 
-    if bc.boundary.ext == -1:
-        a[ 0+order,:] = 0.
+    # left x1 boundary
+    if bc.boundary.ext == -1 and s1 == 0:
+        a[s1 + order, :] = 0.
 
-    if bc.boundary.ext == 1:
-        a[-1-order,:] = 0.
+    # right x1 boundary
+    if bc.boundary.ext == 1 and e1 == n1 - 1:
+        a[e1 - order, :] = 0.
 
 #==============================================================================
 def apply_essential_bc_2d_StencilMatrix(V, bc, a):

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -479,12 +479,12 @@ class DiscreteLinearForm(BasicDiscrete):
             else:
                 vector_space = self.space.vector_space
 
-            if test_ext == -1:
+            if ext == -1:
                 start = vector_space.starts[axis]
                 if start != 0:
                     self._func = do_nothing
 
-            elif test_ext == 1:
+            elif ext == 1:
                 end  = vector_space.ends[axis]
                 npts = vector_space.npts[axis]
                 if end + 1 != npts:

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -474,10 +474,10 @@ class DiscreteLinearForm(BasicDiscrete):
             #...
             # If process does not own the boundary or interface, do not assemble anything
             import psydac
-            if isinstance(test_space.vector_space, psydac.linalg.block.ProductSpace):
-                vector_space = test_space.vector_space.spaces[0]
+            if isinstance(self.space.vector_space, psydac.linalg.block.ProductSpace):
+                vector_space = self.space.vector_space.spaces[0]
             else:
-                vector_space = test_space.vector_space
+                vector_space = self.space.vector_space
 
             if test_ext == -1:
                 start = vector_space.starts[axis]

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -213,22 +213,33 @@ class DiscreteBilinearForm(BasicDiscrete):
             trial_ext = None
 
         if isinstance(domain, (sym_Boundary, sym_Interface)):
+
+            #...
+            # If process does not own the boundary or interface, do not assemble anything
+            import psydac
+            if isinstance(test_space.vector_space, psydac.linalg.block.ProductSpace):
+                vector_space = test_space.vector_space.spaces[0]
+            else:
+                vector_space = test_space.vector_space
+
             if test_ext == -1:
-                start = test_space.vector_space.starts[axis]
-                if start != 0 :
+                start = vector_space.starts[axis]
+                if start != 0:
                     self._func = do_nothing
+
             elif test_ext == 1:
-                end = test_space.vector_space.ends[axis]
-                nb  = test_space.spaces[axis].nbasis
-                if end+1 != nb:
+                end  = vector_space.ends[axis]
+                npts = vector_space.npts[axis]
+                if end + 1 != npts:
                     self._func = do_nothing
+            #...
 
         grid              = QuadratureGrid( test_space, axis, test_ext )
         self._grid        = grid
         self._test_basis  = BasisValues( test_space,  nderiv = self.max_nderiv , trial=False, grid=grid, ext=test_ext)
         self._trial_basis = BasisValues( trial_space, nderiv = self.max_nderiv , trial=True, grid=grid, ext=trial_ext)
 
-        self._args                 = self.construct_arguments()
+        self._args = self.construct_arguments()
 
     @property
     def spaces(self):
@@ -459,15 +470,26 @@ class DiscreteLinearForm(BasicDiscrete):
         else:
             ext  = domain.ext
             axis = domain.axis
-            if ext == -1:
-                start = self.space.vector_space.starts[domain.axis]
-                if start != 0 :
+
+            #...
+            # If process does not own the boundary or interface, do not assemble anything
+            import psydac
+            if isinstance(test_space.vector_space, psydac.linalg.block.ProductSpace):
+                vector_space = test_space.vector_space.spaces[0]
+            else:
+                vector_space = test_space.vector_space
+
+            if test_ext == -1:
+                start = vector_space.starts[axis]
+                if start != 0:
                     self._func = do_nothing
-            elif ext == 1:
-                end = self.space.vector_space.ends[domain.axis]
-                nb  = self.space.spaces[domain.axis].nbasis
-                if end+1 != nb:
+
+            elif test_ext == 1:
+                end  = vector_space.ends[axis]
+                npts = vector_space.npts[axis]
+                if end + 1 != npts:
                     self._func = do_nothing
+            #...
 
         grid             = QuadratureGrid( self.space, axis=axis, ext=ext )
         self._grid       = grid

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -65,25 +65,18 @@ class BoundaryQuadratureGrid(QuadratureGrid):
         weights = self.weights
 
         # ...
-        if V.ldim == 1:
-            assert( isinstance( V, SplineSpace ) )
+        if V.ldim == 1 and isinstance(V, SplineSpace):
+            bounds = {-1: V.domain[0],
+                       1: V.domain[1]}
+        elif isinstance(V, TensorFemSpace):
+            bounds = {-1: V.spaces[axis].domain[0],
+                       1: V.spaces[axis].domain[1]}
+        else:
+            raise ValueError('Incompatible type(V) = {} in {} dimensions'.format(
+                type(V), V.ldim))
 
-            bounds     = {}
-            bounds[-1] = V.domain[0]
-            bounds[1]  = V.domain[1]
-
-            points[axis]  = np.asarray([[bounds[ext]]])
-            weights[axis] = np.asarray([[1.]])
-
-        elif V.ldim in [2, 3]:
-            assert( isinstance( V, TensorFemSpace ) )
-
-            bounds     = {}
-            bounds[-1] = V.spaces[axis].domain[0]
-            bounds[1]  = V.spaces[axis].domain[1]
-
-            points[axis]  = np.asarray([[bounds[ext]]])
-            weights[axis] = np.asarray([[1.]])
+        points [axis] = np.asarray([[bounds[ext]]])
+        weights[axis] = np.asarray([[1.]])
         # ...
 
         self._axis    = axis

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -83,9 +83,6 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
 
     mapping = CollelaMapping1D('M', k=L, eps=eps)
     domain  = mapping(logical_domain)
-
-    # NOTE: don't use mapping at the moment
-    domain  = logical_domain
     #...
 
     # Exact solution

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -140,9 +140,9 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
         a0_bc_h = discretize(a0_bc, domain_h, (derham_h.V0, derham_h.V0), backend=PSYDAC_BACKEND_GPYCCEL)
         M0_bc   = a0_bc_h.assemble()
 
-        # Fix assembly process by hand
-        M0_bc[0, 0] = 1e30
-        M0_bc[M0_bc.domain.ends[0], 0] = 1e30
+#        # Fix assembly process by hand
+#        M0_bc[0, 0] = 1e30
+#        M0_bc[M0_bc.domain.ends[0], 0] = 1e30
 
     # Transpose of derivative matrix
     D0_T = D0.T

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -455,7 +455,10 @@ def test_maxwell_1d_periodic():
         tend     = None,
         splitting_order      = 2,
         plot_interval        = 0,
-        diagnostics_interval = 0
+        diagnostics_interval = 0,
+        tol = 1e-6,
+        bc_mode = None,
+        verbose = False
     )
 
     TOL = 1e-6
@@ -466,7 +469,7 @@ def test_maxwell_1d_periodic():
     assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
 
 
-def test_maxwell_1d_dirichlet():
+def test_maxwell_1d_dirichlet_strong():
 
     namespace = run_maxwell_1d(
         L        = 1.0,
@@ -479,7 +482,10 @@ def test_maxwell_1d_dirichlet():
         tend     = None,
         splitting_order      = 2,
         plot_interval        = 0,
-        diagnostics_interval = 0
+        diagnostics_interval = 0,
+        tol = 1e-6,
+        bc_mode = 'strong',
+        verbose = False
     )
 
     TOL = 1e-6
@@ -488,6 +494,34 @@ def test_maxwell_1d_dirichlet():
 
     assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
     assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
+
+
+def test_maxwell_1d_dirichlet_penalization():
+
+    namespace = run_maxwell_1d(
+        L        = 1.0,
+        eps      = 0.5,
+        ncells   = 20,
+        degree   = 5,
+        periodic = False,
+        Cp       = 0.5,
+        nsteps   = 1,
+        tend     = None,
+        splitting_order      = 2,
+        plot_interval        = 0,
+        diagnostics_interval = 0,
+        tol = 1e-6,
+        bc_mode = 'penalization',
+        verbose = False
+    )
+
+    TOL = 1e-6
+    ref = dict(error_E = 1.320290052669426e-03,
+               error_B = 7.453277842247585e-04)
+
+    assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
+    assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
+
 
 #==============================================================================
 # SCRIPT CAPABILITIES

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -140,10 +140,6 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
         a0_bc_h = discretize(a0_bc, domain_h, (derham_h.V0, derham_h.V0), backend=PSYDAC_BACKEND_GPYCCEL)
         M0_bc   = a0_bc_h.assemble()
 
-#        # Fix assembly process by hand
-#        M0_bc[0, 0] = 1e30
-#        M0_bc[M0_bc.domain.ends[0], 0] = 1e30
-
     # Transpose of derivative matrix
     D0_T = D0.T
 
@@ -287,11 +283,6 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
     if periodic:
         args = (e, b, M0, M1, D0, D0_T)
     else:
-        np.set_printoptions(linewidth = 300, precision = 2)
-        print(M0_bc.toarray())
-        print()
-        print((M0 + M0_bc).toarray())
-        print()
         args = (e, b, M0 + M0_bc, M1, D0, D0_T)
 
     # Time loop

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -83,6 +83,9 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
 
     mapping = CollelaMapping1D('M', k=L, eps=eps)
     domain  = mapping(logical_domain)
+
+    # NOTE: don't use mapping at the moment
+    domain  = logical_domain
     #...
 
     # Exact solution
@@ -137,6 +140,9 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
         a0_bc_h = discretize(a0_bc, domain_h, (derham_h.V0, derham_h.V0), backend=PSYDAC_BACKEND_GPYCCEL)
         M0_bc   = a0_bc_h.assemble()
 
+        # Fix assembly process by hand
+        M0_bc[0, 0] = 1e30
+        M0_bc[M0_bc.domain.ends[0], 0] = 1e30
 
     # Transpose of derivative matrix
     D0_T = D0.T
@@ -281,6 +287,11 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
     if periodic:
         args = (e, b, M0, M1, D0, D0_T)
     else:
+        np.set_printoptions(linewidth = 300, precision = 2)
+        print(M0_bc.toarray())
+        print()
+        print((M0 + M0_bc).toarray())
+        print()
         args = (e, b, M0 + M0_bc, M1, D0, D0_T)
 
     # Time loop

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -159,7 +159,7 @@ def run_maxwell_2d_TE(*, eps, ncells, degree, periodic, Cp, nsteps, tend,
     if not periodic:
         nn = NormalVector('nn')
         a1_bc = BilinearForm((u1, v1),
-                integral(domain.boundary, dot(cross(u1, nn), cross(v1, nn))))
+                integral(domain.boundary, cross(u1, nn) * cross(v1, nn)))
 
     #--------------------------------------------------------------------------
     # Discrete objects: Psydac

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -556,7 +556,7 @@ def test_maxwell_2d_dirichlet():
     print('{:e}'.format(namespace['error_Bz']))
     print('~'*50)
 
-    TOL = 1e-6
+    TOL = 1e-5
     ref = dict(error_Ex = 3.578544e-03,
                error_Ey = 3.578545e-03,
                error_Bz = 4.373875e-03)

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -606,7 +606,9 @@ def test_maxwell_2d_periodic():
         tend     = None,
         splitting_order      = 2,
         plot_interval        = 0,
-        diagnostics_interval = 0
+        diagnostics_interval = 0,
+        tol = 1e-6,
+        verbose = False
     )
 
     TOL = 1e-6
@@ -631,19 +633,15 @@ def test_maxwell_2d_dirichlet():
         tend     = None,
         splitting_order      = 2,
         plot_interval        = 0,
-        diagnostics_interval = 0
+        diagnostics_interval = 0,
+        tol = 1e-6,
+        verbose = False
     )
 
-    print('~'*50)
-    print('{:e}'.format(namespace['error_Ex']))
-    print('{:e}'.format(namespace['error_Ey']))
-    print('{:e}'.format(namespace['error_Bz']))
-    print('~'*50)
-
-    TOL = 1e-5
-    ref = dict(error_Ex = 3.578544e-03,
-               error_Ey = 3.578545e-03,
-               error_Bz = 4.373875e-03)
+    TOL = 1e-6
+    ref = dict(error_Ex = 3.597840e-03,
+               error_Ey = 3.597840e-03,
+               error_Bz = 4.366314e-03)
 
     assert abs(namespace['error_Ex'] - ref['error_Ex']) / ref['error_Ex'] <= TOL
     assert abs(namespace['error_Ey'] - ref['error_Ey']) / ref['error_Ey'] <= TOL

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -159,7 +159,7 @@ def run_maxwell_2d_TE(*, eps, ncells, degree, periodic, Cp, nsteps, tend,
     if not periodic:
         nn = NormalVector('nn')
         a1_bc = BilinearForm((u1, v1),
-                integral(domain.boundary, cross(u1, nn) * cross(v1, nn)))
+                integral(domain.boundary, 1e30 * cross(u1, nn) * cross(v1, nn)))
 
     #--------------------------------------------------------------------------
     # Discrete objects: Psydac
@@ -557,9 +557,9 @@ def test_maxwell_2d_dirichlet():
     print('~'*50)
 
     TOL = 1e-6
-    ref = dict(error_Ex = 6.870389e-03,
-               error_Ey = 6.870389e-03,
-               error_Bz = 4.443822e-03)
+    ref = dict(error_Ex = 3.578544e-03,
+               error_Ey = 3.578545e-03,
+               error_Bz = 4.373875e-03)
 
     assert abs(namespace['error_Ex'] - ref['error_Ex']) / ref['error_Ex'] <= TOL
     assert abs(namespace['error_Ey'] - ref['error_Ey']) / ref['error_Ey'] <= TOL

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -1,0 +1,647 @@
+# coding: utf-8
+# Copyright 2021 Yaman Güçlü
+
+#==============================================================================
+# TIME STEPPING METHOD
+#==============================================================================
+def step_faraday_2d(dt, e, b, M1, M2, D1, D1_T):
+    """
+    Exactly integrate the semi-discrete Faraday equation over one time-step:
+
+    b_new = b - ∆t D1 e
+
+    """
+    b -= dt * D1.dot(e)
+#    b -= dt * (D1 @ e)
+  # e += 0
+
+def step_ampere_2d(dt, e, b, M1, M2, D1, D1_T):
+    """
+    Exactly integrate the semi-discrete Amperè equation over one time-step:
+
+    e_new = e - ∆t (M1^{-1} D1^T M2) b
+
+    """
+    from psydac.linalg.iterative_solvers import cg
+
+  # b += 0
+    e -= dt * cg(M1, D1_T.dot((M2.dot(b))))[0]
+#    e -= dt * cg(M1, D1_T @ (M2 @ b))[0]
+
+#==============================================================================
+# VISUALIZATION
+#==============================================================================
+def make_plot(ax, t, sol_ex, sol_num, x, xlim, label):
+    ax.plot(x, sol_ex , '--', label='exact')
+    ax.plot(x, sol_num, '-' , label='numerical')
+    ax.legend(loc='upper right')
+    ax.grid()
+    ax.set_title('Time t = {:10.3e}'.format(t))
+    ax.set_xlabel('x')
+    ax.set_ylabel(label, rotation='horizontal')
+    ax.set_xlim(xlim)
+
+def update_plot(ax, t, sol_ex, sol_num):
+    ax.set_title('Time t = {:10.3e}'.format(t))
+    ax.lines[0].set_ydata(sol_ex )
+    ax.lines[1].set_ydata(sol_num)
+    ax.get_figure().canvas.draw()
+
+
+def add_colorbar(im, ax, **kwargs):
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+    divider = make_axes_locatable(ax)
+    cax = divider.append_axes("right", size=0.2, pad=0.3)
+    cbar = ax.get_figure().colorbar(im, cax=cax, **kwargs)
+    return cbar
+
+def plot_field_and_error(name, x, y, field_h, field_ex, *gridlines):
+    import matplotlib.pyplot as plt
+    fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(15, 6))
+    im0 = ax0.contourf(x, y, field_h)
+    im1 = ax1.contourf(x, y, field_ex - field_h)
+    ax0.set_title(r'${0}_h$'.format(name))
+    ax1.set_title(r'${0} - {0}_h$'.format(name))
+    for ax in (ax0, ax1):
+        ax.plot(*gridlines[0], color='k')
+        ax.plot(*gridlines[1], color='k')
+        ax.set_xlabel('x', fontsize=14)
+        ax.set_ylabel('y', fontsize=14, rotation='horizontal')
+        ax.set_aspect('equal')
+    add_colorbar(im0, ax0)
+    add_colorbar(im1, ax1)
+    fig.tight_layout()
+    return fig, (ax0, ax1)
+
+#==============================================================================
+# SIMULATION
+#==============================================================================
+def run_maxwell_2d_TE(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
+        splitting_order, plot_interval, diagnostics_interval):
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from mpi4py          import MPI
+    from scipy.integrate import dblquad
+
+    from sympde.topology import Square
+    from sympde.topology import Mapping
+#    from sympde.topology import CollelaMapping2D
+    from sympde.topology import Derham
+    from sympde.topology import elements_of
+    from sympde.topology import NormalVector
+    from sympde.calculus import dot, cross
+    from sympde.expr     import integral
+    from sympde.expr     import BilinearForm
+
+    from psydac.api.discretization import discretize
+    from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
+    from psydac.feec.pull_push     import push_2d_hcurl, push_2d_l2
+    from psydac.utilities.utils    import refine_array_1d
+
+    #--------------------------------------------------------------------------
+    # Problem setup
+    #--------------------------------------------------------------------------
+
+    # Physical domain is rectangle [0, a] x [0, b]
+    a = 2.0
+    b = 2.0
+
+    # Speed of light is 1
+    c = 1.0
+
+    #... Exact solution
+
+    # Mode number
+    (nx, ny) = (2, 2)
+
+    kx = np.pi * nx / a
+    ky = np.pi * ny / a
+    omega = c * np.sqrt(kx**2 + ky**2)
+
+    Ex_ex = lambda t, x, y:  np.cos(kx * x) * np.sin(ky * y) * np.sin(omega * t + np.pi/4) * omega
+    Ey_ex = lambda t, x, y: -np.sin(kx * x) * np.cos(ky * y) * np.sin(omega * t + np.pi/4) * omega
+    Bz_ex = lambda t, x, y:  np.sin(kx * x) * np.sin(ky * y) * np.cos(omega * t + np.pi/4)
+    #...
+
+    #--------------------------------------------------------------------------
+    # Analytical objects: SymPDE
+    #--------------------------------------------------------------------------
+
+    # Logical domain is unit square [0, 1] x [0, 1]
+    logical_domain = Square('Omega')
+
+    # Mapping and physical domain
+    class CollelaMapping2D(Mapping):
+
+        _ldim = 2
+        _pdim = 2
+        _expressions = {'x': 'a * (x1 + eps / (2*pi) * sin(2*pi*x1) * sin(2*pi*x2))',
+                        'y': 'b * (x2 + eps / (2*pi) * sin(2*pi*x1) * sin(2*pi*x2))'}
+
+#    mapping = CollelaMapping2D('M', k1=1, k2=1, eps=eps)
+    mapping = CollelaMapping2D('M', a=a, b=b, eps=eps)
+    domain  = mapping(logical_domain)
+
+    # DeRham sequence
+    derham = Derham(domain, sequence=['h1', 'hcurl', 'l2'])
+
+    # Trial and test functions
+    u1, v1 = elements_of(derham.V1, names='u1, v1')
+    u2, v2 = elements_of(derham.V2, names='u2, v2')
+
+    # Bilinear forms that correspond to mass matrices for spaces V1 and V2
+    a1 = BilinearForm((u1, v1), integral(domain, dot(u1, v1)))
+    a2 = BilinearForm((u2, v2), integral(domain, u2 * v2))
+
+# TODO
+#    # If needed, use penalization to apply homogeneous Dirichlet BCs
+#    if not periodic:
+#        nn = NormalVector('nn')
+#        a1_bc = BilinearForm((u1, v1),
+#                integral(domain.boundary, dot(cross(u1, nn), cross(v1, nn))))
+
+    #--------------------------------------------------------------------------
+    # Discrete objects: Psydac
+    #--------------------------------------------------------------------------
+
+    # Discrete physical domain and discrete DeRham sequence
+    domain_h = discretize(domain, ncells=[ncells, ncells], comm=MPI.COMM_WORLD)
+    derham_h = discretize(derham, domain_h, degree=[degree, degree], periodic=[periodic, periodic])
+
+    # Discrete bilinear forms
+    a1_h = discretize(a1, domain_h, (derham_h.V1, derham_h.V1), backend=PSYDAC_BACKEND_GPYCCEL)
+    a2_h = discretize(a2, domain_h, (derham_h.V2, derham_h.V2), backend=PSYDAC_BACKEND_GPYCCEL)
+
+    # Mass matrices (StencilMatrix objects)
+    M1 = a1_h.assemble()
+    M2 = a2_h.assemble()
+
+    # Differential operators
+    D0, D1 = derham_h.derivatives_as_matrices
+
+# TODO
+#    # Discretize and assemble penalization matrix
+#    if not periodic:
+#        a1_bc_h = discretize(a1_bc, domain_h, (derham_h.V1, derham_h.V1), backend=PSYDAC_BACKEND_GPYCCEL)
+#        M1_bc   = a1_bc_h.assemble()
+
+    # Transpose of derivative matrix
+    D1_T = D1.T
+
+    # Projectors
+    P0, P1, P2 = derham_h.projectors(nquads=[degree+2, degree+2])
+
+    # Logical and physical grids
+    F = mapping.get_callable_mapping()
+    grid_x1 = derham_h.V0.breaks[0]
+    grid_x2 = derham_h.V0.breaks[1]
+
+    grid_x, grid_y = F(*np.meshgrid(grid_x1, grid_x2, indexing='ij'))
+
+#
+#    xmin = grid_x[ 0]
+#    xmax = grid_x[-1]
+
+    #--------------------------------------------------------------------------
+    # Time integration setup
+    #--------------------------------------------------------------------------
+
+    t = 0
+
+    # Initial conditions, discrete fields
+    E = P1((lambda x, y: Ex_ex(0, x, y), lambda x, y: Ey_ex(0, x, y)))
+    B = P2(lambda x, y: Bz_ex(0, x, y))
+
+    # Initial conditions, spline coefficients
+    e = E.coeffs
+    b = B.coeffs
+
+    # Time step size
+    dx_min_1 = np.sqrt(np.diff(grid_x, axis=0)**2 + np.diff(grid_y, axis=0)**2).min()
+    dx_min_2 = np.sqrt(np.diff(grid_x, axis=1)**2 + np.diff(grid_y, axis=1)**2).min()
+
+    dx_min = min(dx_min_1, dx_min_2)
+    dt = Cp * dx_min / c
+
+    # If final time is given, compute number of time steps
+    if tend is not None:
+        nsteps = int(np.ceil(tend / dt))
+
+    #--------------------------------------------------------------------------
+    # Scalar diagnostics setup
+    #--------------------------------------------------------------------------
+
+    def we(t, x1, x2):
+        """ Electric energy density in logical domain.
+        """
+        x, y = F(x1, x2)
+        jac  = np.sqrt(F.metric_det(x1, x2))
+        Ex   = Ex_ex(t, x, y)
+        Ey   = Ey_ex(t, x, y)
+        return 0.5 * (Ex * Ex + Ey * Ey) * jac
+
+    def wb(t, x1, x2):
+        """ Magnetic energy density in logical domain.
+        """
+        x, y = F(x1, x2)
+        jac  = np.sqrt(F.metric_det(x1, x2))
+        Bz   = Bz_ex(t, x, y)
+        return 0.5 * (Bz * Bz) * jac
+
+    # Energy of exact solution
+    # TODO: assemble diagnostics instead
+    def exact_energies(t):
+        """ Compute electric & magnetic energies of exact solution.
+        """
+        kwargs = dict(
+            a    = logical_domain.bounds1[0],
+            b    = logical_domain.bounds1[1],
+            gfun = lambda x1: logical_domain.bounds2[0],
+            hfun = lambda x1: logical_domain.bounds2[1]
+        )
+        We = dblquad(lambda x2, x1: we(t, x1, x2), **kwargs)[0]
+        Wb = dblquad(lambda x2, x1: wb(t, x1, x2), **kwargs)[0]
+        return (We, Wb)
+
+    # Energy of numerical solution
+    def discrete_energies(e, b):
+        """ Compute electric & magnetic energies of numerical solution.
+        """
+        We = 0.5 * M1.dot(e).dot(e)
+        Wb = 0.5 * M2.dot(b).dot(b)
+        return (We, Wb)
+
+    # Scalar diagnostics:
+    diagnostics_ex  = {'time': [], 'electric_energy': [], 'magnetic_energy': []}
+    diagnostics_num = {'time': [], 'electric_energy': [], 'magnetic_energy': []}
+
+    #--------------------------------------------------------------------------
+    # Visualization and diagnostics setup
+    #--------------------------------------------------------------------------
+
+    # Very fine grids for evaluation of solution
+    N = 10 
+    x1 = refine_array_1d(grid_x1, N)
+    x2 = refine_array_1d(grid_x2, N)
+
+    x1, x2 = np.meshgrid(x1, x2, indexing='ij')
+    x, y = F(x1, x2)
+
+    gridlines_x1 = (x[:, ::N],   y[:, ::N]  )
+    gridlines_x2 = (x[::N, :].T, y[::N, :].T)
+    gridlines = (gridlines_x1, gridlines_x2)
+
+    # Prepare plots
+    if plot_interval:
+
+        # Plot physical grid and mapping's metric determinant
+        fig1, ax1 = plt.subplots(1, 1, figsize=(8, 6))
+        im = ax1.contourf(x, y, np.sqrt(F.metric_det(x1, x2)))
+        add_colorbar(im, ax1, label=r'Metric determinant $\sqrt{g}$ of mapping $F$')
+        ax1.plot(*gridlines_x1, color='k')
+        ax1.plot(*gridlines_x2, color='k')
+        ax1.set_title('Mapped grid of {} x {} cells'.format(ncells, ncells))
+        ax1.set_xlabel('x', fontsize=14)
+        ax1.set_ylabel('y', fontsize=14)
+        ax1.set_aspect('equal')
+        fig1.tight_layout()
+        fig1.show()
+
+        # ...
+        # Prepare animations
+        Ex_values = np.empty_like(x1)
+        Ey_values = np.empty_like(x1)
+        Bz_values = np.empty_like(x1)
+
+        # TODO: improve
+        for i, x1i in enumerate(x1[:, 0]):
+            for j, x2j in enumerate(x2[0, :]):
+
+                Ex_values[i, j], Ey_values[i, j] = \
+                        push_2d_hcurl(E.fields[0], E.fields[1], x1i, x2j, mapping)
+
+                Bz_values[i, j] = push_2d_l2(B, x1i, x2j, mapping)
+
+
+        # Electric field, x component
+        fig2, ax2 = plot_field_and_error(r'E^x', x, y, Ex_values, Ex_ex(0, x, y), *gridlines)
+        fig2.show()                                             
+                                                                
+        # Electric field, y component                           
+        fig3, ax3 = plot_field_and_error(r'E^y', x, y, Ey_values, Ey_ex(0, x, y), *gridlines)
+        fig3.show()                                             
+                                                                
+        # Magnetic field, z component                           
+        fig4, ax4 = plot_field_and_error(r'B^z', x, y, Bz_values, Bz_ex(0, x, y), *gridlines)
+        fig4.show()
+        # ...
+
+        input('\nSimulation setup done... press any key to start')
+
+    # Prepare diagnostics
+    if diagnostics_interval:
+
+        # Exact energy at t=0
+        We_ex, Wb_ex = exact_energies(t)
+        diagnostics_ex['time'].append(t)
+        diagnostics_ex['electric_energy'].append(We_ex)
+        diagnostics_ex['magnetic_energy'].append(Wb_ex)
+
+        # Discrete energy at t=0
+        We_num, Wb_num = discrete_energies(e, b)
+        diagnostics_num['time'].append(t)
+        diagnostics_num['electric_energy'].append(We_num)
+        diagnostics_num['magnetic_energy'].append(Wb_num)
+
+        print('\nTotal energy in domain:')
+        print('t = {:8.4f},  exact = {Wt_ex:.13e},  discrete = {Wt_num:.13e}'.format(t,
+            Wt_ex  = We_ex  + Wb_ex,
+            Wt_num = We_num + Wb_num)
+        )
+
+    ##############################
+    print()
+    print(type(e))
+    print(type(b))
+    print()
+    print(type(M1))
+    print(type(M2))
+    print()
+    print(type(D1))
+    print(type(D1_T))
+
+    import sys
+    sys.exit('STOP')
+    ##############################
+
+    #--------------------------------------------------------------------------
+    # Solution
+    #--------------------------------------------------------------------------
+
+    # TODO: add option to convert to scipy sparse format
+
+    # Arguments for time stepping
+    if periodic:
+        args = (e, b, M1, M2, D1, D1_T)
+    else:
+        args = (e, b, M1 + M1_bc, M2, D1, D1_T)
+
+    # Time loop
+    for i in range(nsteps):
+
+        # TODO: allow for high-order splitting
+
+        # Strang splitting, 2nd order
+        step_faraday_2d(0.5*dt, *args)
+        step_ampere_2d (    dt, *args)
+        step_faraday_2d(0.5*dt, *args)
+
+        t += dt
+
+        # Animation
+        if plot_interval and (i % plot_interval == 0 or i == nsteps-1):
+
+            E_values = [E(xi) for xi in x1]
+            B_values = push_1d_l2(lambda x1: np.array([B(xi) for xi in x1]), x1, mapping)
+
+            # Update plot
+            update_plot(ax2[0], t, E_ex(t, x), E_values)
+            update_plot(ax2[1], t, B_ex(t, x), B_values)
+            plt.pause(0.01)
+
+        # Scalar diagnostics
+        if diagnostics_interval and i % diagnostics_interval == 0:
+
+            # Update exact diagnostics
+            We_ex, Wb_ex = exact_energies(t)
+            diagnostics_ex['time'].append(t)
+            diagnostics_ex['electric_energy'].append(We_ex)
+            diagnostics_ex['magnetic_energy'].append(Wb_ex)
+
+            # Update numerical diagnostics
+            We_num, Wb_num = discrete_energies(e, b)
+            diagnostics_num['time'].append(t)
+            diagnostics_num['electric_energy'].append(We_num)
+            diagnostics_num['magnetic_energy'].append(Wb_num)
+
+            # Print total energy to terminal
+            print('t = {:8.4f},  exact = {Wt_ex:.13e},  discrete = {Wt_num:.13e}'.format(t,
+                Wt_ex  = We_ex  + Wb_ex,
+                Wt_num = We_num + Wb_num)
+            )
+
+    #--------------------------------------------------------------------------
+    # Post-processing
+    #--------------------------------------------------------------------------
+
+    # Error at final time
+    E_values = np.array([E(xi) for xi in x1])
+    B_values = push_1d_l2(lambda x1: np.array([B(xi) for xi in x1]), x1, mapping)
+
+    error_E = max(abs(E_ex(t, x) - E_values))
+    error_B = max(abs(B_ex(t, x) - B_values))
+    print()
+    print('Max-norm of error on E(t,x) at final time: {:.2e}'.format(error_E))
+    print('Max-norm of error on B(t,x) at final time: {:.2e}'.format(error_B))
+
+    if diagnostics_interval:
+
+        # Extract exact diagnostics
+        t_ex  = np.asarray(diagnostics_ex['time'])
+        We_ex = np.asarray(diagnostics_ex['electric_energy'])
+        Wb_ex = np.asarray(diagnostics_ex['magnetic_energy'])
+        Wt_ex = We_ex + Wb_ex
+
+        # Extract numerical diagnostics
+        t_num  = np.asarray(diagnostics_num['time'])
+        We_num = np.asarray(diagnostics_num['electric_energy'])
+        Wb_num = np.asarray(diagnostics_num['magnetic_energy'])
+        Wt_num = We_num + Wb_num
+
+        # Energy plots
+        fig3, (ax31, ax32, ax33) = plt.subplots(3, 1, figsize=(12, 10))
+        #
+        ax31.set_title('Energy of exact solution')
+        ax31.plot(t_ex, We_ex, label='electric')
+        ax31.plot(t_ex, Wb_ex, label='magnetic')
+        ax31.plot(t_ex, Wt_ex, label='total'   )
+        ax31.legend()
+        ax31.set_xlabel('t')
+        ax31.set_ylabel('W', rotation='horizontal')
+        ax31.grid()
+        #
+        ax32.set_title('Energy of numerical solution')
+        ax32.plot(t_num, We_num, label='electric')
+        ax32.plot(t_num, Wb_num, label='magnetic')
+        ax32.plot(t_num, Wt_num, label='total'   )
+        ax32.legend()
+        ax32.set_xlabel('t')
+        ax32.set_ylabel('W', rotation='horizontal')
+        ax32.grid()
+        #
+        ax33.set_title('Relative error in total energy')
+        ax33.plot(t_ex , (Wt_ex  - Wt_ex) / Wt_ex[0], '--', label='exact')
+        ax33.plot(t_num, (Wt_num - Wt_ex) / Wt_ex[0], '-' , label='numerical')
+        ax33.legend()
+        ax33.set_xlabel('t')
+        ax33.set_ylabel('(W - W_ex) / W_ex(t=0)')
+        ax33.grid()
+        #
+        fig3.tight_layout()
+        fig3.show()
+
+    # Return whole namespace as dictionary
+    return locals()
+
+#==============================================================================
+# UNIT TESTS
+#==============================================================================
+
+def test_maxwell_1d_periodic():
+
+    namespace = run_maxwell_2d_TE(
+        L        = 1.0,
+        eps      = 0.5,
+        ncells   = 30,
+        degree   = 3,
+        periodic = True,
+        Cp       = 0.5,
+        nsteps   = 1,
+        tend     = None,
+        splitting_order      = 2,
+        plot_interval        = 0,
+        diagnostics_interval = 0
+    )
+
+    TOL = 1e-6
+    ref = dict(error_E = 4.191954319623381e-04,
+               error_B = 4.447074070748624e-04)
+
+    assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
+    assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
+
+
+def test_maxwell_1d_dirichlet():
+
+    namespace = run_maxwell_2d_TE(
+        L        = 1.0,
+        eps      = 0.5,
+        ncells   = 20,
+        degree   = 5,
+        periodic = False,
+        Cp       = 0.5,
+        nsteps   = 1,
+        tend     = None,
+        splitting_order      = 2,
+        plot_interval        = 0,
+        diagnostics_interval = 0
+    )
+
+    TOL = 1e-6
+    ref = dict(error_E = 1.320471502738063e-03,
+               error_B = 7.453774187340390e-04)
+
+    assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
+    assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
+
+#==============================================================================
+# SCRIPT CAPABILITIES
+#==============================================================================
+if __name__ == '__main__':
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class = argparse.ArgumentDefaultsHelpFormatter,
+        description     = "Solve 1D Maxwell equations with spline FEEC method."
+    )
+
+    parser.add_argument('ncells',
+        type = int,
+        help = 'Number of cells in domain'
+    )
+
+    parser.add_argument('degree',
+        type = int,
+        help = 'Polynomial spline degree'
+    )
+
+    parser.add_argument( '-P', '--periodic',
+        action  = 'store_true',
+        help    = 'Use periodic boundary conditions'
+    )
+
+    parser.add_argument('-o', '--splitting_order',
+        type    = int,
+        default = 2,
+        choices = [2, 4, 6],
+        help    = 'Order of accuracy of operator splitting'
+    )
+
+    parser.add_argument( '-l',
+        type    = float,
+        default = 1.0,
+        dest    = 'L',
+        metavar = 'L',
+        help    = 'Length of domain [0, L]'
+    )
+
+    parser.add_argument( '-e',
+        type    = float,
+        default = 0.25,
+        dest    = 'eps',
+        metavar = 'EPS',
+        help    = 'Deformation level (0 <= EPS < 1)'
+    )
+
+    parser.add_argument( '-c',
+        type    = float,
+        default = 0.5,
+        dest    = 'Cp',
+        metavar = 'Cp',
+        help    = 'Courant parameter on uniform grid'
+    )
+
+    # ...
+    time_opts = parser.add_mutually_exclusive_group()
+    time_opts.add_argument( '-t',
+        type    = int,
+        default = 1,
+        dest    = 'nsteps',
+        metavar = 'NSTEPS',
+        help    = 'Number of time-steps to be taken'
+    )
+    time_opts.add_argument( '-T',
+        type    = float,
+        dest    = 'tend',
+        metavar = 'END_TIME',
+        help    = 'Run simulation until given final time'
+    )
+    # ...
+
+    parser.add_argument( '-p',
+        type    = int,
+        default = 4,
+        metavar = 'I',
+        dest    = 'plot_interval',
+        help    = 'No. of time steps between successive plots of solution, if I=0 no plots are made'
+    )
+
+    parser.add_argument( '-d',
+        type    = int,
+        default = 1,
+        metavar = 'I',
+        dest    = 'diagnostics_interval',
+        help    = 'No. of time steps between successive calculations of scalar diagnostics, if I=0 no diagnostics are computed'
+    )
+
+    # Read input arguments
+    args = parser.parse_args()
+
+    # Run simulation
+    namespace = run_maxwell_2d_TE(**vars(args))
+
+    # Keep matplotlib windows open
+    import matplotlib.pyplot as plt
+    plt.show()

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -177,13 +177,12 @@ class Gradient_2D(DiffOperator):
         self._codomain = Hcurl
         self._matrix   = block_tostencil(matrix)
 
-    def __call__(self, x):
+    def __call__(self, u):
 
-        assert isinstance(x, FemField)
-        assert x.space == self._domain
+        assert isinstance(u, FemField)
+        assert u.space == self.domain
 
-        y = BlockVector(ProductSpace(x.coeffs.space), blocks=[x.coeffs])
-        coeffs = self._matrix.dot(y)
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
         return VectorFemField(self.codomain, coeffs=coeffs)
@@ -238,13 +237,12 @@ class Gradient_3D(DiffOperator):
         self._codomain = Hcurl
         self._matrix   = block_tostencil(matrix)
 
-    def __call__(self, x):
+    def __call__(self, u):
 
-        assert isinstance(x, FemField)
-        assert x.space == self._domain
+        assert isinstance(u, FemField)
+        assert u.space == self.domain
 
-        y = BlockVector(ProductSpace(x.coeffs.space), blocks=[x.coeffs])
-        coeffs = self._matrix.dot(y)
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
         return VectorFemField(self.codomain, coeffs=coeffs)
@@ -306,7 +304,7 @@ class ScalarCurl_2D(DiffOperator):
         assert isinstance(u, VectorFemField)
         assert u.space == self.domain
         
-        coeffs = self.matrix.dot(u.coeffs)[0]
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
         return FemField(self.codomain, coeffs=coeffs)
@@ -364,8 +362,7 @@ class VectorCurl_2D(DiffOperator):
         assert isinstance(u, FemField)
         assert u.space == self.domain
 
-        x      = BlockVector(ProductSpace(u.coeffs.space), blocks=[u.coeffs])
-        coeffs = self.matrix.dot(x)
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
         return VectorFemField(self.codomain, coeffs=coeffs)
@@ -493,15 +490,15 @@ class Divergence_2D(DiffOperator):
         self._codomain = L2
         self._matrix   = block_tostencil(matrix)
 
-    def __call__(self, x):
+    def __call__(self, u):
 
-        assert isinstance(x, VectorFemField)
-        assert x.space == self._domain
+        assert isinstance(u, VectorFemField)
+        assert u.space == self.domain
 
-        coeffs = self._matrix.dot(x.coeffs)
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return FemField(self._codomain, coeffs=coeffs[0])
+        return FemField(self.codomain, coeffs=coeffs)
 
 #====================================================================================================
 class Divergence_3D(DiffOperator):
@@ -557,12 +554,12 @@ class Divergence_3D(DiffOperator):
         self._codomain = L2
         self._matrix   = block_tostencil(matrix)
 
-    def __call__(self, x):
+    def __call__(self, u):
 
-        assert isinstance(x, VectorFemField)
-        assert x.space == self._domain
+        assert isinstance(u, VectorFemField)
+        assert u.space == self.domain
 
-        coeffs = self._matrix.dot(x.coeffs)
+        coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return FemField(self._codomain, coeffs=coeffs[0])
+        return FemField(self.codomain, coeffs=coeffs)

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -204,13 +204,13 @@ class Projector_Hcurl:
 
         Parameters
         ----------
-        fun : callable
-            Real-valued vector function to be projected, with arguments the
-            coordinates (x_1, ..., x_N) of a point in the logical domain. This
-            corresponds to the coefficients of a 1-form in the canonical basis
-            (dx_1, ..., dx_N).
+        fun : list/tuple of callables
+            Scalar components of the real-valued vector function to be
+            projected, with arguments the coordinates (x_1, ..., x_N) of a
+            point in the logical domain. These correspond to the coefficients
+            of a 1-form in the canonical basis (dx_1, ..., dx_N).
 
-            $fun : \hat{\Omega} \mapsto \mathbb{R}^N$.
+            $fun_i : \hat{\Omega} \mapsto \mathbb{R}$ with i = 1, ..., N.
 
         Returns
         -------
@@ -346,13 +346,14 @@ class Projector_Hdiv:
 
         Parameters
         ----------
-        fun : callable
-            Real-valued vector function to be projected, with arguments the
-            coordinates (x_1, ..., x_N) of a point in the logical domain. In 3D
-            this corresponds to the coefficients of a 2-form in the canonical
-            basis (dx_1 ∧ dx_2, dx_2 ∧ dx_3, dx_3 ∧ dx_1).
+        fun : list/tuples of callable
+            Scalar components of the real-valued vector function to be
+            projected, with arguments the coordinates (x_1, ..., x_N) of a
+            point in the logical domain. In 3D these correspond to the
+            coefficients of a 2-form in the canonical basis (dx_1 ∧ dx_2,
+            dx_2 ∧ dx_3, dx_3 ∧ dx_1).
 
-            $fun : \hat{\Omega} \mapsto \mathbb{R}^N$.
+            $fun_i : \hat{\Omega} \mapsto \mathbb{R}$ with i = 1, ..., N.
 
         Returns
         -------

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -11,11 +11,22 @@ from psydac.fem.vector            import VectorFemField
 
 #==============================================================================
 class Projector_H1:
+    """
+    Projector from H1 to an H1-conformal finite element space (i.e. a finite
+    dimensional subspace of H1) constructed with tensor-product B-splines in 1,
+    2 or 3 dimensions.
 
+    This is a global projector based on interpolation over a tensor-product
+    grid in the logical domain. The interpolation grid is the tensor-product of
+    the 1D splines' Greville points along each direction.
+
+    Parameters
+    ----------
+    H1 : SplineSpace or TensorFemSpace
+        H1-conformal finite element space, codomain of the projection operator.
+
+    """
     def __init__(self, H1):
-
-        # Quadrature grids in cells defined by consecutive Greville points
-
 
         # Number of dimensions
         dim = H1.ldim
@@ -49,20 +60,28 @@ class Projector_H1:
 
     #--------------------------------------------------------------------------
     def __call__(self, fun):
-        r'''
-        Projection on the space V0 via interpolation.
+        r"""
+        Project scalar function onto the H1-conformal finite element space.
+        This happens in the logical domain $\hat{\Omega}$.
 
         Parameters
         ----------
         fun : callable
-            fun(x) \in R is the 0-form to be projected.
+            Real-valued scalar function to be projected, with arguments the
+            coordinates (x1, ..., xd) of a point in the logical domain. This
+            corresponds to the coefficient of a 0-form in the canonical basis
+            (dx1, dx2, dx3).
+
+            $fun : \hat{\Omega} \mapsto \mathbb{R}$.
 
         Returns
         -------
-        coeffs : 1D array_like
-            Finite element coefficients obtained by projection.
-        '''
+        field : FemField
+            Field obtained by projection (element of the H1-conformal finite
+            element space). This is also a real-valued scalar function in the
+            logical domain.
 
+        """
         # build the rhs
         self.func(*self.args, fun)
 

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -12,19 +12,18 @@ from psydac.fem.vector            import VectorFemField
 #==============================================================================
 class Projector_H1:
     """
-    Projector from H1 to an H1-conformal finite element space (i.e. a finite
+    Projector from H1 to an H1-conforming finite element space (i.e. a finite
     dimensional subspace of H1) constructed with tensor-product B-splines in 1,
     2 or 3 dimensions.
 
     This is a global projector based on interpolation over a tensor-product
-    grid in the logical domain. The interpolation grid is the tensor-product of
+    grid in the logical domain. The interpolation grid is the tensor product of
     the 1D splines' Greville points along each direction.
 
     Parameters
     ----------
     H1 : SplineSpace or TensorFemSpace
-        H1-conformal finite element space, codomain of the projection operator.
-
+        H1-conforming finite element space, codomain of the projection operator
     """
     def __init__(self, H1):
 
@@ -61,26 +60,24 @@ class Projector_H1:
     #--------------------------------------------------------------------------
     def __call__(self, fun):
         r"""
-        Project scalar function onto the H1-conformal finite element space.
+        Project scalar function onto the H1-conforming finite element space.
         This happens in the logical domain $\hat{\Omega}$.
 
         Parameters
         ----------
         fun : callable
             Real-valued scalar function to be projected, with arguments the
-            coordinates (x1, ..., xd) of a point in the logical domain. This
-            corresponds to the coefficient of a 0-form in the canonical basis
-            (dx1, dx2, dx3).
+            coordinates (x_1, ..., x_N) of a point in the logical domain. This
+            corresponds to the coefficient of a 0-form.
 
             $fun : \hat{\Omega} \mapsto \mathbb{R}$.
 
         Returns
         -------
         field : FemField
-            Field obtained by projection (element of the H1-conformal finite
+            Field obtained by projection (element of the H1-conforming finite
             element space). This is also a real-valued scalar function in the
             logical domain.
-
         """
         # build the rhs
         self.func(*self.args, fun)
@@ -96,7 +93,31 @@ class Projector_H1:
 
 #==============================================================================
 class Projector_Hcurl:
+    """
+    Projector from H(curl) to an H(curl)-conforming finite element space, i.e.
+    a finite dimensional subspace of H(curl), constructed with tensor-product
+    B- and M-splines in 2 or 3 dimensions.
 
+    This is a global projector constructed over a tensor-product grid in the
+    logical domain. The vertices of this grid are obtained as the tensor
+    product of the 1D splines' Greville points along each direction.
+
+    The H(curl) projector matches the "geometric" degrees of freedom of
+    discrete 1-forms, which are the line integrals of a vector field along cell
+    edges. To achieve this, each component of the vector field is projected
+    independently, by combining 1D histopolation along the direction of the
+    edges with 1D interpolation along the other directions.
+
+    Parameters
+    ----------
+    Hcurl : ProductFemSpace
+        H(curl)-conforming finite element space, codomain of the projection
+        operator.
+
+    nquads : list(int) | tuple(int)
+        Number of quadrature points along each direction, to be used in Gauss
+        quadrature rule for computing the (approximated) degrees of freedom.
+    """
     def __init__(self, Hcurl, nquads=None):
 
         dim = Hcurl.n_components
@@ -175,8 +196,31 @@ class Projector_Hcurl:
         else:
             raise NotImplementedError('Hcurl projector is only available in 2D or 3D.')
 
-    # ======================================
+    #--------------------------------------------------------------------------
     def __call__(self, fun):
+        r"""
+        Project vector function onto the H(curl)-conforming finite element
+        space. This happens in the logical domain $\hat{\Omega}$.
+
+        Parameters
+        ----------
+        fun : callable
+            Real-valued vector function to be projected, with arguments the
+            coordinates (x_1, ..., x_N) of a point in the logical domain. This
+            corresponds to the coefficients of a 1-form in the canonical basis
+            (dx_1, ..., dx_N).
+
+            $fun : \hat{\Omega} \mapsto \mathbb{R}^N$.
+
+        Returns
+        -------
+        field : VectorFemField
+            Field obtained by projection (element of the H(curl)-conforming
+            finite element space). This is also a real-valued vector function
+            in the logical domain.
+        """
+        # build the rhs
+        self.func(*self.args, fun)
 
         # build the rhs
         self.func(*self.args, *fun)
@@ -192,7 +236,34 @@ class Projector_Hcurl:
 
 #==============================================================================
 class Projector_Hdiv:
+    """
+    Projector from H(div) to an H(div)-conforming finite element space, i.e. a
+    finite dimensional subspace of H(div), constructed with tensor-product
+    B- and M-splines in 2 or 3 dimensions.
 
+    This is a global projector constructed over a tensor-product grid in the
+    logical domain. The vertices of this grid are obtained as the tensor
+    product of the 1D splines' Greville points along each direction.
+
+    The H(div) projector matches the "geometric" degrees of freedom of discrete
+    (N-1)-forms in N dimensions, which are the integrated flux of a vector
+    field through cell faces (in 3D) or cell edges (in 2D).
+
+    To achieve this, each component of the vector field is projected
+    independently, by combining histopolation along the direction(s) tangential
+    to the face (in 3D) or edge (in 2D), with 1D interpolation along the normal
+    direction.
+
+    Parameters
+    ----------
+    Hdiv : ProductFemSpace
+        H(div)-conforming finite element space, codomain of the projection
+        operator.
+
+    nquads : list(int) | tuple(int)
+        Number of quadrature points along each direction, to be used in Gauss
+        quadrature rule for computing the (approximated) degrees of freedom.
+    """
     def __init__(self, Hdiv, nquads=None):
 
         dim = Hdiv.n_components
@@ -270,9 +341,29 @@ class Projector_Hdiv:
         else:
             raise NotImplementedError('Hdiv projector is only available in 2D or 3D.')
 
-    # ======================================
+    #--------------------------------------------------------------------------
     def __call__(self, fun):
+        r"""
+        Project vector function onto the H(div)-conforming finite element
+        space. This happens in the logical domain $\hat{\Omega}$.
 
+        Parameters
+        ----------
+        fun : callable
+            Real-valued vector function to be projected, with arguments the
+            coordinates (x_1, ..., x_N) of a point in the logical domain. In 3D
+            this corresponds to the coefficients of a 2-form in the canonical
+            basis (dx_1 ∧ dx_2, dx_2 ∧ dx_3, dx_3 ∧ dx_1).
+
+            $fun : \hat{\Omega} \mapsto \mathbb{R}^N$.
+
+        Returns
+        -------
+        field : VectorFemField
+            Field obtained by projection (element of the H(div)-conforming
+            finite element space). This is also a real-valued vector function
+            in the logical domain.
+        """
         # build the rhs
         self.func(*self.args, *fun)
 
@@ -288,7 +379,29 @@ class Projector_Hdiv:
 
 #==============================================================================
 class Projector_L2:
+    """
+    Projector from L2 to an L2-conforming finite element space (i.e. a finite
+    dimensional subspace of L2) constructed with tensor-product M-splines in 1,
+    2 or 3 dimensions.
 
+    This is a global projector constructed over a tensor-product grid in the
+    logical domain. The vertices of this grid are obtained as the tensor
+    product of the 1D splines' Greville points along each direction.
+
+    The L2 projector matches the "geometric" degrees of freedom of discrete
+    N-forms in N dimensions, which are line/surface/volume integrals of a
+    scalar field over an edge/face/cell in 1/2/3 dimension(s). To this end
+    histopolation is used along each direction.
+
+    Parameters
+    ----------
+    L2 : SplineSpace
+        L2-conforming finite element space, codomain of the projection operator
+
+    nquads : list(int) | tuple(int)
+        Number of quadrature points along each direction, to be used in Gauss
+        quadrature rule for computing the (approximated) degrees of freedom.
+    """
     def __init__(self, L2, nquads=None):
 
         # Quadrature grids in cells defined by consecutive Greville points
@@ -318,21 +431,29 @@ class Projector_L2:
 
         self.args  = (*quad_x, *quad_w, self.rhs._data[slices])
 
+    #--------------------------------------------------------------------------
     def __call__(self, fun):
-        r'''
-        Projection on the space V1 via histopolation.
+        r"""
+        Project scalar function onto the L2-conforming finite element space.
+        This happens in the logical domain $\hat{\Omega}$.
 
         Parameters
         ----------
         fun : callable
-            fun(x) \in R is the 1-form to be projected.
+            Real-valued scalar function to be projected, with arguments the
+            coordinates (x_1, ..., x_N) of a point in the logical domain. This
+            corresponds to the coefficient of an N-form in N dimensions, in
+            the canonical basis dx_1 ∧ ... ∧ dx_N.
+
+            $fun : \hat{\Omega} \mapsto \mathbb{R}$.
 
         Returns
         -------
-        coeffs : Vector
-            Finite element coefficients obtained by projection.
-        '''
-
+        field : FemField
+            Field obtained by projection (element of the L2-conforming finite
+            element space). This is also a real-valued scalar function in the
+            logical domain.
+        """
         # build the rhs
         self.func(*self.args, fun)
 

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -69,13 +69,13 @@ class Projector_H1:
 #==============================================================================
 class Projector_Hcurl:
 
-    def __init__(self, Hcurl, n_quads=None):
+    def __init__(self, Hcurl, nquads=None):
 
         dim = Hcurl.n_components
 
-        if n_quads:
-            assert len(n_quads) == dim
-            uw = [gauss_legendre( k-1 ) for k in n_quads]
+        if nquads:
+            assert len(nquads) == dim
+            uw = [gauss_legendre( k-1 ) for k in nquads]
             uw = [(u[::-1], w[::-1]) for u,w in uw]
         else:
             uw = [(V.quad_grids[i].quad_rule_x,V.quad_grids[i].quad_rule_w) for i,V in enumerate(Hcurl.spaces)]
@@ -163,13 +163,13 @@ class Projector_Hcurl:
 #==============================================================================
 class Projector_Hdiv:
 
-    def __init__(self, Hdiv, n_quads=None):
+    def __init__(self, Hdiv, nquads=None):
 
         dim = Hdiv.n_components
 
-        if n_quads:
-            assert len(n_quads) == dim
-            uw = [gauss_legendre( k-1 ) for k in n_quads]
+        if nquads:
+            assert len(nquads) == dim
+            uw = [gauss_legendre( k-1 ) for k in nquads]
             uw = [(u[::-1], w[::-1]) for u,w in uw]
         else:
             uw = [(V.quad_grids[i].quad_rule_x,V.quad_grids[i].quad_rule_w) for i,V in enumerate(Hdiv.spaces)]
@@ -258,17 +258,17 @@ class Projector_Hdiv:
 #==============================================================================
 class Projector_L2:
 
-    def __init__(self, L2, quads=None):
+    def __init__(self, L2, nquads=None):
 
         # Quadrature grids in cells defined by consecutive Greville points
-        if quads:
-            uw = [gauss_legendre( k-1 ) for k in quads]
+        if nquads:
+            uw = [gauss_legendre( k-1 ) for k in nquads]
             uw = [(u[::-1], w[::-1]) for u,w in uw]
         else:
             uw = [(V.quad_rule_x,V.quad_rule_w) for V in L2.quad_grids]
 
         quads = [quadrature_grid(V.histopolation_grid, u, w) for V,(u,w) in zip(L2.spaces, uw)]
-        points, weights = list(zip(*quads))
+        quad_x, quad_w = list(zip(*quads))
 
         L2.init_histopolation()
 
@@ -288,7 +288,7 @@ class Projector_L2:
         else:
             raise ValueError('H1 projector of dimension {} not available'.format(str(len(self.N))))
 
-        self.args  = (*points, *weights, self.rhs._data[slices])
+        self.args  = (*quad_x, *quad_w, self.rhs._data[slices])
 
     def __call__(self, fun):
         r'''

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -9,6 +9,7 @@ from psydac.utilities.quadratures import gauss_legendre
 from psydac.fem.basic             import FemField
 from psydac.fem.vector            import VectorFemField
 
+#==============================================================================
 class Projector_H1:
 
     def __init__(self, H1):
@@ -65,17 +66,19 @@ class Projector_H1:
 
         return FemField(self.space, coeffs=coeffs)
 
+#==============================================================================
 class Projector_Hcurl:
 
     def __init__(self, Hcurl, n_quads=None):
 
+        dim = Hcurl.n_components
+
         if n_quads:
+            assert len(n_quads) == dim
             uw = [gauss_legendre( k-1 ) for k in n_quads]
             uw = [(u[::-1], w[::-1]) for u,w in uw]
         else:
             uw = [(V.quad_grids[i].quad_rule_x,V.quad_grids[i].quad_rule_w) for i,V in enumerate(Hcurl.spaces)]
-
-        dim = len(n_quads)
 
         self.space  = Hcurl
         self.rhs    = BlockVector(Hcurl.vector_space)
@@ -157,23 +160,24 @@ class Projector_Hcurl:
         coeffs.update_ghost_regions()
         return VectorFemField(self.space, coeffs=coeffs)
 
+#==============================================================================
 class Projector_Hdiv:
 
     def __init__(self, Hdiv, n_quads=None):
 
+        dim = Hdiv.n_components
+
         if n_quads:
+            assert len(n_quads) == dim
             uw = [gauss_legendre( k-1 ) for k in n_quads]
             uw = [(u[::-1], w[::-1]) for u,w in uw]
         else:
             uw = [(V.quad_grids[i].quad_rule_x,V.quad_grids[i].quad_rule_w) for i,V in enumerate(Hdiv.spaces)]
 
-        dim = len(n_quads)
-
         self.space  = Hdiv
         self.rhs    = BlockVector(Hdiv.vector_space)
         self.dim    = dim
         self.mats   = [None]*dim
-
 
         for V in Hdiv.spaces:
             V.init_interpolation()
@@ -251,6 +255,7 @@ class Projector_Hdiv:
         coeffs.update_ghost_regions()
         return VectorFemField(self.space, coeffs=coeffs)
 
+#==============================================================================
 class Projector_L2:
 
     def __init__(self, L2, quads=None):

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -220,9 +220,6 @@ class Projector_Hcurl:
             in the logical domain.
         """
         # build the rhs
-        self.func(*self.args, fun)
-
-        # build the rhs
         self.func(*self.args, *fun)
 
         self.rhs.update_ghost_regions()

--- a/psydac/feec/pull_push.py
+++ b/psydac/feec/pull_push.py
@@ -80,7 +80,7 @@ def pull_2d_h1(func_ini, mapping):
     return fun
 
 #==============================================================================
-def pull_2d_hcurl(func_ini, mapping):
+def pull_2d_hcurl(funcs_ini, mapping):
 
     mapping  = mapping.get_callable_mapping()
     f1,f2    = mapping._func_eval
@@ -113,7 +113,7 @@ def pull_2d_hcurl(func_ini, mapping):
     return fun1, fun2
 
 #==============================================================================
-def pull_2d_hdiv(func_ini, mapping):
+def pull_2d_hdiv(funcs_ini, mapping):
 
     mapping    = mapping.get_callable_mapping()
     f1,f2      = mapping._func_eval

--- a/psydac/feec/pull_push.py
+++ b/psydac/feec/pull_push.py
@@ -353,19 +353,14 @@ def push_1d_l2(func, xi1, mapping):
 #==============================================================================
 def push_2d_hcurl(a1, a2, xi1, xi2, mapping):
 
-    mapping    = mapping.get_callable_mapping()
-    J_inv      = mapping._jacobian_inv
+    F = mapping.get_callable_mapping()
+    J_inv_value = F.jacobian_inv(xi1, xi2)
 
-    J_inv_value = J_inv(xi1, xi2)
+    a1_value = a1(xi1, xi2)
+    a2_value = a2(xi1, xi2)
 
-    value1 = (J_inv_value[0,0]*a1(xi1, xi2) +
-              J_inv_value[1,0]*a2(xi1, xi2))
-
-    value2 = (J_inv_value[0,1]*a1(xi1, xi2) +
-              J_inv_value[1,1]*a2(xi1, xi2))
-
-    value3 = (J_inv_value[0,2]*a1(xi1, xi2) +
-              J_inv_value[1,2]*a2(xi1, xi2))
+    value1 = J_inv_value[0, 0] * a1_value + J_inv_value[1, 0] * a2_value
+    value2 = J_inv_value[0, 1] * a1_value + J_inv_value[1, 1] * a2_value
 
     return value1, value2
 
@@ -384,17 +379,18 @@ def push_2d_hdiv(a1, a2, xi1, xi2, mapping):
 
     value2 = ( J_value[1,0]*a1(xi1, xi2) +
                J_value[1,1]*a2(xi1, xi2)) / det_value
+
     return value1, value2
 
 #==============================================================================
 def push_2d_l2(func, xi1, xi2, mapping):
 
-    mapping    = mapping.get_callable_mapping()
-    metric_det = mapping._metric_det
+    F = mapping.get_callable_mapping()
 
-    det_value = metric_det(xi1, xi2)**0.5
+    det_value = F.metric_det(xi1, xi2)**0.5
     value     = func(xi1, xi2)
-    return value/det_value
+
+    return value / det_value
 
 #==============================================================================
 # 3D PUSH-FORWARDS

--- a/psydac/feec/tests/test_global_projectors.py
+++ b/psydac/feec/tests/test_global_projectors.py
@@ -61,7 +61,7 @@ def test_L2_projector_1d(domain, ncells, degree, periodic, nquads):
     V1 = V0.reduce_degree(axes=[0], basis='M')
 
     # Projector onto L2 space (1D histopolation)
-    P1 = Projector_L2(V1, quads=[nquads])
+    P1 = Projector_L2(V1, nquads=[nquads])
 
     # Function to project
     f  = lambda xi1 : np.sin( xi1 + 0.5 )

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -151,6 +151,54 @@ class Matrix( LinearOperator ):
     def tosparse( self ):
         """ Convert to any Scipy sparse matrix format. """
 
+    @abstractmethod
+    def copy(self):
+        """ Create an identical copy of the matrix. """
+
+    @abstractmethod
+    def __neg__(self):
+        """ Get the opposite matrix, i.e. a copy with negative sign. """
+
+    @abstractmethod
+    def __mul__(self, a):
+        """ Multiply by scalar. """
+
+    @abstractmethod
+    def __rmul__(self, a):
+        """ Multiply by scalar. """
+
+    @abstractmethod
+    def __add__(self, m):
+        """ Add matrix. """
+
+    @abstractmethod
+    def __sub__(self, m):
+        """ Subtract matrix. """
+
+    @abstractmethod
+    def __imul__(self, a):
+        """ Multiply by scalar, in place. """
+
+    @abstractmethod
+    def __iadd__(self, m):
+        """ Add matrix, in place. """
+
+    @abstractmethod
+    def __isub__(self, m):
+        """ Subtract matrix, in place. """
+
+    #-------------------------------------
+    # Methods with default implementation
+    #-------------------------------------
+    def __div__(self, a):
+        """ Divide by scalar. """
+        return self * (1.0 / a)
+
+    def __idiv__(self, a):
+        """ Divide by scalar, in place. """
+        self *= 1.0 / a
+        return self
+
 #===============================================================================
 class LinearSolver( metaclass=ABCMeta ):
     """

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -61,7 +61,7 @@ class Vector( metaclass=ABCMeta ):
         pass
 
     @abstractmethod
-    def __neg__( self, a ):
+    def __neg__( self ):
         pass
 
     @abstractmethod

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -61,6 +61,10 @@ class Vector( metaclass=ABCMeta ):
         pass
 
     @abstractmethod
+    def __neg__( self, a ):
+        pass
+
+    @abstractmethod
     def __mul__( self, a ):
         pass
 
@@ -87,6 +91,16 @@ class Vector( metaclass=ABCMeta ):
     @abstractmethod
     def __isub__( self, v ):
         pass
+
+    #-------------------------------------
+    # Methods with default implementation
+    #-------------------------------------
+    def __div__( self, a ):
+        return self * (1.0 / a)
+
+    def __idiv__( self, a ):
+        self *= 1.0 / a
+        return self
 
 Vector.register( ndarray )
 

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -461,7 +461,7 @@ class BlockMatrix( BlockLinearOperator, Matrix ):
         return BlockMatrix(self.domain, self.codomain, blocks=blocks)
 
     # ...
-    def __neg__(self, a):
+    def __neg__(self):
         blocks = {ij: -Bij for ij, Bij in self._blocks.items()}
         return BlockMatrix(self.domain, self.codomain, blocks=blocks)
 

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -145,6 +145,10 @@ class BlockVector( Vector ):
         return BlockVector( self._space, [b.copy() for b in self._blocks] )
 
     #...
+    def __neg__( self ):
+        return BlockVector( self._space, [-b for b in self._blocks] )
+
+    #...
     def __mul__( self, a ):
         return BlockVector( self._space, [b*a for b in self._blocks] )
 

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -61,13 +61,15 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
 
     # First guess of solution
     if x0 is None:
-        x = 0.0 * b.copy()
+        x  = b.copy()
+        x *= 0.0
     else:
         assert( x0.shape == (n,) )
         x = x0.copy()
 
     # First values
-    r  = b - A.dot( x )
+    v  = A.dot(x)
+    r  = b - v
     am = r.dot( r )
     p  = r.copy()
 
@@ -88,12 +90,13 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
             m -= 1
             break
 
-        v   = A.dot( p )
+        v   = A.dot(p, out=v)
         l   = am / v.dot( p )
         x  += l*p
         r  -= l*v
         am1 = r.dot( r )
-        p   = r + (am1/am)*p
+        p  *= (am1/am)
+        p  += r
         am  = am1
 
         if verbose:

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -251,31 +251,11 @@ def jacobi(A, b):
     #-------------------------------------------------------------
 
     V = b.space
-    x = V.zeros()
+    i = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
+    ii = i + (0,) * V.ndim
 
-    # ...
-    if V.ndim == 1:
-        [s1] = V.starts
-        [e1] = V.ends
-        for i1 in range(s1, e1+1):
-            x[i1] = b[i1] / A[i1, 0]
-
-    elif V.ndim == 2:
-        [s1, s2] = V.starts
-        [e1, e2] = V.ends
-        for i1 in range(s1, e1+1):
-            for i2 in range(s2, e2+1):
-                x[i1, i2] = b[i1, i2] / A[i1, i2, 0, 0]
-
-    elif V.ndim == 3:
-        [s1, s2, s3] = V.starts
-        [e1, e2, e3] = V.ends
-        for i1 in range(s1, e1+1):
-            for i2 in range(s2, e2+1):
-                for i3 in range(s3, e3+1):
-                    x[i1, i2, i3] = b[i1, i2, i3] / A[i1, i2, i3, 0, 0, 0]
-    #...
-
+    x = b.copy()
+    x[i] /= A[ii]
     x.update_ghost_regions()
 
     return x

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -79,9 +79,10 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         print( "+ Iter. # | L2-norm of residual |")
         print( "+---------+---------------------+")
         template = "| {:7d} | {:19.2e} |"
+        print( template.format( 1, sqrt( am ) ) )
 
     # Iterate to convergence
-    for m in range( 1, maxiter+1 ):
+    for m in range( 2, maxiter+1 ):
 
         if am < tol_sqr:
             m -= 1

--- a/psydac/linalg/kron.py
+++ b/psydac/linalg/kron.py
@@ -223,6 +223,44 @@ class KroneckerStencilMatrix( Matrix ):
         out.ghost_regions_in_sync = False
         return out
 
+    # ...
+    def copy(self):
+        mats = [m.copy() for m in self.mats]
+        return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
+
+    # ...
+    def __neg__(self):
+        mats = [-self.mats[0], *(m.copy() for m in self.mats[1:])]
+        return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
+
+    # ...
+    def __mul__(self, a):
+        mats = [*(m.copy() for m in self.mats[:-1]), self.mats[-1] * a]
+        return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
+
+    # ...
+    def __rmul__(self):
+        mats = [a * self.mats[0], *(m.copy() for m in self.mats[1:])]
+        return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
+
+    # ...
+    def __imul__(self, a):
+        self.mats[-1] *= a
+        return self
+
+    # ...
+    def __add__(self, m):
+        raise NotImplementedError('Cannot sum Kronecker matrices')
+
+    def __sub__(self, m):
+        raise NotImplementedError('Cannot subtract Kronecker matrices')
+
+    def __iadd__(self, m):
+        raise NotImplementedError('Cannot sum Kronecker matrices')
+
+    def __isub__(self, m):
+        raise NotImplementedError('Cannot subtract Kronecker matrices')
+
     #--------------------------------------
     # Other properties/methods
     #--------------------------------------
@@ -278,9 +316,6 @@ class KroneckerStencilMatrix( Matrix ):
 
     def toarray(self):
         return self.tosparse().toarray()
-
-    def copy(self):
-        return KroneckerStencilMatrix(self.domain, self.codomain, *self.mats)
 
     def transpose(self):
         mats_tr = [Mi.transpose() for Mi in self.mats]

--- a/psydac/linalg/kron.py
+++ b/psydac/linalg/kron.py
@@ -239,7 +239,7 @@ class KroneckerStencilMatrix( Matrix ):
         return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
 
     # ...
-    def __rmul__(self):
+    def __rmul__(self, a):
         mats = [a * self.mats[0], *(m.copy() for m in self.mats[1:])]
         return KroneckerStencilMatrix(self.domain, self.codomain, *mats)
 

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -230,7 +230,7 @@ class StencilVector( Vector ):
         return w
 
     #...
-    def __neg__( self, a ):
+    def __neg__( self ):
         w = StencilVector( self._space )
         w._data[:] = -self._data[:]
         w._sync    =  self._sync

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -1249,6 +1249,9 @@ class StencilMatrix( Matrix ):
             self._data[idx_ghost] = 0
 
 #===============================================================================
+# TODO [YG, 28.01.2021]:
+# - Check if StencilMatrix should be subclassed
+# - Reimplement magic methods (some are simply copied from StencilMatrix)
 class StencilInterfaceMatrix(Matrix):
     """
     Matrix in n-dimensional stencil format for an interface.
@@ -1387,6 +1390,50 @@ class StencilInterfaceMatrix(Matrix):
 
         return coo
 
+    #...
+    def copy( self ):
+        M = StencilMatrix( self.domain, self.codomain, self._pads )
+        M._data[:] = self._data[:]
+        return M
+
+    # ...
+    def __neg__(self):
+        return self.__mul__(-1)
+
+    #...
+    def __mul__( self, a ):
+        w = StencilMatrix( self._domain, self._codomain, self._pads )
+        w._data = self._data * a
+        w._sync = self._sync
+        return w
+
+    #...
+    def __rmul__( self, a ):
+        w = StencilMatrix( self._domain, self._codomain, self._pads )
+        w._data = a * self._data
+        w._sync = self._sync
+        return w
+
+    #...
+    def __add__(self, m):
+        raise NotImplementedError('TODO: StencilInterfaceMatrix.__add__')
+
+    #...
+    def __sub__(self, m):
+        raise NotImplementedError('TODO: StencilInterfaceMatrix.__sub__')
+
+    #...
+    def __imul__(self, a):
+        raise NotImplementedError('TODO: StencilInterfaceMatrix.__imul__')
+
+    #...
+    def __iadd__(self, m):
+        raise NotImplementedError('TODO: StencilInterfaceMatrix.__iadd__')
+
+    #...
+    def __isub__(self, m):
+        raise NotImplementedError('TODO: StencilInterfaceMatrix.__isub__')
+
     #--------------------------------------
     # Other properties/methods
     #--------------------------------------
@@ -1423,30 +1470,6 @@ class StencilInterfaceMatrix(Matrix):
     #...
     def max( self ):
         return self._data.max()
-
-    #...
-    def copy( self ):
-        M = StencilMatrix( self.domain, self.codomain, self._pads )
-        M._data[:] = self._data[:]
-        return M
-
-    #...
-    def __mul__( self, a ):
-        w = StencilMatrix( self._domain, self._codomain, self._pads )
-        w._data = self._data * a
-        w._sync = self._sync
-        return w
-
-    #...
-    def __rmul__( self, a ):
-        w = StencilMatrix( self._domain, self._codomain, self._pads )
-        w._data = a * self._data
-        w._sync = self._sync
-        return w
-
-    # ...
-    def __neg__(self):
-        return self.__mul__(-1)
 
     # ...
     def update_ghost_regions( self, *, direction=None ):

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -734,7 +734,7 @@ class StencilMatrix( Matrix ):
     #...
     def __sub__( self, a):
         w = StencilMatrix( self._domain, self._codomain, self._pads )
-        w._data = a._data - self._data
+        w._data = self._data - a._data
         w._sync = self._sync
         return w
 

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -732,6 +732,17 @@ class StencilMatrix( Matrix ):
         return self.__mul__(-1)
 
     #...
+    def __add__(self, m):
+        assert isinstance(m, StencilMatrix)
+        assert m._domain   == self._domain
+        assert m._codomain == self._codomain
+        assert m._pads     == self._pads
+        w = StencilMatrix(self._domain, self._codomain, self._pads)
+        w._data = self._data  +  m._data
+        w._sync = self._sync and m._sync
+        return w
+
+    #...
     def __sub__(self, m):
         assert isinstance(m, StencilMatrix)
         assert m._domain   == self._domain
@@ -741,6 +752,31 @@ class StencilMatrix( Matrix ):
         w._data = self._data  -  m._data
         w._sync = self._sync and m._sync
         return w
+
+    #...
+    def __imul__(self, a):
+        self._data *= a
+        return self
+
+    #...
+    def __iadd__(self, m):
+        assert isinstance(m, StencilMatrix)
+        assert m._domain   == self._domain
+        assert m._codomain == self._codomain
+        assert m._pads     == self._pads
+        self._data += m._data
+        self._sync  = m._sync and self._sync
+        return self
+
+    #...
+    def __isub__(self, m):
+        assert isinstance(m, StencilMatrix)
+        assert m._domain   == self._domain
+        assert m._codomain == self._codomain
+        assert m._pads     == self._pads
+        self._data -= m._data
+        self._sync  = m._sync and self._sync
+        return self
 
     #...
     def __abs__( self ):

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -230,6 +230,13 @@ class StencilVector( Vector ):
         return w
 
     #...
+    def __neg__( self, a ):
+        w = StencilVector( self._space )
+        w._data[:] = -self._data[:]
+        w._sync    =  self._sync
+        return w
+
+    #...
     def __mul__( self, a ):
         w = StencilVector( self._space )
         w._data = self._data * a

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -732,10 +732,14 @@ class StencilMatrix( Matrix ):
         return self.__mul__(-1)
 
     #...
-    def __sub__( self, a):
-        w = StencilMatrix( self._domain, self._codomain, self._pads )
-        w._data = self._data - a._data
-        w._sync = self._sync
+    def __sub__(self, m):
+        assert isinstance(m, StencilMatrix)
+        assert m._domain   == self._domain
+        assert m._codomain == self._codomain
+        assert m._pads     == self._pads
+        w = StencilMatrix(self._domain, self._codomain, self._pads)
+        w._data = self._data  -  m._data
+        w._sync = self._sync and m._sync
         return w
 
     #...

--- a/psydac/polar/c1_linops.py
+++ b/psydac/polar/c1_linops.py
@@ -113,6 +113,57 @@ class LinearOperator_StencilToDense( Matrix ):
     def tosparse( self ):
         return self.tocoo()
 
+    # ...
+    def copy(self):
+        return LinearOperator_StencilToDense(self.domain, self.codomain, self._data.copy())
+
+    # ...
+    def __neg__(self):
+        return LinearOperator_StencilToDense(self.domain, self.codomain, -self._data)
+
+    # ...
+    def __mul__(self, a):
+        return LinearOperator_StencilToDense(self.domain, self.codomain, self._data * a)
+
+    # ...
+    def __rmul__(self, a):
+        return LinearOperator_StencilToDense(self.domain, self.codomain, a * self._data)
+
+    # ...
+    def __add__(self, m):
+        assert isinstance(m, LinearOperator_StencilToDense)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return LinearOperator_StencilToDense(self.domain, self.codomain, self._data + m._data)
+
+    # ...
+    def __sub__(self, m):
+        assert isinstance(m, LinearOperator_StencilToDense)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return LinearOperator_StencilToDense(self.domain, self.codomain, self._data - m._data)
+
+    # ...
+    def __imul__(self, a):
+        self._data *= a
+        return self
+
+    # ...
+    def __iadd__(self, m):
+        assert isinstance(m, LinearOperator_StencilToDense)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data += m._data
+        return self
+
+    # ...
+    def __isub__(self, m):
+        assert isinstance(m, LinearOperator_StencilToDense)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data -= m._data
+        return self
+
     #-------------------------------------
     # Other properties/methods
     #-------------------------------------
@@ -232,6 +283,56 @@ class LinearOperator_DenseToStencil( Matrix ):
     def tosparse( self ):
         return self.tocoo()
 
+    # ...
+    def copy(self):
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, self._data.copy())
+
+    # ...
+    def __neg__(self):
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, -self._data)
+
+    # ...
+    def __mul__(self, a):
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, self._data * a)
+
+    # ...
+    def __rmul__(self, a):
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, a * self._data)
+
+    # ...
+    def __add__(self, m):
+        assert isinstance(m, LinearOperator_DenseToStencil)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, self._data + m._data)
+
+    # ...
+    def __sub__(self, m):
+        assert isinstance(m, LinearOperator_DenseToStencil)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return LinearOperator_DenseToStencil(self.domain, self.codomain, self._data - m._data)
+
+    # ...
+    def __imul__(self, a):
+        self._data *= a
+        return self
+
+    # ...
+    def __iadd__(self, m):
+        assert isinstance(m, LinearOperator_DenseToStencil)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data += m._data
+        return self
+
+    # ...
+    def __isub__(self, m):
+        assert isinstance(m, LinearOperator_DenseToStencil)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data -= m._data
+        return self
     #-------------------------------------
     # Other properties/methods
     #-------------------------------------

--- a/psydac/polar/dense.py
+++ b/psydac/polar/dense.py
@@ -214,7 +214,7 @@ class DenseVector( Vector ):
         return DenseVector( self._space, self._data.copy() )
 
     # ...
-    def __neg__( self, a ):
+    def __neg__( self ):
         return DenseVector( self._space, -self._data )
 
     # ...

--- a/psydac/polar/dense.py
+++ b/psydac/polar/dense.py
@@ -214,6 +214,10 @@ class DenseVector( Vector ):
         return DenseVector( self._space, self._data.copy() )
 
     # ...
+    def __neg__( self, a ):
+        return DenseVector( self._space, -self._data )
+
+    # ...
     def __mul__( self, a ):
         return DenseVector( self._space, self._data * a )
 
@@ -320,3 +324,54 @@ class DenseMatrix( Matrix ):
     # ...
     def tosparse( self ):
         return coo_matrix( self._data )
+
+    # ...
+    def copy(self):
+        return DenseMatrix(self.domain, self.codomain, self._data.copy())
+
+    # ...
+    def __neg__(self):
+        return DenseMatrix(self.domain, self.codomain, -self._data)
+
+    # ...
+    def __mul__(self, a):
+        return DenseMatrix(self.domain, self.codomain, self._data * a)
+
+    # ...
+    def __rmul__(self, a):
+        return DenseMatrix(self.domain, self.codomain, a * self._data)
+
+    # ...
+    def __add__(self, m):
+        assert isinstance(m, DenseMatrix)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return DenseMatrix(self.domain, self.codomain, self._data + m._data)
+
+    # ...
+    def __sub__(self, m):
+        assert isinstance(m, DenseMatrix)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        return DenseMatrix(self.domain, self.codomain, self._data - m._data)
+
+    # ...
+    def __imul__(self, a):
+        self._data *= a
+        return self
+
+    # ...
+    def __iadd__(self, m):
+        assert isinstance(m, DenseMatrix)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data += m._data
+        return self
+
+    # ...
+    def __isub__(self, m):
+        assert isinstance(m, DenseMatrix)
+        assert self.  domain == m.  domain
+        assert self.codomain == m.codomain
+        self._data -= m._data
+        return self

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     'yamlloader',
 
     # Our packages from PyPi
-    'sympde==0.10.7',
+    'sympde==0.10.8',
     'pyccel==0.10.1',
     'gelato',
 


### PR DESCRIPTION
Apply homogeneous Dirichlet boundary conditions to V0 space of de Rham sequence. This PR also fixes #80.

**New features**
- Add option to 1D Maxwell test: Dirichlet BCs can be applied by penalizing the mass-matrix bilinear form, or strongly;
- Add 2D Maxwell test, where Dirichlet BCs are applied by penalizing the mass-matrix bilinear form;
- Add magic methods to `Matrix` and `Vector` base classes;
- Make Jacobi preconditioner work on block matrices, and for any number of dimensions;
- Change behavior of `BlockLinearOperator` for single row or column:
   - If no. of rows == 1, codomain does not have to be `ProductSpace`;
   - If no. of columns == 1 domain does not have to be `ProductSpace`;
   - Accordingly, dot product allows non-block vectors as input or output;
   - Further, `ProductSpace` constructed from one space returns input space;
   - This allows simplified usage of FEEC derivative matrices.

**Bug fixes**
- Fix bug in 2D push-forwards;
- Fix bug in constructors of `DiscreteLinearForm` and `DiscreteBilinearForm`;
- Fix bug in `apply_essential_bc_1d_StencilMatrix`;

**Improvements**
- Speed up Jacobi preconditioner;
- Reduce number of temporary vectors in CG and PCG solvers;
- Correct iteration counter in CG and PCG solvers.

**Other changes**
- Cleanup and document global projectors;
- Some cleanup in 2D push-forwards;
- Use SymPDE version 0.10.8.