### PR TITLE
Make DiscreteEquation.solve() return a FemField

### DIFF
--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -36,6 +36,7 @@ from psydac.api.glt                  import DiscreteGltExpr
 from psydac.api.expr                 import DiscreteExpr
 from psydac.api.essential_bc         import apply_essential_bc
 from psydac.linalg.iterative_solvers import cg
+from psydac.fem.basic                import FemField
 from psydac.fem.splines              import SplineSpace
 from psydac.fem.tensor               import TensorFemSpace
 from psydac.fem.vector               import ProductFemSpace
@@ -262,14 +263,16 @@ class DiscreteEquation(BasicDiscrete):
                 loc_settings = settings.copy()
                 loc_settings['solver'] = 'cg'
                 loc_settings.pop('info',False)
-                X = equation_h.solve(**loc_settings)
+                uh = equation_h.solve(**loc_settings)
 
                 # Use inhomogeneous solution as initial guess to solver
-                settings['x0'] = X
+                settings['x0'] = uh.coeffs
 
         #----------------------------------------------------------------------
 
-        return driver_solve(self.linear_system, **settings)
+        X = driver_solve(self.linear_system, **settings)
+
+        return FemField(self.trial_space, coeffs=X)
 
 #==============================================================================
 class DiscreteDerham(BasicDiscrete):

--- a/psydac/api/tests/test_api_2d_fields.py
+++ b/psydac/api/tests/test_api_2d_fields.py
@@ -87,9 +87,7 @@ def run_field_test(filename, f):
 
     # Solve linear system
     # uh is the L2-projection of the analytical field "f"
-
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     #+++++++++++++++++++++++++++++++
     l1   = LinearForm( v, integral(domain, F*v))
@@ -162,15 +160,14 @@ def run_non_linear_poisson(filename, comm=None):
     l2norm_du_h  = discretize(l2norm_du , Omega_h, Vh)
 
     # First guess: zero solution
-    u_h  = FemField(Vh)
+    u_h = FemField(Vh)
 
     # Newton iteration
     for n in range(N):
 
         print()
         print('==== iteration {} ===='.format(n))
-        X = equation_h.solve(u=u_h)
-        du_h = FemField(Vh, X)
+        du_h = equation_h.solve(u=u_h)
 
         # Compute L2 norm of increment
         l2_du = l2norm_du_h.assemble(du=du_h)
@@ -181,7 +178,7 @@ def run_non_linear_poisson(filename, comm=None):
             break
 
         # update field
-        u_h.coeffs[:,:] += X[:,:]
+        u_h += du_h
 
     # Compute L2 error norm from solution field
     l2_error = l2norm_err_h.assemble(u=u_h)

--- a/psydac/api/tests/test_api_2d_scalar.py
+++ b/psydac/api/tests/test_api_2d_scalar.py
@@ -16,7 +16,6 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 x,y,z = symbols('x1, x2, x3')
@@ -104,8 +103,7 @@ def run_poisson_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -181,8 +179,7 @@ def run_laplace_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -256,8 +253,7 @@ def run_biharmonic_2d_dir(solution, f, dir_zero_boundary, ncells, degree, comm=N
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)

--- a/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
+++ b/psydac/api/tests/test_api_2d_scalar_analytical_mapping.py
@@ -11,11 +11,9 @@ from sympde.expr.expr     import integral
 from sympde.expr.expr     import Norm
 from sympde.expr.equation import find, EssentialBC
 
-from psydac.fem.basic import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
-
 def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
 
     #+++++++++++++++++++++++++++++++
@@ -50,9 +48,7 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
 
-    x  = equation_h.solve()
-
-    uh = FemField( Vh , x)
+    uh = equation_h.solve()
 
     l2_error = l2norm_h.assemble(u=uh)
     h1_error = h1norm_h.assemble(u=uh)
@@ -60,7 +56,6 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     return l2_error, h1_error
 
 #------------------------------------------------------------------------------
-
 def test_poisson_2d_analytical_mapping_0():
 
     domain  = Square('A',bounds1=(0., 1.), bounds2=(0, np.pi))
@@ -77,15 +72,12 @@ def test_poisson_2d_analytical_mapping_0():
     expected_l2_error = 1.0930839536997034e-09
     expected_h1_error = 1.390398663745195e-08
 
-
     assert ( abs(l2_error - expected_l2_error) < 1e-7 )
     assert ( abs(h1_error - expected_h1_error) < 1e-7 )
-
 
 #==============================================================================
 # CLEAN UP SYMPY NAMESPACE
 #==============================================================================
-
 def teardown_module():
     from sympy.core import cache
     cache.clear_cache()
@@ -93,4 +85,3 @@ def teardown_module():
 def teardown_function():
     from sympy.core import cache
     cache.clear_cache()
-

--- a/psydac/api/tests/test_api_2d_scalar_backends.py
+++ b/psydac/api/tests/test_api_2d_scalar_backends.py
@@ -1,8 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from mpi4py import MPI
-from sympy import pi, cos, sin, symbols
-from sympy.utilities.lambdify import implemented_function
+from sympy import pi, sin, symbols
 import pytest
 
 from sympde.calculus import grad, dot
@@ -16,9 +15,7 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
-
 from psydac.api.settings import PSYDAC_BACKEND_GPYCCEL, PSYDAC_BACKEND_NUMBA
 
 x,y,z = symbols('x1, x2, x3')
@@ -106,8 +103,7 @@ def run_poisson_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -183,8 +179,7 @@ def run_laplace_2d(solution, f, dir_zero_boundary, dir_nonzero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -258,8 +253,7 @@ def run_biharmonic_2d_dir(solution, f, dir_zero_boundary, ncells, degree, comm=N
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    x  = equation_h.solve()
-    uh = FemField( Vh, x )
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)

--- a/psydac/api/tests/test_api_2d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_2d_scalar_mapping.py
@@ -31,7 +31,6 @@ from sympde.expr import BilinearForm, LinearForm, integral
 from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 # ... get the mesh directory
@@ -128,8 +127,7 @@ def run_poisson_2d(filename, solution, f, dir_zero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    X  = equation_h.solve()
-    uh = FemField(Vh, X)
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -205,8 +203,7 @@ def run_laplace_2d(filename, solution, f, dir_zero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    X  = equation_h.solve()
-    uh = FemField(Vh, X)
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)
@@ -282,8 +279,7 @@ def run_biharmonic_2d_dir(filename, solution, f, dir_zero_boundary,
     #+++++++++++++++++++++++++++++++
 
     # Solve linear system
-    X  = equation_h.solve()
-    uh = FemField(Vh, X)
+    uh = equation_h.solve()
 
     # Compute error norms
     l2_error = l2norm_h.assemble(u=uh)

--- a/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_mapping_multi_patch.py
@@ -15,7 +15,6 @@ from sympde.expr.expr     import integral
 from sympde.expr.expr     import Norm
 from sympde.expr.equation import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -71,12 +70,7 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
 
-    x  = equation_h.solve()
-
-    uh = FemField( Vh )
-
-    for i in range(len(uh.coeffs[:])):
-        uh.coeffs[i][:,:] = x[i][:,:]
+    uh = equation_h.solve()
 
     l2_error = l2norm_h.assemble(u=uh)
     h1_error = h1norm_h.assemble(u=uh)

--- a/psydac/api/tests/test_api_2d_scalar_multi_patch.py
+++ b/psydac/api/tests/test_api_2d_scalar_multi_patch.py
@@ -11,7 +11,6 @@ from sympde.expr.expr     import integral
 from sympde.expr.expr     import Norm
 from sympde.expr.equation import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -68,12 +67,7 @@ def run_poisson_2d(solution, f, domain, ncells, degree):
     l2norm_h = discretize(l2norm, domain_h, Vh)
     h1norm_h = discretize(h1norm, domain_h, Vh)
 
-    x  = equation_h.solve()
-
-    uh = FemField( Vh )
-
-    for i in range(len(uh.coeffs[:])):
-        uh.coeffs[i][:,:] = x[i][:,:]
+    uh = equation_h.solve()
 
     l2_error = l2norm_h.assemble(u=uh)
     h1_error = h1norm_h.assemble(u=uh)

--- a/psydac/api/tests/test_api_2d_system.py
+++ b/psydac/api/tests/test_api_2d_system.py
@@ -36,7 +36,7 @@ def run_system_1_2d_dir(Fe, Ge, f0, f1, ncells, degree):
     G = element_of(V, name='G')
 
     u,v = [element_of(W, name=i) for i in ['u', 'v']]
-    p,q = [      element_of(V, name=i) for i in ['p', 'q']]
+    p,q = [element_of(V, name=i) for i in ['p', 'q']]
 
     int_0 = lambda expr: integral(domain , expr)
 
@@ -74,7 +74,7 @@ def run_system_1_2d_dir(Fe, Ge, f0, f1, ncells, degree):
 #    Xh = Wh * Vh
 #    Wh, Vh = Xh.spaces
 
-    # ... dsicretize the equation using Dirichlet bc
+    # ... discretize the equation using Dirichlet bc
     equation_h = discretize(equation, domain_h, [Xh, Xh])
     # ...
 
@@ -87,18 +87,22 @@ def run_system_1_2d_dir(Fe, Ge, f0, f1, ncells, degree):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
+    Xh = equation_h.solve()
     # ...
+
+    # TODO [YG, 12.02.2021]: Fh and Gh are temporary FEM fields needed because
+    #   the blocks in Xh.coeffs have been flattened. Once this assumption is
+    #   removed, just assemble the error norms passing F = Xh[0] and G = Xh[1].
 
     # ...
     Fh = FemField( Wh )
-    Fh.coeffs[0][:,:] = x[0][:,:]
-    Fh.coeffs[1][:,:] = x[1][:,:]
+    Fh.coeffs[0][:,:] = Xh.coeffs[0][:,:]
+    Fh.coeffs[1][:,:] = Xh.coeffs[1][:,:]
     # ...
 
     # ...
     Gh = FemField( Vh )
-    Gh.coeffs[:,:] = x[2][:,:]
+    Gh.coeffs[:,:] = Xh.coeffs[2][:,:]
     # ...
 
     # ... compute norms

--- a/psydac/api/tests/test_api_2d_vector.py
+++ b/psydac/api/tests/test_api_2d_vector.py
@@ -11,7 +11,6 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -24,8 +23,6 @@ def run_vector_poisson_2d_dir(solution, f, ncells, degree):
 
     x,y = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -37,7 +34,7 @@ def run_vector_poisson_2d_dir(solution, f, ncells, degree):
     expr = dot(f, v)
     l = LinearForm(v, int_0(expr))
 
-    error = Matrix([F[0]-solution[0], F[1]-solution[1]])
+    error  = Matrix([u[0]-solution[0], u[1]-solution[1]])
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -63,16 +60,12 @@ def run_vector_poisson_2d_dir(solution, f, ncells, degree):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error

--- a/psydac/api/tests/test_api_2d_vector_mapping.py
+++ b/psydac/api/tests/test_api_2d_vector_mapping.py
@@ -1,28 +1,19 @@
 # -*- coding: UTF-8 -*-
 
-from sympy import Tuple, Matrix
-from sympy import pi, cos, sin
-
-from sympde.core import Constant
-from sympde.calculus import grad, dot, inner, cross, rot, curl, div
-from sympde.calculus import laplace, hessian
-from sympde.topology import (dx, dy, dz)
-from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
-from sympde.topology import element_of
-from sympde.topology import Boundary, NormalVector, TangentVector
-from sympde.topology import Domain, Line, Square, Cube
-from sympde.topology import Trace, trace_0, trace_1
-from sympde.topology import Union
-from sympde.expr import BilinearForm, LinearForm, integral
-from sympde.expr import Norm
-from sympde.expr import find, EssentialBC
-
-from psydac.fem.basic  import FemField
-from psydac.api.discretization import discretize
-
-from numpy import linspace, zeros, allclose
-
 import os
+from sympy import Tuple, Matrix
+from sympy import pi, sin
+
+from sympde.calculus import grad, dot, inner
+from sympde.topology import VectorFunctionSpace
+from sympde.topology import element_of
+from sympde.topology import Domain
+from sympde.topology import Union
+from sympde.expr     import BilinearForm, LinearForm, integral
+from sympde.expr     import Norm
+from sympde.expr     import find, EssentialBC
+
+from psydac.api.discretization import discretize
 
 # ... get the mesh directory
 try:
@@ -44,8 +35,6 @@ def run_vector_poisson_2d_dir(filename, solution, f):
 
     x,y = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -57,7 +46,7 @@ def run_vector_poisson_2d_dir(filename, solution, f):
     expr = dot(f, v)
     l = LinearForm(v, int_0(expr))
 
-    error = Matrix([F[0]-solution[0], F[1]-solution[1]])
+    error  = Matrix([u[0]-solution[0], u[1]-solution[1]])
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -83,16 +72,12 @@ def run_vector_poisson_2d_dir(filename, solution, f):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error

--- a/psydac/api/tests/test_api_3d_scalar.py
+++ b/psydac/api/tests/test_api_3d_scalar.py
@@ -14,7 +14,6 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -27,8 +26,6 @@ def run_poisson_3d_dir(solution, f, ncells, degree, comm=None):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -40,7 +37,7 @@ def run_poisson_3d_dir(solution, f, ncells, degree, comm=None):
     expr = f*v
     l = LinearForm(v, int_0(expr))
 
-    error = F - solution
+    error  = u - solution
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -66,16 +63,12 @@ def run_poisson_3d_dir(solution, f, ncells, degree, comm=None):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error
@@ -99,8 +92,6 @@ def run_poisson_3d_dirneu(solution, f, boundary, ncells, degree, comm=None):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -121,7 +112,7 @@ def run_poisson_3d_dirneu(solution, f, boundary, ncells, degree, comm=None):
     expr = l0(v) + l_B_neumann(v)
     l = LinearForm(v, expr)
 
-    error = F-solution
+    error  = u - solution
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -149,16 +140,12 @@ def run_poisson_3d_dirneu(solution, f, boundary, ncells, degree, comm=None):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error

--- a/psydac/api/tests/test_api_3d_scalar_mapping.py
+++ b/psydac/api/tests/test_api_3d_scalar_mapping.py
@@ -15,7 +15,6 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 # ... get the mesh directory
@@ -38,8 +37,6 @@ def run_poisson_3d_dir(filename, solution, f, comm=None):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -51,7 +48,7 @@ def run_poisson_3d_dir(filename, solution, f, comm=None):
     expr = f*v
     l = LinearForm(v, int_0(expr))
 
-    error = F - solution
+    error  = u - solution
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -77,16 +74,12 @@ def run_poisson_3d_dir(filename, solution, f, comm=None):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error
@@ -110,8 +103,6 @@ def run_poisson_3d_dirneu(filename, solution, f, boundary, comm=None):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -132,7 +123,7 @@ def run_poisson_3d_dirneu(filename, solution, f, boundary, comm=None):
     expr = l0(v) + l_B_neumann(v)
     l = LinearForm(v, expr)
 
-    error = F-solution
+    error  = u - solution
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -160,16 +151,12 @@ def run_poisson_3d_dirneu(filename, solution, f, boundary, comm=None):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error
@@ -208,7 +195,7 @@ def run_laplace_3d_neu(filename, solution, f, comm=None):
     expr = l0(v) + l_B_neumann(v)
     l = LinearForm(v, expr)
 
-    error = F-solution
+    error  = u - solution
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -233,16 +220,12 @@ def run_laplace_3d_neu(filename, solution, f, comm=None):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error

--- a/psydac/api/tests/test_api_3d_vector.py
+++ b/psydac/api/tests/test_api_3d_vector.py
@@ -11,7 +11,6 @@ from sympde.expr     import BilinearForm, LinearForm, integral
 from sympde.expr     import Norm
 from sympde.expr     import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 #==============================================================================
@@ -24,8 +23,6 @@ def run_vector_poisson_3d_dir(solution, f, ncells, degree):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -37,7 +34,7 @@ def run_vector_poisson_3d_dir(solution, f, ncells, degree):
     expr = dot(f, v)
     l = LinearForm(v, int_0(expr))
 
-    error = Matrix([F[0]-solution[0], F[1]-solution[1], F[2]-solution[2]])
+    error  = Matrix([u[0]-solution[0], u[1]-solution[1], u[2]-solution[2]])
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -63,16 +60,12 @@ def run_vector_poisson_3d_dir(solution, f, ncells, degree):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error

--- a/psydac/api/tests/test_api_3d_vector_mapping.py
+++ b/psydac/api/tests/test_api_3d_vector_mapping.py
@@ -12,7 +12,6 @@ from sympde.expr import BilinearForm, LinearForm, integral
 from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
-from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 
 # ... get the mesh directory
@@ -35,8 +34,6 @@ def run_vector_poisson_3d_dir(filename, solution, f):
 
     x,y,z = domain.coordinates
 
-    F = element_of(V, name='F')
-
     v = element_of(V, name='v')
     u = element_of(V, name='u')
 
@@ -48,7 +45,7 @@ def run_vector_poisson_3d_dir(filename, solution, f):
     expr = dot(f, v)
     l = LinearForm(v, int_0(expr))
 
-    error = Matrix([F[0]-solution[0], F[1]-solution[1], F[2]-solution[2]])
+    error  = Matrix([u[0]-solution[0], u[1]-solution[1], u[2]-solution[2]])
     l2norm = Norm(error, domain, kind='l2')
     h1norm = Norm(error, domain, kind='h1')
 
@@ -74,16 +71,12 @@ def run_vector_poisson_3d_dir(filename, solution, f):
     # ...
 
     # ... solve the discrete equation
-    x = equation_h.solve()
-    # ...
-
-    # ...
-    phi = FemField( Vh, x )
+    uh = equation_h.solve()
     # ...
 
     # ... compute norms
-    l2_error = l2norm_h.assemble(F=phi)
-    h1_error = h1norm_h.assemble(F=phi)
+    l2_error = l2norm_h.assemble(u = uh)
+    h1_error = h1norm_h.assemble(u = uh)
     # ...
 
     return l2_error, h1_error


### PR DESCRIPTION
Now the method `solve` of class `DiscreteEquation` from module `psydac.api.discretization` returns a `FemField` object instead of a `Vector` of coefficients.