### PR TITLE
Improve FemField and remove VectorFemField

### DIFF
--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -15,7 +15,6 @@ from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
 from psydac.fem.basic          import FemField
-from psydac.fem.vector         import VectorFemField
 from psydac.api.discretization import discretize
 from psydac.linalg.utilities   import array_to_stencil
 
@@ -159,7 +158,7 @@ def run_system_2_2d_dir(f1, f2,u1, u2, ncells, degree):
     M_inv = linalg.inv(M_1)
     x = M_inv.dot(rhs_1)
     
-    phi1 = VectorFemField(V1h)
+    phi1 = FemField(V1h)
     phi2 = FemField(V2h)
 
     

--- a/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
+++ b/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
@@ -1,39 +1,18 @@
-import pytest
-
-from sympy.core.containers import Tuple
-from sympy import Matrix
-from sympy import Function
-from sympy import pi, cos, sin, exp
-
-from sympde.core import Constant
-from sympde.calculus import grad, dot, inner, rot, div
-from sympde.calculus import laplace, bracket, convect
-from sympde.calculus import jump, avg, Dn, minus, plus
-#from sympde.topology import dx
-from sympde.topology import ScalarFunctionSpace
-from sympde.topology import element_of, elements_of
-from sympde.topology import InteriorDomain, Union
-from sympde.topology import Boundary, NormalVector
-from sympde.topology import Domain
-from sympde.topology import trace_1
-from sympde.topology import Square
-from sympde.topology import ElementDomain
-from sympde.topology import Area
-from sympde.topology import IdentityMapping, PolarMapping
-
-from sympde.expr.expr import LinearExpr
-from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral
-from sympde.expr.expr import Functional, Norm
-from sympde.expr.expr import linearize
-from sympde.expr.evaluation import TerminalExpr
-from psydac.api.discretization import discretize
-from sympde.expr     import find, EssentialBC
-from psydac.fem.vector                  import VectorFemField
-from psydac.fem.basic                   import FemField
 import numpy as np
-
 from mpi4py import MPI
+
+from sympde.calculus      import grad, dot
+from sympde.topology      import ScalarFunctionSpace
+from sympde.topology      import elements_of
+from sympde.topology      import Square
+from sympde.topology      import PolarMapping
+from sympde.expr.expr     import LinearForm, BilinearForm
+from sympde.expr.expr     import integral
+from sympde.expr.expr     import Norm
+from sympde.expr.equation import find, EssentialBC
+
+from psydac.fem.basic import FemField
+from psydac.api.discretization import discretize
 
 #==============================================================================
 

--- a/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
@@ -1,39 +1,22 @@
 import pytest
-
-from sympy.core.containers import Tuple
-from sympy import Matrix
-from sympy import Function
-from sympy import pi, cos, sin, exp
-
-from sympde.core import Constant
-from sympde.calculus import grad, dot, inner, rot, div
-from sympde.calculus import laplace, bracket, convect
-from sympde.calculus import jump, avg, Dn, minus, plus
-#from sympde.topology import dx
-from sympde.topology import ScalarFunctionSpace
-from sympde.topology import element_of, elements_of
-from sympde.topology import InteriorDomain, Union
-from sympde.topology import Boundary, NormalVector
-from sympde.topology import Domain
-from sympde.topology import trace_1
-from sympde.topology import Square
-from sympde.topology import ElementDomain
-from sympde.topology import Area
-from sympde.topology import IdentityMapping, PolarMapping
-
-from sympde.expr.expr import LinearExpr
-from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral
-from sympde.expr.expr import Functional, Norm
-from sympde.expr.expr import linearize
-from sympde.expr.evaluation import TerminalExpr
-from psydac.api.discretization import discretize
-from sympde.expr     import find, EssentialBC
-from psydac.fem.vector                  import VectorFemField
-from psydac.fem.basic                   import FemField
 import numpy as np
-
 from mpi4py import MPI
+from sympy  import pi, sin
+
+from sympde.calculus      import grad, dot
+from sympde.calculus      import minus, plus
+from sympde.topology      import ScalarFunctionSpace
+from sympde.topology      import elements_of
+from sympde.topology      import NormalVector
+from sympde.topology      import Square
+from sympde.topology      import IdentityMapping, PolarMapping
+from sympde.expr.expr     import LinearForm, BilinearForm
+from sympde.expr.expr     import integral
+from sympde.expr.expr     import Norm
+from sympde.expr.equation import find, EssentialBC
+
+from psydac.fem.basic          import FemField
+from psydac.api.discretization import discretize
 
 #==============================================================================
 
@@ -90,7 +73,7 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
 
     x  = equation_h.solve()
 
-    uh = VectorFemField( Vh )
+    uh = FemField( Vh )
 
     for i in range(len(uh.coeffs[:])):
         uh.coeffs[i][:,:] = x[i][:,:]

--- a/psydac/api/tests/test_api_2d_scalar_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_multi_patch.py
@@ -1,35 +1,18 @@
-import pytest
+from sympy import pi, sin
 
-from sympy.core.containers import Tuple
-from sympy import Matrix
-from sympy import Function
-from sympy import pi, cos, sin, exp
+from sympde.calculus      import grad, dot
+from sympde.calculus      import minus, plus
+from sympde.topology      import Square
+from sympde.topology      import ScalarFunctionSpace
+from sympde.topology      import elements_of
+from sympde.topology      import NormalVector
+from sympde.expr.expr     import LinearForm, BilinearForm
+from sympde.expr.expr     import integral
+from sympde.expr.expr     import Norm
+from sympde.expr.equation import find, EssentialBC
 
-from sympde.core import Constant
-from sympde.calculus import grad, dot, inner, rot, div
-from sympde.calculus import laplace, bracket, convect
-from sympde.calculus import jump, avg, Dn, minus, plus
-#from sympde.topology import dx
-from sympde.topology import ScalarFunctionSpace
-from sympde.topology import element_of, elements_of
-from sympde.topology import InteriorDomain, Union
-from sympde.topology import Boundary, NormalVector
-from sympde.topology import Domain
-from sympde.topology import trace_1
-from sympde.topology import Square
-from sympde.topology import ElementDomain
-from sympde.topology import Area
-
-from sympde.expr.expr import LinearExpr
-from sympde.expr.expr import LinearForm, BilinearForm
-from sympde.expr.expr import integral
-from sympde.expr.expr import Functional, Norm
-from sympde.expr.expr import linearize
-from sympde.expr.evaluation import TerminalExpr
+from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
-from sympde.expr     import find, EssentialBC
-from psydac.fem.vector                  import VectorFemField
-from psydac.fem.basic                   import FemField
 
 #==============================================================================
 
@@ -87,7 +70,7 @@ def run_poisson_2d(solution, f, domain, ncells, degree):
 
     x  = equation_h.solve()
 
-    uh = VectorFemField( Vh )
+    uh = FemField( Vh )
 
     for i in range(len(uh.coeffs[:])):
         uh.coeffs[i][:,:] = x[i][:,:]

--- a/psydac/api/tests/test_api_2d_system.py
+++ b/psydac/api/tests/test_api_2d_system.py
@@ -15,7 +15,6 @@ from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
 from psydac.fem.basic          import FemField
-from psydac.fem.vector         import VectorFemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -92,7 +91,7 @@ def run_system_1_2d_dir(Fe, Ge, f0, f1, ncells, degree):
     # ...
 
     # ...
-    Fh = VectorFemField( Wh )
+    Fh = FemField( Wh )
     Fh.coeffs[0][:,:] = x[0][:,:]
     Fh.coeffs[1][:,:] = x[1][:,:]
     # ...

--- a/psydac/api/tests/test_api_2d_vector.py
+++ b/psydac/api/tests/test_api_2d_vector.py
@@ -11,7 +11,7 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.vector         import VectorFemField
+from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -67,7 +67,7 @@ def run_vector_poisson_2d_dir(solution, f, ncells, degree):
     # ...
 
     # ...
-    phi = VectorFemField( Vh, x )
+    phi = FemField( Vh, x )
     # ...
 
     # ... compute norms

--- a/psydac/api/tests/test_api_2d_vector_mapping.py
+++ b/psydac/api/tests/test_api_2d_vector_mapping.py
@@ -17,7 +17,7 @@ from sympde.expr import BilinearForm, LinearForm, integral
 from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
-from psydac.fem.vector  import VectorFemField
+from psydac.fem.basic  import FemField
 from psydac.api.discretization import discretize
 
 from numpy import linspace, zeros, allclose
@@ -87,7 +87,7 @@ def run_vector_poisson_2d_dir(filename, solution, f):
     # ...
 
     # ...
-    phi = VectorFemField( Vh, x )
+    phi = FemField( Vh, x )
     # ...
 
     # ... compute norms

--- a/psydac/api/tests/test_api_3d_vector.py
+++ b/psydac/api/tests/test_api_3d_vector.py
@@ -11,7 +11,7 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.vector         import VectorFemField
+from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -67,7 +67,7 @@ def run_vector_poisson_3d_dir(solution, f, ncells, degree):
     # ...
 
     # ...
-    phi = VectorFemField( Vh, x )
+    phi = FemField( Vh, x )
     # ...
 
     # ... compute norms

--- a/psydac/api/tests/test_api_3d_vector_mapping.py
+++ b/psydac/api/tests/test_api_3d_vector_mapping.py
@@ -12,7 +12,7 @@ from sympde.expr import BilinearForm, LinearForm, integral
 from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
-from psydac.fem.vector         import VectorFemField
+from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 # ... get the mesh directory
@@ -78,7 +78,7 @@ def run_vector_poisson_3d_dir(filename, solution, f):
     # ...
 
     # ...
-    phi = VectorFemField( Vh, x )
+    phi = FemField( Vh, x )
     # ...
 
     # ... compute norms

--- a/psydac/api/tests/test_api_expr_2d_scalar.py
+++ b/psydac/api/tests/test_api_expr_2d_scalar.py
@@ -9,7 +9,7 @@ from sympde.topology import VectorFunctionSpace
 from sympde.topology import element_of
 from sympde.topology import Square
 
-from psydac.fem.vector         import VectorFemField
+from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -37,7 +37,7 @@ def run_poisson_2d_dir(ncells, degree, comm=None):
     # ... dsicretize the bilinear form
     exprh = discretize(expr, domain_h, Vh)
     
-    Fh = VectorFemField(Vh) 
+    Fh = FemField(Vh)
    
     x = np.linspace(0., 1., 101)
     y = np.linspace(0., 1., 101)

--- a/psydac/api/tests/test_api_feec_3d.py
+++ b/psydac/api/tests/test_api_feec_3d.py
@@ -13,7 +13,6 @@ from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
 from psydac.fem.basic          import FemField
-from psydac.fem.vector         import VectorFemField
 from psydac.api.discretization import discretize
 from psydac.feec.pull_push     import push_3d_hcurl, push_3d_hdiv
 from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL, PSYDAC_BACKEND_NUMBA
@@ -141,7 +140,7 @@ def run_maxwell_3d_scipy(logical_domain, mapping, e_ex, b_ex, ncells, degree, pe
 
     # study of fields
     b_history = [array_to_stencil(bi, derham_h.V2.vector_space) for bi in b_history]
-    b_fields  = [VectorFemField(derham_h.V2, bi).fields for bi in b_history]
+    b_fields  = [FemField(derham_h.V2, bi).fields for bi in b_history]
 
     bx_fields = [bi[0] for bi in b_fields]
     by_fields = [bi[1] for bi in b_fields]
@@ -225,7 +224,7 @@ def run_maxwell_3d_stencil(logical_domain, mapping, e_ex, b_ex, ncells, degree, 
     e_history, b_history = splitting_integrator_stencil(e0_coeff, b0_coeff, M1, M2, CURL, dt, niter)
 
     # study of fields
-    b_fields  = [VectorFemField(derham_h.V2, bi).fields for bi in b_history]
+    b_fields  = [FemField(derham_h.V2, bi).fields for bi in b_history]
 
     bx_fields = [bi[0] for bi in b_fields]
     by_fields = [bi[1] for bi in b_fields]

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -9,7 +9,6 @@ from psydac.fem.vector      import ProductFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.identity import IdentityLinearOperator, IdentityStencilMatrix as IdentityMatrix
 from psydac.fem.basic       import FemField
-from psydac.fem.vector      import VectorFemField
 
 __all__ = (
     'd_matrix',
@@ -185,7 +184,7 @@ class Gradient_2D(DiffOperator):
         coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return VectorFemField(self.codomain, coeffs=coeffs)
+        return FemField(self.codomain, coeffs=coeffs)
 
 #====================================================================================================
 class Gradient_3D(DiffOperator):
@@ -245,7 +244,7 @@ class Gradient_3D(DiffOperator):
         coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return VectorFemField(self.codomain, coeffs=coeffs)
+        return FemField(self.codomain, coeffs=coeffs)
 
 #====================================================================================================
 class ScalarCurl_2D(DiffOperator):
@@ -301,7 +300,7 @@ class ScalarCurl_2D(DiffOperator):
    
     def __call__(self, u):
 
-        assert isinstance(u, VectorFemField)
+        assert isinstance(u, FemField)
         assert u.space == self.domain
         
         coeffs = self.matrix.dot(u.coeffs)
@@ -365,7 +364,7 @@ class VectorCurl_2D(DiffOperator):
         coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return VectorFemField(self.codomain, coeffs=coeffs)
+        return FemField(self.codomain, coeffs=coeffs)
 
 #====================================================================================================
 class Curl_3D(DiffOperator):
@@ -430,13 +429,13 @@ class Curl_3D(DiffOperator):
    
     def __call__(self, u):
 
-        assert isinstance(u, VectorFemField)
+        assert isinstance(u, FemField)
         assert u.space == self.domain
         
         coeffs = self.matrix.dot(u.coeffs)
         coeffs.update_ghost_regions()
 
-        return VectorFemField(self.codomain, coeffs=coeffs)
+        return FemField(self.codomain, coeffs=coeffs)
 
 #====================================================================================================
 class Divergence_2D(DiffOperator):
@@ -492,7 +491,7 @@ class Divergence_2D(DiffOperator):
 
     def __call__(self, u):
 
-        assert isinstance(u, VectorFemField)
+        assert isinstance(u, FemField)
         assert u.space == self.domain
 
         coeffs = self.matrix.dot(u.coeffs)
@@ -556,7 +555,7 @@ class Divergence_3D(DiffOperator):
 
     def __call__(self, u):
 
-        assert isinstance(u, VectorFemField)
+        assert isinstance(u, FemField)
         assert u.space == self.domain
 
         coeffs = self.matrix.dot(u.coeffs)

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -7,7 +7,6 @@ from psydac.linalg.block          import BlockVector
 from psydac.core.bsplines         import quadrature_grid
 from psydac.utilities.quadratures import gauss_legendre
 from psydac.fem.basic             import FemField
-from psydac.fem.vector            import VectorFemField
 
 #==============================================================================
 class Projector_H1:
@@ -214,7 +213,7 @@ class Projector_Hcurl:
 
         Returns
         -------
-        field : VectorFemField
+        field : FemField
             Field obtained by projection (element of the H(curl)-conforming
             finite element space). This is also a real-valued vector function
             in the logical domain.
@@ -224,12 +223,12 @@ class Projector_Hcurl:
 
         self.rhs.update_ghost_regions()
 
-        coeffs    = BlockVector(self.space.vector_space)
+        coeffs = BlockVector(self.space.vector_space)
         for i in range(self.dim):
             coeffs[i] = kronecker_solve(solvers = self.mats[i], rhs = self.rhs[i])
 
         coeffs.update_ghost_regions()
-        return VectorFemField(self.space, coeffs=coeffs)
+        return FemField(self.space, coeffs=coeffs)
 
 #==============================================================================
 class Projector_Hdiv:
@@ -357,7 +356,7 @@ class Projector_Hdiv:
 
         Returns
         -------
-        field : VectorFemField
+        field : FemField
             Field obtained by projection (element of the H(div)-conforming
             finite element space). This is also a real-valued vector function
             in the logical domain.
@@ -373,7 +372,7 @@ class Projector_Hdiv:
             coeffs[i] = kronecker_solve(solvers = self.mats[i], rhs = self.rhs[i])
 
         coeffs.update_ghost_regions()
-        return VectorFemField(self.space, coeffs=coeffs)
+        return FemField(self.space, coeffs=coeffs)
 
 #==============================================================================
 class Projector_L2:

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -3,8 +3,9 @@ import pytest
 
 from psydac.core.bsplines    import make_knots
 from psydac.fem.basic        import FemField
-from psydac.fem.tensor       import SplineSpace, TensorFemSpace
-from psydac.fem.vector       import ProductFemSpace, VectorFemField
+from psydac.fem.splines      import SplineSpace
+from psydac.fem.tensor       import TensorFemSpace
+from psydac.fem.vector       import ProductFemSpace
 
 from psydac.feec.derivatives import Derivative_1D, Gradient_2D, Gradient_3D
 from psydac.feec.derivatives import ScalarCurl_2D, VectorCurl_2D, Curl_3D
@@ -193,7 +194,7 @@ def test_ScalarCurl_2D(domain, ncells, degree, periodic):
 
     # ...
     # Create random field in V1
-    u1 = VectorFemField(V1)
+    u1 = FemField(V1)
 
     s1, s2 = V1.vector_space[0].starts
     e1, e2 = V1.vector_space[0].ends
@@ -324,7 +325,7 @@ def test_Curl_3D(domain, ncells, degree, periodic):
 
     # ...
     # Create random field in V1
-    u1 = VectorFemField(V1)
+    u1 = FemField(V1)
 
     s1, s2, s3 = V1.vector_space[0].starts
     e1, e2, e3 = V1.vector_space[0].ends
@@ -401,7 +402,7 @@ def test_Divergence_2D(domain, ncells, degree, periodic):
 
     # ...
     # Create random field in V1
-    u1 = VectorFemField(V1)
+    u1 = FemField(V1)
 
     s1, s2 = V1.vector_space[0].starts
     e1, e2 = V1.vector_space[0].ends
@@ -471,7 +472,7 @@ def test_Divergence_3D(domain, ncells, degree, periodic):
 
     # ...
     # Create random field in V2
-    u2 = VectorFemField(V2)
+    u2 = FemField(V2)
 
     s1, s2, s3 = V2.vector_space[0].starts
     e1, e2, e3 = V2.vector_space[0].ends

--- a/psydac/feec/tests/test_global_projectors.py
+++ b/psydac/feec/tests/test_global_projectors.py
@@ -1,10 +1,11 @@
 import numpy as np
 import pytest
 
-from psydac.core.bsplines    import make_knots
-from psydac.fem.basic        import FemField
-from psydac.fem.tensor       import SplineSpace, TensorFemSpace
-from psydac.fem.vector       import ProductFemSpace, VectorFemField
+from psydac.core.bsplines          import make_knots
+from psydac.fem.basic              import FemField
+from psydac.fem.splines            import SplineSpace
+from psydac.fem.tensor             import TensorFemSpace
+from psydac.fem.vector             import ProductFemSpace
 from psydac.feec.global_projectors import Projector_H1, Projector_L2
 
 #==============================================================================

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -262,11 +262,13 @@ class FemField:
 
     # ...
     def __add__(self, other):
+        assert isinstance(other, FemField)
         assert self._space is other._space
         return FemField(self._space, coeffs = self._coeffs + other._coeffs)
 
     # ...
     def __sub__(self, other):
+        assert isinstance(other, FemField)
         assert self._space is other._space
         return FemField(self._space, coeffs = self._coeffs - other._coeffs)
 
@@ -277,12 +279,14 @@ class FemField:
 
     # ...
     def __iadd__(self, other):
+        assert isinstance(other, FemField)
         assert self._space is other._space
         self._coeffs += other._coeffs
         return self
 
     # ...
     def __isub__(self, other):
+        assert isinstance(other, FemField)
         assert self._space is other._space
         self._coeffs -= other._coeffs
         return self

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -243,3 +243,46 @@ class FemField:
     def divergence(self, *eta):
         """Evaluate divergence of vector field at location identified by logical coordinates eta."""
         return self._space.eval_field_divergence(self, *eta)
+
+    # ...
+    def copy(self):
+        return FemField(self.space, coeffs = self.coeffs.copy())
+
+    # ...
+    def __neg__(self):
+        return FemField(self.space, coeffs = -self.coeffs)
+
+    # ...
+    def __mul__(self, a):
+        return FemField(self.space, coeffs = self.coeffs * a)
+
+    # ...
+    def __rmul__(self, a):
+        return FemField(self.space, coeffs = a * self.coeffs)
+
+    # ...
+    def __add__(self, other):
+        assert self.space is other.space
+        return FemField(self.space, coeffs = self.coeffs + other.coeffs)
+
+    # ...
+    def __sub__(self, other):
+        assert self.space is other.space
+        return FemField(self.space, coeffs = self.coeffs - other.coeffs)
+
+    # ...
+    def __imul__(self, a):
+        self.coeffs *= a
+        return self
+
+    # ...
+    def __iadd__(self, other):
+        assert self.space is other.space
+        self.coeffs += other.coeffs
+        return self
+
+    # ...
+    def __isub__(self, other):
+        assert self.space is other.space
+        self.coeffs -= other.coeffs
+        return self

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -246,43 +246,43 @@ class FemField:
 
     # ...
     def copy(self):
-        return FemField(self.space, coeffs = self.coeffs.copy())
+        return FemField(self._space, coeffs = self._coeffs.copy())
 
     # ...
     def __neg__(self):
-        return FemField(self.space, coeffs = -self.coeffs)
+        return FemField(self._space, coeffs = -self._coeffs)
 
     # ...
     def __mul__(self, a):
-        return FemField(self.space, coeffs = self.coeffs * a)
+        return FemField(self._space, coeffs = self._coeffs * a)
 
     # ...
     def __rmul__(self, a):
-        return FemField(self.space, coeffs = a * self.coeffs)
+        return FemField(self._space, coeffs = a * self._coeffs)
 
     # ...
     def __add__(self, other):
-        assert self.space is other.space
-        return FemField(self.space, coeffs = self.coeffs + other.coeffs)
+        assert self._space is other._space
+        return FemField(self._space, coeffs = self._coeffs + other._coeffs)
 
     # ...
     def __sub__(self, other):
-        assert self.space is other.space
-        return FemField(self.space, coeffs = self.coeffs - other.coeffs)
+        assert self._space is other._space
+        return FemField(self._space, coeffs = self._coeffs - other._coeffs)
 
     # ...
     def __imul__(self, a):
-        self.coeffs *= a
+        self._coeffs *= a
         return self
 
     # ...
     def __iadd__(self, other):
-        assert self.space is other.space
-        self.coeffs += other.coeffs
+        assert self._space is other._space
+        self._coeffs += other._coeffs
         return self
 
     # ...
     def __isub__(self, other):
-        assert self.space is other.space
-        self.coeffs -= other.coeffs
+        assert self._space is other._space
+        self._coeffs -= other._coeffs
         return self

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -20,6 +20,7 @@ class FemSpace( metaclass=ABCMeta ):
     A unique basis is associated to a FemSpace, i.e. FemSpace = Span( basis )
 
     """
+
     #-----------------------------------------
     # Abstract interface: read-only attributes
     #-----------------------------------------
@@ -54,6 +55,15 @@ class FemSpace( metaclass=ABCMeta ):
     @abstractmethod
     def vector_space( self ):
         """Topologically associated vector space."""
+
+    @property
+    @abstractmethod
+    def is_product( self ):
+        """
+        Boolean flag that describes whether the space is a product space.
+        If True, an element of this space can be decomposed into separate fields.
+
+        """
 
     #---------------------------------------
     # Abstract interface: evaluation methods
@@ -180,8 +190,15 @@ class FemField:
         else:
             coeffs = space.vector_space.zeros()
 
+        # Case of a vector field, element of a ProductSpace
+        if space.is_product:
+            fields = tuple(FemField(V, c) for V, c in zip(space.spaces, coeffs))
+        else:
+            fields = tuple()
+
         self._space  = space
         self._coeffs = coeffs
+        self._fields = fields
 
     # ...
     @property
@@ -203,6 +220,15 @@ class FemField:
         """
         return self._coeffs
         
+    # ...
+    @property
+    def fields(self):
+        return self._fields
+
+    # ...
+    def __getitem__(self, key):
+        return self._fields[key]
+
     # ...
     def __call__( self, *eta ):
         """Evaluate field at location identified by logical coordinates eta."""

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -219,6 +219,10 @@ class SplineSpace( FemSpace ):
         """Returns the topological associated vector space."""
         return self._vector_space
 
+    @property
+    def is_product(self):
+        return False
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -132,6 +132,10 @@ class TensorFemSpace( FemSpace ):
         """Returns the topological associated vector space."""
         return self._vector_space
 
+    @property
+    def is_product(self):
+        return False
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------

--- a/psydac/fem/tests/test_product.py
+++ b/psydac/fem/tests/test_product.py
@@ -3,7 +3,7 @@
 from psydac.fem.basic   import FemField
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
-from psydac.fem.vector  import ProductFemSpace, VectorFemField
+from psydac.fem.vector  import ProductFemSpace
 
 from numpy import linspace
 
@@ -29,7 +29,7 @@ def test_product_space_2d():
     # ...
 
     V = ProductFemSpace(Vx, Vy)
-    F = VectorFemField(V)
+    F = FemField(V)
 
 def test_product_space_3d():
     print ('>>> test_product_space_3d')
@@ -64,7 +64,7 @@ def test_product_space_3d():
     # ...
 
     V = ProductFemSpace(Vx, Vy, Vz)
-    F = VectorFemField(V)
+    F = FemField(V)
 
 
 ###############################################

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -204,9 +204,8 @@ class ProductFemSpace( FemSpace ):
         return self._vector_space
 
     @property
-    def fields( self ):
-        """Dictionary containing all FemField objects associated to this space."""
-        raise NotImplementedError( "ProductFemSpace not yet operational" )
+    def is_product(self):
+        return True
 
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
@@ -251,58 +250,3 @@ class ProductFemSpace( FemSpace ):
     @property
     def comm( self ):
         return self.spaces[0].comm
-
-
-# TODO still experimental
-#===============================================================================
-class VectorFemField:
-    """
-    Element of a finite element product space V.
-
-    Parameters
-    ----------
-    space : ProductFemSpace
-        Finite element product space to which this field belongs.
-
-    """
-    def __init__( self, space, coeffs=None ):
-
-        assert isinstance( space, ProductFemSpace )
-
-        if coeffs is not None:
-            assert isinstance( coeffs, Vector )
-            assert space.vector_space is coeffs.space
-        else:
-            coeffs = space.vector_space.zeros()
-
-        self._space  = space
-        self._coeffs = coeffs
-        self._fields = [FemField(s, coeff) for s,coeff in zip(self.space.spaces, self.coeffs)]
-
-    # ...
-    @property
-    def space( self ):
-        """Finite element space to which this field belongs."""
-        return self._space
-
-    # ...
-    @property
-    def coeffs( self ):
-        """
-        Coefficients that uniquely identify this field as a linear combination of
-        the elements of the basis of a Finite element space.
-
-        Coefficients are stored into one element of the vector space in
-        'self.space.vector_space', which is topologically associated to
-        the finite element space.
-
-        """
-        return self._coeffs
-
-    @property
-    def fields( self ):
-        return self._fields
-
-    def __call__( self , *eta):
-        return tuple(f( *eta ) for f in self.fields)
-

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -67,6 +67,10 @@ class VectorFemSpace( FemSpace ):
         """Returns the topological associated vector space."""
         return self._vector_space
 
+    @property
+    def is_product(self):
+        return True
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------


### PR DESCRIPTION
- Add abstract property `is_product` to base class `FemSpace`;
- Add property `fields` and magic method `__getitem__` to  `FemField`;
- Allow `FemField` to represent any kind of field (scalar, vector, "product", etc.);
- Add basic linear operations (add, subtract, scalar multiply) to `FemField` objects;
- Remove obsolete class `VectorFemField`, which is only a source of confusion at this point. 