### PR TITLE
Rename ProductSpace as BlockVectorSpace

### DIFF
--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -5,47 +5,44 @@
 
 # TODO: avoid using os.system and use subprocess.call
 
-
-from sympde.expr     import BasicForm as sym_BasicForm
-from sympde.expr     import BilinearForm as sym_BilinearForm
-from sympde.expr     import LinearForm as sym_LinearForm
-from sympde.expr     import Functional as sym_Functional
-from sympde.expr     import Equation as sym_Equation
-from sympde.expr     import Boundary as sym_Boundary, Interface as sym_Interface
-from sympde.expr     import Norm as sym_Norm
-from sympde.topology import Domain, Boundary
-from sympde.topology import Line, Square, Cube
-from sympde.topology import BasicFunctionSpace
-from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import ProductSpace
-from sympde.topology import Mapping
-from sympde.topology import H1SpaceType, L2SpaceType, UndefinedSpaceType
-
-from sympde.calculus.core  import PlusInterfaceOperator, MinusInterfaceOperator
-
-from psydac.api.basic           import BasicDiscrete
-from psydac.api.basic           import random_string
-from psydac.api.grid            import QuadratureGrid, BasisValues
-from psydac.api.ast.glt         import GltKernel
-from psydac.api.ast.glt         import GltInterface
-from psydac.api.glt             import DiscreteGltExpr
-from psydac.api.utilities       import flatten
-
-from psydac.linalg.stencil      import StencilVector, StencilMatrix, StencilInterfaceMatrix
-
-from psydac.linalg.block        import BlockVector, BlockMatrix
-from psydac.cad.geometry        import Geometry
-from psydac.mapping.discrete    import SplineMapping, NurbsMapping
-from psydac.fem.vector          import ProductFemSpace
-from psydac.fem.basic           import FemField
-from psydac.fem.vector          import VectorFemField
-
 from collections import OrderedDict
 from sympy import ImmutableDenseMatrix, Matrix
 import inspect
 import sys
 import numpy as np
 
+from sympde.expr          import BasicForm as sym_BasicForm
+from sympde.expr          import BilinearForm as sym_BilinearForm
+from sympde.expr          import LinearForm as sym_LinearForm
+from sympde.expr          import Functional as sym_Functional
+from sympde.expr          import Equation as sym_Equation
+from sympde.expr          import Boundary as sym_Boundary, Interface as sym_Interface
+from sympde.expr          import Norm as sym_Norm
+from sympde.topology      import Domain, Boundary
+from sympde.topology      import Line, Square, Cube
+from sympde.topology      import BasicFunctionSpace
+from sympde.topology      import ScalarFunctionSpace, VectorFunctionSpace
+from sympde.topology      import ProductSpace
+from sympde.topology      import Mapping
+from sympde.topology      import H1SpaceType, L2SpaceType, UndefinedSpaceType
+from sympde.calculus.core import PlusInterfaceOperator, MinusInterfaceOperator
+
+from psydac.api.basic        import BasicDiscrete
+from psydac.api.basic        import random_string
+from psydac.api.grid         import QuadratureGrid, BasisValues
+from psydac.api.ast.glt      import GltKernel
+from psydac.api.ast.glt      import GltInterface
+from psydac.api.glt          import DiscreteGltExpr
+from psydac.api.utilities    import flatten
+from psydac.linalg.stencil   import StencilVector, StencilMatrix, StencilInterfaceMatrix
+from psydac.linalg.block     import BlockVectorSpace, BlockVector, BlockMatrix
+from psydac.cad.geometry     import Geometry
+from psydac.mapping.discrete import SplineMapping, NurbsMapping
+from psydac.fem.vector       import ProductFemSpace
+from psydac.fem.basic        import FemField
+from psydac.fem.vector       import VectorFemField
+
+#==============================================================================
 def get_quad_order(Vh):
     if isinstance(Vh, ProductFemSpace):
         Vh = Vh.spaces[0]
@@ -216,8 +213,7 @@ class DiscreteBilinearForm(BasicDiscrete):
 
             #...
             # If process does not own the boundary or interface, do not assemble anything
-            import psydac
-            if isinstance(test_space.vector_space, psydac.linalg.block.ProductSpace):
+            if isinstance(test_space.vector_space, BlockVectorSpace):
                 vector_space = test_space.vector_space.spaces[0]
             else:
                 vector_space = test_space.vector_space
@@ -473,8 +469,7 @@ class DiscreteLinearForm(BasicDiscrete):
 
             #...
             # If process does not own the boundary or interface, do not assemble anything
-            import psydac
-            if isinstance(self.space.vector_space, psydac.linalg.block.ProductSpace):
+            if isinstance(self.space.vector_space, BlockVectorSpace):
                 vector_space = self.space.vector_space.spaces[0]
             else:
                 vector_space = self.space.vector_space

--- a/psydac/api/tests/test_api_2d_vector_mapping.py
+++ b/psydac/api/tests/test_api_2d_vector_mapping.py
@@ -8,7 +8,6 @@ from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian
 from sympde.topology import (dx, dy, dz)
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import ProductSpace
 from sympde.topology import element_of
 from sympde.topology import Boundary, NormalVector, TangentVector
 from sympde.topology import Domain, Line, Square, Cube

--- a/psydac/api/tests/test_api_3d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_3d_scalar_mapping.py
@@ -7,7 +7,6 @@ import os
 
 from sympde.calculus import grad, dot
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import ProductSpace
 from sympde.topology import element_of
 from sympde.topology import NormalVector
 from sympde.topology import Union

--- a/psydac/api/tests/test_api_3d_vector.py
+++ b/psydac/api/tests/test_api_3d_vector.py
@@ -5,7 +5,6 @@ from sympy import pi, sin
 
 from sympde.calculus import grad, dot, inner
 from sympde.topology import VectorFunctionSpace
-from sympde.topology import ProductSpace
 from sympde.topology import element_of
 from sympde.topology import Cube
 from sympde.expr     import BilinearForm, LinearForm, integral

--- a/psydac/api/tests/test_api_glt_2d_scalar.py
+++ b/psydac/api/tests/test_api_glt_2d_scalar.py
@@ -8,7 +8,6 @@ from sympde.calculus import grad, dot, inner, cross, rot, curl, div
 from sympde.calculus import laplace, hessian
 from sympde.topology import dx1, dx2, dx3
 from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import ProductSpace
 from sympde.topology import element_of
 from sympde.topology import Boundary, NormalVector, TangentVector
 from sympde.topology import Domain, Line, Square, Cube

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from psydac.linalg.stencil  import StencilMatrix, StencilVectorSpace
 from psydac.linalg.kron     import KroneckerStencilMatrix
-from psydac.linalg.block    import ProductSpace, BlockVector, BlockLinearOperator, BlockMatrix
+from psydac.linalg.block    import BlockVectorSpace, BlockVector, BlockLinearOperator, BlockMatrix
 from psydac.fem.vector      import ProductFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.identity import IdentityLinearOperator, IdentityStencilMatrix as IdentityMatrix
@@ -170,7 +170,7 @@ class Gradient_2D(DiffOperator):
         # Build Gradient matrix block by block
         blocks = [[KroneckerStencilMatrix(B_B, M_B, *(Dx, Iy))],
                   [KroneckerStencilMatrix(B_B, B_M, *(Ix, Dy))]]
-        matrix = BlockMatrix(ProductSpace(H1.vector_space), Hcurl.vector_space, blocks=blocks)
+        matrix = BlockMatrix(BlockVectorSpace(H1.vector_space), Hcurl.vector_space, blocks=blocks)
 
         # Store data in object
         self._domain   = H1
@@ -230,7 +230,7 @@ class Gradient_3D(DiffOperator):
         blocks = [[KroneckerStencilMatrix(B_B_B, M_B_B, *(Dx, Iy, Iz))],
                   [KroneckerStencilMatrix(B_B_B, B_M_B, *(Ix, Dy, Iz))],
                   [KroneckerStencilMatrix(B_B_B, B_B_M, *(Ix, Iy, Dz))]]
-        matrix = BlockMatrix(ProductSpace(H1.vector_space), Hcurl.vector_space, blocks=blocks)
+        matrix = BlockMatrix(BlockVectorSpace(H1.vector_space), Hcurl.vector_space, blocks=blocks)
 
         # Store data in object
         self._domain   = H1
@@ -292,7 +292,7 @@ class ScalarCurl_2D(DiffOperator):
         # Build Curl matrix block by block
         f = KroneckerStencilMatrix
         blocks = [[f(M_B, M_M, *(-Jx, Dy)), f(B_M, M_M, *(Dx, Jy))]]
-        matrix = BlockMatrix(Hcurl.vector_space, ProductSpace(L2.vector_space), blocks=blocks)
+        matrix = BlockMatrix(Hcurl.vector_space, BlockVectorSpace(L2.vector_space), blocks=blocks)
 
         # Store data in object
         self._domain   = Hcurl
@@ -350,7 +350,7 @@ class VectorCurl_2D(DiffOperator):
         # Build Curl matrix block by block
         blocks = [[KroneckerStencilMatrix(B_B, B_M, *( Ix, Dy))],
                   [KroneckerStencilMatrix(B_B, M_B, *(-Dx, Iy))]]
-        matrix = BlockMatrix(ProductSpace(H1.vector_space), Hdiv.vector_space, blocks=blocks)
+        matrix = BlockMatrix(BlockVectorSpace(H1.vector_space), Hdiv.vector_space, blocks=blocks)
 
         # Store data in object
         self._domain   = H1
@@ -483,7 +483,7 @@ class Divergence_2D(DiffOperator):
         # Build Divergence matrix block by block
         f = KroneckerStencilMatrix
         blocks = [[f(B_M, M_M, *(Dx, Jy)), f(M_B, M_M, *(Jx, Dy))]]
-        matrix = BlockMatrix(Hdiv.vector_space, ProductSpace(L2.vector_space), blocks=blocks) 
+        matrix = BlockMatrix(Hdiv.vector_space, BlockVectorSpace(L2.vector_space), blocks=blocks) 
 
         # Store data in object
         self._domain   = Hdiv
@@ -547,7 +547,7 @@ class Divergence_3D(DiffOperator):
         # Build Divergence matrix block by block
         f = KroneckerStencilMatrix
         blocks = [[f(B_M_M, M_M_M, *(Dx, Jy, Jz)), f(M_B_M, M_M_M, *(Jx, Dy, Jz)), f(M_M_B, M_M_M, *(Jx, Jy, Dz))]]
-        matrix = BlockMatrix(Hdiv.vector_space, ProductSpace(L2.vector_space), blocks=blocks) 
+        matrix = BlockMatrix(Hdiv.vector_space, BlockVectorSpace(L2.vector_space), blocks=blocks) 
 
         # Store data in object
         self._domain   = Hdiv

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -146,7 +146,7 @@ class VectorFemSpace( FemSpace ):
 
 # TODO still experimental
 #===============================================================================
-from psydac.linalg.block import ProductSpace
+from psydac.linalg.block import BlockVectorSpace
 class ProductFemSpace( FemSpace ):
     """
     Product of FEM space
@@ -178,7 +178,7 @@ class ProductFemSpace( FemSpace ):
 
         # ...
         v_spaces = [V.vector_space for V in self.spaces]
-        self._vector_space = ProductSpace(*v_spaces)
+        self._vector_space = BlockVectorSpace(*v_spaces)
         # ...
 
     #--------------------------------------------------------------------------

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -8,10 +8,10 @@ from scipy.sparse       import bmat
 
 from psydac.linalg.basic   import VectorSpace, Vector, LinearOperator, Matrix
 
-__all__ = ['ProductSpace', 'BlockVector', 'BlockLinearOperator', 'BlockMatrix']
+__all__ = ['BlockVectorSpace', 'BlockVector', 'BlockLinearOperator', 'BlockMatrix']
 
 #===============================================================================
-class ProductSpace( VectorSpace ):
+class BlockVectorSpace( VectorSpace ):
     """
     Product Vector Space V of two Vector Spaces (V1,V2) or more.
 
@@ -29,13 +29,13 @@ class ProductSpace( VectorSpace ):
 
         # If no spaces are passed, raise an error
         if len(spaces) == 0:
-            raise ValueError('Cannot create a ProductSpace of zero spaces')
+            raise ValueError('Cannot create a BlockVectorSpace of zero spaces')
 
         # If only one space is passed, return it without creating a new object
         if len(spaces) == 1:
             return spaces[0]
 
-        # Create a new ProductSpace object
+        # Create a new BlockVectorSpace object
         return VectorSpace.__new__(cls)
 
     # ...
@@ -98,11 +98,11 @@ class ProductSpace( VectorSpace ):
 #===============================================================================
 class BlockVector( Vector ):
     """
-    Block of Vectors, which is an element of a ProductSpace.
+    Block of Vectors, which is an element of a BlockVectorSpace.
 
     Parameters
     ----------
-    V : psydac.linalg.block.ProductSpace
+    V : psydac.linalg.block.BlockVectorSpace
         Space to which the new vector belongs.
 
     blocks : list or tuple (psydac.linalg.basic.Vector)
@@ -111,7 +111,7 @@ class BlockVector( Vector ):
     """
     def __init__( self,  V, blocks=None ):
 
-        assert isinstance( V, ProductSpace )
+        assert isinstance( V, BlockVectorSpace )
         self._space = V
 
         # We store the blocks in a List so that we can change them later.
@@ -235,7 +235,7 @@ class BlockLinearOperator( LinearOperator ):
     """
     Linear operator that can be written as blocks of other Linear Operators.
     Either the domain or the codomain of this operator, or both, should be of
-    class ProductSpace.
+    class BlockVectorSpace.
 
     Parameters
     ----------
@@ -261,15 +261,15 @@ class BlockLinearOperator( LinearOperator ):
         assert isinstance( V1, VectorSpace )
         assert isinstance( V2, VectorSpace )
 
-        if not (isinstance(V1, ProductSpace) or isinstance(V2, ProductSpace)):
-            raise TypeError("Either domain or codomain must be of type ProductSpace")
+        if not (isinstance(V1, BlockVectorSpace) or isinstance(V2, BlockVectorSpace)):
+            raise TypeError("Either domain or codomain must be of type BlockVectorSpace")
 
         self._domain   = V1
         self._codomain = V2
         self._blocks   = OrderedDict()
 
-        self._nrows = V2.n_blocks if isinstance(V2, ProductSpace) else 1
-        self._ncols = V1.n_blocks if isinstance(V1, ProductSpace) else 1
+        self._nrows = V2.n_blocks if isinstance(V2, BlockVectorSpace) else 1
+        self._ncols = V1.n_blocks if isinstance(V1, BlockVectorSpace) else 1
 
         # Store blocks in OrderedDict (hence they can be manually changed later)
         if blocks:
@@ -411,10 +411,10 @@ class BlockMatrix( BlockLinearOperator, Matrix ):
 
     Parameters
     ----------
-    V1 : psydac.linalg.block.ProductSpace
+    V1 : psydac.linalg.block.BlockVectorSpace
         Domain of the new linear operator.
 
-    V2 : psydac.linalg.block.ProductSpace
+    V2 : psydac.linalg.block.BlockVectorSpace
         Codomain of the new linear operator.
 
     blocks : dict | (list of lists) | (tuple of tuples)

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -5,7 +5,8 @@ import numpy as np
 from random import random
 
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
-from psydac.linalg.block   import ProductSpace, BlockVector, BlockLinearOperator, BlockMatrix
+from psydac.linalg.block   import BlockVectorSpace, BlockVector
+from psydac.linalg.block   import BlockLinearOperator, BlockMatrix
 
 #===============================================================================
 # SERIAL TESTS
@@ -37,7 +38,7 @@ def test_block_linear_operator_serial_dot( n1, n2, p1, p2, P1, P2  ):
     M2.remove_spurious_entries()
     M3.remove_spurious_entries()
 
-    W = ProductSpace(V, V)
+    W = BlockVectorSpace(V, V)
 
     # Construct a BlockLinearOperator object containing M1, M2, M, using 3 ways
     #     |M1  M2|
@@ -121,7 +122,7 @@ def test_block_matrix( n1, n2, p1, p2, P1, P2  ):
     M3.remove_spurious_entries()
     M4.remove_spurious_entries()
 
-    W = ProductSpace(V, V)
+    W = BlockVectorSpace(V, V)
     # Construct a BlockMatrix object containing M1, M2, M3 and M4, using 3 ways
     #     |M1  M2|
     # L = |      |
@@ -230,7 +231,7 @@ def test_block_linear_operator_parallel_dot( n1, n2, p1, p2, P1, P2, reorder ):
     x2.update_ghost_regions()
 
     # Create and Fill Block objects
-    W = ProductSpace(V, V)
+    W = BlockVectorSpace(V, V)
     L = BlockLinearOperator( W, W )
     L[0,0] = M1
     L[0,1] = M2

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector
-from psydac.linalg.block   import BlockVector, ProductSpace
+from psydac.linalg.block   import BlockVector, BlockVectorSpace
 
 import numpy as np
 
@@ -10,7 +10,7 @@ __all__ = ['array_to_stencil']
 def array_to_stencil(x, Xh):
     """ converts a numpy array to StencilVector or BlockVector format"""
 
-    if isinstance(Xh, ProductSpace):
+    if isinstance(Xh, BlockVectorSpace):
         u = BlockVector(Xh)
         starts = [np.array(V.starts) for V in Xh.spaces]
         ends   = [np.array(V.ends)   for V in Xh.spaces]
@@ -30,6 +30,6 @@ def array_to_stencil(x, Xh):
         shape = tuple(ends-starts+1)
         u[g] = x[:np.product(shape)].reshape(shape)
     else:
-        raise ValueError('Xh must be a StencilVectorSpace or a ProductSpace')
+        raise ValueError('Xh must be a StencilVectorSpace or a BlockVectorSpace')
 
     return u

--- a/psydac/polar/c1_projections.py
+++ b/psydac/polar/c1_projections.py
@@ -6,8 +6,8 @@ import numpy as np
 
 from psydac.mapping.discrete import SplineMapping
 from psydac.linalg.stencil   import StencilVectorSpace, StencilVector, StencilMatrix
-from psydac.linalg.block     import ProductSpace, BlockVector, BlockMatrix
-from psydac.polar .dense     import DenseVectorSpace, DenseVector, DenseMatrix
+from psydac.linalg.block     import BlockVector, BlockMatrix
+from psydac.polar .dense     import DenseVector, DenseMatrix
 from psydac.polar.c1_spaces  import new_c1_vector_space
 from psydac.polar.c1_linops  import LinearOperator_StencilToDense
 from psydac.polar.c1_linops  import LinearOperator_DenseToStencil

--- a/psydac/polar/c1_spaces.py
+++ b/psydac/polar/c1_spaces.py
@@ -3,7 +3,7 @@
 # Copyright 2018 Yaman Güçlü
 
 from psydac.linalg.stencil import StencilVectorSpace
-from psydac.linalg.block   import ProductSpace
+from psydac.linalg.block   import BlockVectorSpace
 from psydac.polar .dense   import DenseVectorSpace
 from psydac.polar .c1_cart import C1_Cart
 
@@ -28,7 +28,7 @@ def new_c1_vector_space( V, radial_dim=0, angle_dim=1 ):
 
     Results
     -------
-    P : ProductSpace
+    P : BlockVectorSpace
         Space of the coefficients of a new finite-element space which has
         C^1 continuity at the O-point.
 
@@ -51,6 +51,6 @@ def new_c1_vector_space( V, radial_dim=0, angle_dim=1 ):
         S = StencilVectorSpace( c1_npts, V.pads, V.periods, V.dtype )
         D = DenseVectorSpace( 3 )
 
-    P = ProductSpace( D, S )
+    P = BlockVectorSpace( D, S )
 
     return P

--- a/psydac/polar/tests/test_c1_linops.py
+++ b/psydac/polar/tests/test_c1_linops.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from psydac.polar.dense    import DenseVectorSpace, DenseVector, DenseMatrix
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
-from psydac.linalg.block   import ProductSpace, BlockVector, BlockMatrix
+from psydac.linalg.block   import BlockVectorSpace, BlockVector, BlockMatrix
 
 from psydac.polar.c1_linops import LinearOperator_StencilToDense
 from psydac.polar.c1_linops import LinearOperator_DenseToStencil
@@ -24,7 +24,7 @@ def test_c1_linops( n0, npts, pads, verbose=False ):
     # Spaces
     U = DenseVectorSpace( n0 )
     V = StencilVectorSpace( npts=(n1-2,n2), pads=(p1,p2), periods=(False, True), dtype=float )
-    W = ProductSpace( U, V )
+    W = BlockVectorSpace( U, V )
 
     s1, s2 = V.starts
     e1, e2 = V.ends


### PR DESCRIPTION
Fixes #92. Class `ProductSpace` from module `psydac.linalg.block` caused a name clash with class `ProductSpace` from module `sympde.topology.space`. Therefore we have renamed it as `BlockVectorSpace`, which is consistent with the other names in the same module.