### PR TITLE
Use new names for SymPDE classes

### DIFF
--- a/psydac/api/ast/evaluation.py
+++ b/psydac/api/ast/evaluation.py
@@ -4,7 +4,7 @@ from sympy import symbols, Range
 from sympy import Tuple
 
 from sympde.topology             import Mapping
-from sympde.topology             import ScalarTestFunction
+from sympde.topology             import ScalarFunction
 from sympde.topology             import SymbolicExpr
 from sympde.topology.space       import element_of
 from sympde.topology.derivatives import _logical_partial_derivatives
@@ -93,7 +93,7 @@ class EvalArrayField(SplBasic):
         dim = space.ldim
         mapping = self.mapping
 
-        field_atoms = self.fields.atoms(ScalarTestFunction)
+        field_atoms = self.fields.atoms(ScalarFunction)
         fields_str = sorted([SymbolicExpr(f).name for f in self.fields])
 
         # ... declarations

--- a/psydac/api/ast/expr.py
+++ b/psydac/api/ast/expr.py
@@ -17,9 +17,9 @@ from pyccel.ast.core import If, Is, Return
 from pyccel.ast.core import _atomic
 
 from sympde.core                 import Constant
-from sympde.topology.space       import ScalarTestFunction
-from sympde.topology.space       import VectorTestFunction
-from sympde.topology.space       import IndexedTestTrial
+from sympde.topology.space       import ScalarFunction
+from sympde.topology.space       import VectorFunction
+from sympde.topology.space       import IndexedVectorFunction
 from sympde.topology.derivatives import _partial_derivatives
 from sympde.topology.derivatives import _logical_partial_derivatives
 from sympde.topology.derivatives import get_max_partial_derivatives
@@ -46,7 +46,7 @@ def is_scalar_field(expr):
     elif isinstance(expr, _logical_partial_derivatives):
         return is_scalar_field(expr.args[0])
 
-    elif isinstance(expr, ScalarTestFunction):
+    elif isinstance(expr, ScalarFunction):
         return True
 
     return False
@@ -60,7 +60,7 @@ def is_vector_field(expr):
     elif isinstance(expr, _logical_partial_derivatives):
         return is_vector_field(expr.args[0])
 
-    elif isinstance(expr, (VectorTestFunction, IndexedTestTrial)):
+    elif isinstance(expr, (VectorFunction, IndexedVectorFunction)):
         return True
 
     return False
@@ -69,9 +69,9 @@ def is_vector_field(expr):
 def compute_atoms_expr(atom, basis, indices, loc_indices, dim):
 
     cls = (_partial_derivatives,
-           ScalarTestFunction,
-           VectorTestFunction,
-           IndexedTestTrial)
+           ScalarFunction,
+           VectorFunction,
+           IndexedVectorFunction)
 
     if not isinstance(atom, cls):
         raise TypeError('atom must be of type {}'.format(str(cls)))
@@ -85,13 +85,13 @@ def compute_atoms_expr(atom, basis, indices, loc_indices, dim):
         orders[atom.grad_index] = p_indices[atom.coordinate]
         
 
-    if isinstance(a, IndexedTestTrial):
+    if isinstance(a, IndexedVectorFunction):
         ind = a.indices[0]
     args = []
     for i in range(dim):
-        if isinstance(a, IndexedTestTrial):
+        if isinstance(a, IndexedVectorFunction):
             args.append(basis[ind+i*dim][loc_indices[i],orders[i],indices[i]])
-        elif isinstance(a, ScalarTestFunction):
+        elif isinstance(a, ScalarFunction):
             args.append(basis[i][loc_indices[i],orders[i],indices[i]])
         else:
             raise NotImplementedError('TODO')
@@ -256,8 +256,8 @@ class ExprKernel(SplBasic):
         # ...
         atoms_types = (_partial_derivatives,
                        _logical_partial_derivatives,
-                       ScalarTestFunction,
-                       VectorTestFunction, IndexedTestTrial,
+                       ScalarFunction,
+                       VectorFunction, IndexedVectorFunction,
                        SymbolicDeterminant,
                        Symbol)
 
@@ -269,8 +269,8 @@ class ExprKernel(SplBasic):
         atomic_expr_field        = [atom for atom in atoms if is_scalar_field(atom)]
         atomic_expr_vector_field = [atom for atom in atoms if is_vector_field(atom)]
 
-        self._fields = tuple(expr.atoms(ScalarTestFunction))
-        self._vector_fields = tuple(expr.atoms(VectorTestFunction))
+        self._fields = tuple(expr.atoms(ScalarFunction))
+        self._vector_fields = tuple(expr.atoms(VectorFunction))
         # ...
         fields_str        = tuple(SymbolicExpr(f).name for f in atomic_expr_field)
         vector_fields_str = tuple(SymbolicExpr(f).name for f in atomic_expr_vector_field)

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -13,9 +13,9 @@ from sympde.expr                 import Functional
 from sympde.topology.basic       import Boundary, Interface
 from sympde.topology             import H1SpaceType, HcurlSpaceType
 from sympde.topology             import HdivSpaceType, L2SpaceType, UndefinedSpaceType
-from sympde.topology.space       import ScalarTestFunction
-from sympde.topology.space       import VectorTestFunction
-from sympde.topology.space       import IndexedTestTrial
+from sympde.topology.space       import ScalarFunction
+from sympde.topology.space       import VectorFunction
+from sympde.topology.space       import IndexedVectorFunction
 from sympde.topology.derivatives import _logical_partial_derivatives
 from sympde.topology.derivatives import get_max_logical_partial_derivatives
 from sympde.topology.mapping     import InterfaceMapping
@@ -75,7 +75,7 @@ def regroup(tests):
     This function regourps the test/trial functions by their Function Space
 
     """
-    tests  = [i.base if isinstance(i, IndexedTestTrial) else i for i in tests]
+    tests  = [i.base if isinstance(i, IndexedVectorFunction) else i for i in tests]
     new_tests = []
     for i in tests:
         if i not in new_tests:
@@ -90,7 +90,7 @@ def regroup(tests):
     grs = [(list(g.values())[0],tuple(g.keys())) for g in grs]
     groups = []
     for d,g in grs:
-        if isinstance(d, (HcurlSpaceType, HdivSpaceType)) and isinstance(g[0], VectorTestFunction):
+        if isinstance(d, (HcurlSpaceType, HdivSpaceType)) and isinstance(g[0], VectorFunction):
             dim = g[0].space.ldim
             for i in range(dim):
                 s = [u[i] for u in g]
@@ -107,9 +107,9 @@ def expand(args):
     """
     new_args = []
     for i in args:
-        if isinstance(i, (ScalarTestFunction, IndexedTestTrial)):
+        if isinstance(i, (ScalarFunction, IndexedVectorFunction)):
             new_args += [i]
-        elif isinstance(i, VectorTestFunction):
+        elif isinstance(i, VectorFunction):
             new_args += [i[k] for k in  range(i.space.ldim)]
         else:
             raise NotImplementedError("TODO")
@@ -123,9 +123,9 @@ def expand_hdiv_hcurl(args):
     """
     new_args = []
     for i in args:
-        if isinstance(i, (ScalarTestFunction, IndexedTestTrial)):
+        if isinstance(i, (ScalarFunction, IndexedVectorFunction)):
             new_args += [i]
-        elif isinstance(i, VectorTestFunction):
+        elif isinstance(i, VectorFunction):
             if isinstance(i.space.kind, (HcurlSpaceType, HdivSpaceType)):
                 new_args += [i[k] for k in  range(i.space.ldim)]
             else:
@@ -228,7 +228,7 @@ class AST(object):
 
         elif isinstance(expr, Functional):
             is_functional       = True
-            fields              = tuple(expr.atoms(ScalarTestFunction, VectorTestFunction))
+            fields              = tuple(expr.atoms(ScalarFunction, VectorFunction))
             mapping             = spaces.symbolic_mapping
             is_rational_mapping = spaces.is_rational_mapping
             spaces              = spaces.symbolic_space
@@ -241,7 +241,7 @@ class AST(object):
         trials = expand_hdiv_hcurl(trials)
         fields = expand_hdiv_hcurl(fields)
 
-        atoms_types = (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)
+        atoms_types = (ScalarFunction, VectorFunction, IndexedVectorFunction)
 
         nderiv = 1
         if isinstance(terminal_expr, (ImmutableDenseMatrix, Matrix)):
@@ -453,7 +453,7 @@ def _create_ast_bilinear_form(terminal_expr, atomic_expr_field,
     # sort tests and trials by their space type
     test_groups  = regroup(tests)
     trial_groups = regroup(trials)
-    # expand every VectorTestFunction into IndexedTestFunctions
+    # expand every VectorFunction into IndexedVectorFunctions
     ex_tests     = expand(tests)
     ex_trials    = expand(trials)
 
@@ -629,7 +629,7 @@ def _create_ast_linear_form(terminal_expr, atomic_expr_field, tests, d_tests, fi
 
     # sort tests by their space type
     groups = regroup(tests)
-    # expand every VectorTestFunction into IndexedTestFunctions
+    # expand every VectorFunction into IndexedVectorFunctions
     ex_tests = expand(tests)
     # ... 
     #=========================================================begin kernel======================================================

--- a/psydac/api/ast/glt.py
+++ b/psydac/api/ast/glt.py
@@ -23,9 +23,9 @@ from pyccel.ast.core import _atomic
 
 from pyccel.ast.numpyext import Zeros
 
-from sympde.topology.space       import ScalarTestFunction
-from sympde.topology.space       import VectorTestFunction
-from sympde.topology.space       import IndexedTestTrial
+from sympde.topology.space       import ScalarFunction
+from sympde.topology.space       import VectorFunction
+from sympde.topology.space       import IndexedVectorFunction
 from sympde.topology.derivatives import _partial_derivatives
 from sympde.topology.derivatives import _logical_partial_derivatives
 from sympde.topology.derivatives import get_max_partial_derivatives
@@ -270,9 +270,9 @@ class GltKernel(SplBasic):
 
         atoms_types = (_partial_derivatives,
                        _logical_partial_derivatives,
-                       ScalarTestFunction,
-                       VectorTestFunction,
-                       IndexedTestTrial,
+                       ScalarFunction,
+                       VectorFunction,
+                       IndexedVectorFunction,
                        SymbolicDeterminant)
 
         atoms  = _atomic(expr, cls=atoms_types)
@@ -280,8 +280,8 @@ class GltKernel(SplBasic):
 
         # ...
 #        atomic_expr_mapping      = [atom for atom in atoms if is_mapping(atom)]
-        atomic_expr_field        = [atom for atom in atoms if atom.atoms(ScalarTestFunction)]
-        atomic_expr_vector_field = [atom for atom in atoms if atom.atoms(VectorTestFunction)]
+        atomic_expr_field        = [atom for atom in atoms if atom.atoms(ScalarFunction)]
+        atomic_expr_vector_field = [atom for atom in atoms if atom.atoms(VectorFunction)]
         # ...
 
         # ...
@@ -295,7 +295,7 @@ class GltKernel(SplBasic):
         atomic_expr_field_logical = tuple(f.subs(d_subs) for f in atomic_expr_field)
         fields_str         = tuple(sorted(SymbolicExpr(f).name for f in atomic_expr_field))
         fields_logical_str = tuple(sorted(SymbolicExpr(f).name for f in atomic_expr_field_logical))
-        field_atoms        = tuple(expr.atoms(ScalarTestFunction))
+        field_atoms        = tuple(expr.atoms(ScalarFunction))
         # ...
 
         # ... create EvalArrayField
@@ -308,7 +308,7 @@ class GltKernel(SplBasic):
                 g_names = set([f.name for f in group])
                 fields_expressions = []
                 for e in atomic_expr_field:
-                    fs = e.atoms(ScalarTestFunction)
+                    fs = e.atoms(ScalarFunction)
                     f_names = set([f.name for f in fs])
                     if f_names & g_names:
                         fields_expressions += [e]

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -12,9 +12,9 @@ from sympy.core.containers    import Tuple
 from sympy.core.compatibility import with_metaclass
 
 from sympde.topology import elements_of
-from sympde.topology import ScalarTestFunction, VectorTestFunction
+from sympde.topology import ScalarFunction, VectorFunction
 from sympde.topology import VectorFunctionSpace
-from sympde.topology import IndexedTestTrial
+from sympde.topology import IndexedVectorFunction
 from sympde.topology import H1SpaceType, L2SpaceType, UndefinedSpaceType
 from sympde.topology import Mapping
 from sympde.topology import dx1, dx2, dx3
@@ -243,12 +243,12 @@ class EvalMapping(BaseNode):
         mapping_atoms  = components.arguments
         basis          = q_basis
         target         = basis.target
-        if isinstance(target, IndexedTestTrial):
+        if isinstance(target, IndexedVectorFunction):
             space          = target.base.space
         else:
             space      = target.space
         weight,        = elements_of(space, names='weight')
-        if isinstance(target, VectorTestFunction):
+        if isinstance(target, VectorFunction):
             target = target[0]
 
         l_coeffs    = []
@@ -482,7 +482,7 @@ class GlobalTensorQuadratureBasis(ArrayNode):
     _free_indices = [index_element, index_quad, index_dof]
 
     def __new__(cls, target):
-        if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+        if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
             raise TypeError('Expecting a scalar/vector test function')
         return Basic.__new__(cls, target)
 
@@ -493,7 +493,7 @@ class GlobalTensorQuadratureBasis(ArrayNode):
     @property
     def unique_scalar_space(self):
         unique_scalar_space = True
-        if isinstance(self.target, IndexedTestTrial):
+        if isinstance(self.target, IndexedVectorFunction):
             return True
         space = self.target.space
         if isinstance(space, VectorFunctionSpace):
@@ -502,7 +502,7 @@ class GlobalTensorQuadratureBasis(ArrayNode):
 
     @property
     def is_scalar(self):
-        return isinstance(self.target, (ScalarTestFunction, IndexedTestTrial))
+        return isinstance(self.target, (ScalarFunction, IndexedVectorFunction))
 
 #==============================================================================
 class LocalTensorQuadratureBasis(ArrayNode):
@@ -513,7 +513,7 @@ class LocalTensorQuadratureBasis(ArrayNode):
     _free_indices = [index_dof]
 
     def __new__(cls, target):
-        if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+        if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
             raise TypeError('Expecting a scalar/vector test function')
         return Basic.__new__(cls, target)
 
@@ -524,7 +524,7 @@ class LocalTensorQuadratureBasis(ArrayNode):
     @property
     def unique_scalar_space(self):
         unique_scalar_space = True
-        if isinstance(self.target, IndexedTestTrial):
+        if isinstance(self.target, IndexedVectorFunction):
             return True
         space = self.target.space
         if isinstance(space, VectorFunctionSpace):
@@ -533,7 +533,7 @@ class LocalTensorQuadratureBasis(ArrayNode):
 
     @property
     def is_scalar(self):
-        return isinstance(self.target, (ScalarTestFunction, IndexedTestTrial))
+        return isinstance(self.target, (ScalarFunction, IndexedVectorFunction))
 #==============================================================================
 class TensorQuadratureBasis(ArrayNode):
     """
@@ -543,7 +543,7 @@ class TensorQuadratureBasis(ArrayNode):
     _free_indices = [index_quad]
 
     def __new__(cls, target):
-        if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+        if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
             raise TypeError('Expecting a scalar/vector test function')
 
         return Basic.__new__(cls, target)
@@ -555,7 +555,7 @@ class TensorQuadratureBasis(ArrayNode):
     @property
     def unique_scalar_space(self):
         unique_scalar_space = True
-        if isinstance(self.target, IndexedTestTrial):
+        if isinstance(self.target, IndexedVectorFunction):
             return True
         space = self.target.space
         if isinstance(space, VectorFunctionSpace):
@@ -564,13 +564,13 @@ class TensorQuadratureBasis(ArrayNode):
 
     @property
     def is_scalar(self):
-        return isinstance(self.target, (ScalarTestFunction, IndexedTestTrial))
+        return isinstance(self.target, (ScalarFunction, IndexedVectorFunction))
 #==============================================================================
 class CoefficientBasis(ScalarNode):
     """
     """
     def __new__(cls, target):
-        ls = target.atoms(ScalarTestFunction, VectorTestFunction, Mapping)
+        ls = target.atoms(ScalarFunction, VectorFunction, Mapping)
         if not len(ls) == 1:
             raise TypeError('Expecting a scalar/vector test function or a Mapping')
         return Basic.__new__(cls, target)
@@ -955,7 +955,7 @@ class GlobalSpan(ArrayNode):
     _positions = {index_element: 0}
 
     def __new__(cls, target):
-        if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+        if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
             raise TypeError('Expecting a scalar/vector test function')
 
         return Basic.__new__(cls, target)
@@ -969,7 +969,7 @@ class Span(ScalarNode):
     """
     """
     def __new__(cls, target):
-        if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+        if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
             raise TypeError('Expecting a scalar/vector test function')
 
         return Basic.__new__(cls, target)
@@ -983,7 +983,7 @@ class Pads(ScalarNode):
     """
     def __new__(cls, tests, trials):
         for target in tests + trials:
-            if not isinstance(target, (ScalarTestFunction, VectorTestFunction, IndexedTestTrial)):
+            if not isinstance(target, (ScalarFunction, VectorFunction, IndexedVectorFunction)):
                 raise TypeError('Expecting a scalar/vector test function')
         return Basic.__new__(cls, tests, trials)
 
@@ -1187,7 +1187,7 @@ class BasisAtom(AtomicNode):
     """
     """
     def __new__(cls, expr):
-        types = (IndexedTestTrial, VectorTestFunction, ScalarTestFunction)
+        types = (IndexedVectorFunction, VectorFunction, ScalarFunction)
 
         ls = _atomic(expr, cls=types)
         if not(len(ls) == 1):
@@ -1441,7 +1441,7 @@ class SplitArray(BaseNode):
 
 #==============================================================================
 def construct_logical_expressions(u, nderiv):
-    if isinstance(u, IndexedTestTrial):
+    if isinstance(u, IndexedVectorFunction):
         dim = u.base.space.ldim
     else:
         dim = u.space.ldim
@@ -1455,7 +1455,7 @@ def construct_logical_expressions(u, nderiv):
     indices = [ijk for ijk in indices if sum(ijk) <= nderiv]
 
     args = []
-    u = [u] if isinstance(u, (ScalarTestFunction, IndexedTestTrial)) else [u[i] for i in range(dim)]
+    u = [u] if isinstance(u, (ScalarFunction, IndexedVectorFunction)) else [u[i] for i in range(dim)]
     for ijk in indices:
         for atom in u:
             for n,op in zip(ijk, ops):

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -7,9 +7,9 @@ from sympy import Mul, Pow, Function, Tuple
 from sympy import sqrt as sympy_sqrt, Range
 from sympy.utilities.iterables import cartes
 
-from sympde.topology.space       import ScalarTestFunction
-from sympde.topology.space       import VectorTestFunction
-from sympde.topology.space       import IndexedTestTrial
+from sympde.topology.space       import ScalarFunction
+from sympde.topology.space       import VectorFunction
+from sympde.topology.space       import IndexedVectorFunction
 from sympde.topology.space       import element_of
 from sympde.topology             import Mapping
 from sympde.topology             import Boundary
@@ -65,13 +65,13 @@ def logical2physical(expr):
 #==============================================================================
 def _get_name(atom):
     atom_name = None
-    if isinstance( atom, ScalarTestFunction ):
+    if isinstance( atom, ScalarFunction ):
         atom_name = str(atom.name)
 
-    elif isinstance( atom, VectorTestFunction ):
+    elif isinstance( atom, VectorFunction ):
         atom_name = str(atom.name)
 
-    elif isinstance( atom, IndexedTestTrial ):
+    elif isinstance( atom, IndexedVectorFunction ):
         atom_name = str(atom.base.name)
 
     else:
@@ -130,9 +130,9 @@ def compute_atoms_expr(atomic_exprs, indices_quad, indices_test,
     """
 
     cls = (_partial_derivatives,
-           VectorTestFunction,
-           ScalarTestFunction,
-           IndexedTestTrial)
+           VectorFunction,
+           ScalarFunction,
+           IndexedVectorFunction)
     
     dim  = len(indices_test)
 
@@ -257,9 +257,9 @@ def compute_atoms_expr_field(atomic_exprs, indices_quad,
     map_stmts = []
 
     cls = (_partial_derivatives,
-           ScalarTestFunction,
-           IndexedTestTrial,
-           VectorTestFunction)
+           ScalarFunction,
+           IndexedVectorFunction,
+           VectorFunction)
 
     # If there is a mapping, compute [dx(u), dy(u), dz(u)] as functions
     # of [dx1(u), dx2(u), dx3(u)], and store results into intermediate
@@ -311,12 +311,12 @@ def compute_atoms_expr_field(atomic_exprs, indices_quad,
     for atom in new_atoms:
 
         # Extract field, compute name of coefficient variable, and get base
-        if atom.atoms(ScalarTestFunction):
-            field      = atom.atoms(ScalarTestFunction).pop()
+        if atom.atoms(ScalarFunction):
+            field      = atom.atoms(ScalarFunction).pop()
             field_name = 'coeff_' + SymbolicExpr(field).name
             base       = field
-        elif atom.atoms(VectorTestFunction):
-            field      = atom.atoms(IndexedTestTrial).pop()
+        elif atom.atoms(VectorFunction):
+            field      = atom.atoms(IndexedVectorFunction).pop()
             field_name = 'coeff_' + SymbolicExpr(field).name
             base       = field.base
         else:

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -227,7 +227,7 @@ class DiscreteEquation(BasicDiscrete):
 
                 from sympde.expr import integral
                 from sympde.expr import find
-                from sympde.topology import element_of #, ScalarTestFunction
+                from sympde.topology import element_of #, ScalarFunction
 
                 # Extract trial functions from model equation
                 u = self.expr.trial_functions
@@ -243,7 +243,7 @@ class DiscreteEquation(BasicDiscrete):
                 test_dict = dict(zip(u, v))
 
                 # TODO: use dot product for vector quantities
-#                product  = lambda f, g: (f * g if isinstance(g, ScalarTestFunction) else dot(f, g))
+#                product  = lambda f, g: (f * g if isinstance(g, ScalarFunction) else dot(f, g))
                 product  = lambda f, g: f * g
 
                 # Construct variational formulation that performs L2 projection

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     'yamlloader',
 
     # Our packages from PyPi
-    'sympde==0.10.10',
+    'sympde==0.11',
     'pyccel==0.10.1',
     'gelato==0.11',
 


### PR DESCRIPTION
Use SymPDE version 0.11. Accordingly, rename imported classes:

- `ScalarTestFunction` -> `ScalarFunction`,
- `VectorTestFunction` -> `VectorFunction`,
- `IndexedTestTrial` -> `IndexedVectorFunction`.

See also SymPDE's pull request [no. 97](https://github.com/pyccel/sympde/pull/97).