### PR TITLE
Fix bug in application of essential boundary conditions to linear systems

### DIFF
--- a/psydac/api/essential_bc.py
+++ b/psydac/api/essential_bc.py
@@ -10,92 +10,115 @@ from psydac.linalg.block   import BlockVector, BlockMatrix
 def apply_essential_bc_1d_StencilVector(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 1D """
 
-    # assumes a 1D spline space
-    # add asserts on the space if it is periodic
+    s1, = a.codomain.starts
+    e1, = a.codomain.ends
+    n1, = a.codomain.npts
+    P1, = a.codomain.periods
 
-    # get order
-    order = bc.order
+    if P1:
+        raise ValueError('Cannot apply essential boundary condition\
+                along periodic direction x1')
 
-    if bc.boundary.ext == -1:
-        a[0+order] = 0.
+    # left x1 boundary
+    if bc.boundary.ext == -1 and s1 == 0:
+        a[s1 + bc.order] = 0.
 
-    if bc.boundary.ext == 1:
-        a[V.nbasis-1-order] = 0.
+    # right x1 boundary
+    elif bc.boundary.ext == 1 and e1 == n1 - 1:
+        a[e1 - bc.order] = 0.
 
 #==============================================================================
 def apply_essential_bc_2d_StencilVector(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 2D """
 
-    # assumes a 2D Tensor space
-    # add asserts on the space if it is periodic
-
-    V1,V2 = V.spaces
-
     s1, s2 = a.space.starts
     e1, e2 = a.space.ends
+    n1, n2 = a.space.npts
+    P1, P2 = a.space.periods
 
-    # get order
-    order = bc.order
-
+    # x1 direction
     if bc.boundary.axis == 0:
-        # left  bc.boundary.at x=0.
-        if s1 == 0 and bc.boundary.ext == -1:
-            a[0+order,:] = 0.
 
-        # right bc.boundary.at x=1.
-        if e1 == V1.nbasis-1 and bc.boundary.ext == 1:
-            a [e1-order,:] = 0.
+        if P1:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x1')
 
-    if bc.boundary.axis == 1:
-        # lower bc.boundary.at y=0.
-        if s2 == 0 and bc.boundary.ext == -1:
-            a [:,0+order] = 0.
+        elif bc.boundary.ext == -1 and s1 == 0:
+            a[s1 + bc.order, :] = 0.
 
-        # upper bc.boundary.at y=1.
-        if e2 == V2.nbasis-1 and bc.boundary.ext == 1:
-            a [:,e2-order] = 0.
+        elif bc.boundary.ext == 1 and e1 == n1 - 1:
+            a[e1 - bc.order, :] = 0.
+
+    # x2 direction
+    elif bc.boundary.axis == 1:
+
+        if P2:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x2')
+
+        elif bc.boundary.ext == -1 and s2 == 0:
+            a[:, s2 + bc.order] = 0.
+
+        elif bc.boundary.ext == 1 and e2 == n2 - 1:
+            a[:, e2 - bc.order] = 0.
+
+    # wrong direction
+    else:
+        raise ValueError('Cannot apply boundary condition along axis {} in 2D'\
+                .format(bc.boundary.axis))
 
 #==============================================================================
 def apply_essential_bc_3d_StencilVector(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 3D """
 
-    # assumes a 3D Tensor space
-    # add asserts on the space if it is periodic
-
-    V1,V2,V3 = V.spaces
-
     s1, s2, s3 = a.space.starts
     e1, e2, e3 = a.space.ends
+    n1, n2, n3 = a.space.npts
+    P1, P2, P3 = a.space.periods
 
-    # get order
-    order = bc.order
-
+    # x1 direction
     if bc.boundary.axis == 0:
-        # left  bc at x=0.
-        if s1 == 0 and bc.boundary.ext == -1:
-            a[0+order,:,:] = 0.
 
-        # right bc at x=1.
-        if e1 == V1.nbasis-1 and bc.boundary.ext == 1:
-            a [e1-order,:,:] = 0.
+        if P1:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x1')
 
-    if bc.boundary.axis == 1:
-        # lower bc at y=0.
-        if s2 == 0 and bc.boundary.ext == -1:
-            a [:,0+order,:] = 0.
+        elif bc.boundary.ext == -1 and s1 == 0:
+            a[s1 + bc.order, :, :] = 0.
 
-        # upper bc at y=1.
-        if e2 == V2.nbasis-1 and bc.boundary.ext == 1:
-            a [:,e2-order,:] = 0.
+        elif bc.boundary.ext == 1 and e1 == n1 - 1:
+            a[e1 - bc.order, :, :] = 0.
 
-    if bc.boundary.axis == 2:
-        # lower bc at z=0.
-        if s3 == 0 and bc.boundary.ext == -1:
-            a [:,:,0+order] = 0.
+    # x2 direction
+    elif bc.boundary.axis == 1:
 
-        # upper bc at z=1.
-        if e3 == V3.nbasis-1 and bc.boundary.ext == 1:
-            a [:,:,e3-order] = 0.
+        if P2:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x2')
+
+        elif bc.boundary.ext == -1 and s2 == 0:
+            a[:, s2 + bc.order, :] = 0.
+
+        elif bc.boundary.ext == 1 and e2 == n2 - 1:
+            a[:, e2 - bc.order, :] = 0.
+
+    # x3 direction
+    elif bc.boundary.axis == 2:
+
+        if P3:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x3')
+
+        elif bc.boundary.ext == -1 and s3 == 0:
+            a[:, :, s3 + bc.order] = 0.
+
+        elif bc.boundary.ext == 1 and e3 == n3 - 1:
+            a[:, :, e3 - bc.order] = 0.
+
+    # wrong direction
+    else:
+        raise ValueError('Cannot apply boundary condition along axis {} in 3D'\
+                .format(bc.boundary.axis))
 
 #==============================================================================
 def apply_essential_bc_1d_StencilMatrix(V, bc, a):

--- a/psydac/api/essential_bc.py
+++ b/psydac/api/essential_bc.py
@@ -101,100 +101,115 @@ def apply_essential_bc_3d_StencilVector(V, bc, a):
 def apply_essential_bc_1d_StencilMatrix(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 1D """
 
-    # assumes a 1D spline space
-    # TODO: add asserts on the space if it is periodic
-    # TODO: verify if V argument is really needed
-
     s1, = a.codomain.starts
     e1, = a.codomain.ends
     n1, = a.codomain.npts
+    P1, = a.codomain.periods
 
-    # get order
-    order = bc.order
+    if P1:
+        raise ValueError('Cannot apply essential boundary condition\
+                along periodic direction x1')
 
     # left x1 boundary
-    if bc.boundary.ext == -1 and s1 == 0:
-        a[s1 + order, :] = 0.
+    elif bc.boundary.ext == -1 and s1 == 0:
+        a[s1 + bc.order, :] = 0.
 
     # right x1 boundary
-    if bc.boundary.ext == 1 and e1 == n1 - 1:
-        a[e1 - order, :] = 0.
+    elif bc.boundary.ext == 1 and e1 == n1 - 1:
+        a[e1 - bc.order, :] = 0.
 
 #==============================================================================
 def apply_essential_bc_2d_StencilMatrix(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 2D """
 
-    # assumes a 2D Tensor space
-    # add asserts on the space if it is periodic
+    s1, s2 = a.codomain.starts
+    e1, e2 = a.codomain.ends
+    n1, n2 = a.codomain.npts
+    P1, P2 = a.codomain.periods
 
-    V1,V2 = V.spaces
-
-    s1, s2 = a.domain.starts
-    e1, e2 = a.domain.ends
-
-    # get order
-    order = bc.order
-
+    # x1 direction
     if bc.boundary.axis == 0:
-        # left  bc.boundary.at x=0.
-        if s1 == 0 and bc.boundary.ext == -1:
-            a[0+order,:,:,:] = 0.
 
-        # right bc.boundary.at x=1.
-        if e1 == V1.nbasis-1 and bc.boundary.ext == 1:
-            a[e1-order,:,:,:] = 0.
+        if P1:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x1')
 
-    if bc.boundary.axis == 1:
-        # lower bc.boundary.at y=0.
-        if s2 == 0 and bc.boundary.ext == -1:
-            a[:,0+order,:,:] = 0.
+        elif bc.boundary.ext == -1 and s1 == 0:
+            a[s1 + bc.order, :, :, :] = 0.
 
-        # upper bc.boundary.at y=1.
-        if e2 == V2.nbasis-1 and bc.boundary.ext == 1:
-            a[:,e2-order,:,:] = 0.
+        elif bc.boundary.ext == 1 and e1 == n1 - 1:
+            a[e1 - bc.order, :, :, :] = 0.
+
+    # x2 direction
+    elif bc.boundary.axis == 1:
+
+        if P2:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x2')
+
+        elif bc.boundary.ext == -1 and s2 == 0:
+            a[:, s2 + bc.order, :, :] = 0.
+
+        elif bc.boundary.ext == 1 and e2 == n2 - 1:
+            a[:, e2 - bc.order, :, :] = 0.
+
+    # wrong direction
+    else:
+        raise ValueError('Cannot apply boundary condition along axis {} in 2D'\
+                .format(bc.boundary.axis))
 
 #==============================================================================
 def apply_essential_bc_3d_StencilMatrix(V, bc, a):
     """ Apply homogeneous dirichlet boundary conditions in 3D """
 
-    # assumes a 3D Tensor space
-    # add asserts on the space if it is periodic
-
-    V1,V2,V3 = V.spaces
-
     s1, s2, s3 = a.domain.starts
     e1, e2, e3 = a.domain.ends
+    n1, n2, n3 = a.codomain.npts
+    P1, P2, P3 = a.codomain.periods
 
-    # get order
-    order = bc.order
-
+    # x1 direction
     if bc.boundary.axis == 0:
-        # left  bc at x=0.
-        if s1 == 0 and bc.boundary.ext == -1:
-            a[0+order,:,:,:,:,:] = 0.
 
-        # right bc at x=1.
-        if e1 == V1.nbasis-1 and bc.boundary.ext == 1:
-            a[e1-order,:,:,:,:,:] = 0.
+        if P1:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x1')
 
-    if bc.boundary.axis == 1:
-        # lower bc at y=0.
-        if s2 == 0 and bc.boundary.ext == -1:
-            a[:,0+order,:,:,:,:] = 0.
+        elif bc.boundary.ext == -1 and s1 == 0:
+            a[s1 + bc.order, :, :, :, :, :] = 0.
 
-        # upper bc at y=1.
-        if e2 == V2.nbasis-1 and bc.boundary.ext == 1:
-            a[:,e2-order,:,:,:,:] = 0.
+        elif bc.boundary.ext == 1 and e1 == n1 - 1:
+            a[e1 - bc.order, :, :, :, :, :] = 0.
 
-    if bc.boundary.axis == 2:
-        # lower bc at z=0.
-        if s3 == 0 and bc.boundary.ext == -1:
-            a[:,:,0+order,:,:,:] = 0.
+    # x2 direction
+    elif bc.boundary.axis == 1:
 
-        # upper bc at z=1.
-        if e3 == V3.nbasis-1 and bc.boundary.ext == 1:
-            a[:,:,e3-order,:,:,:] = 0.
+        if P2:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x2')
 
+        elif bc.boundary.ext == -1 and s2 == 0:
+            a[:, s2 + bc.order, :, :, :, :] = 0.
+
+        elif bc.boundary.ext == 1 and e2 == n2 - 1:
+            a[:, e2 - bc.order, :, :, :, :] = 0.
+
+    # x3 direction
+    elif bc.boundary.axis == 2:
+
+        if P3:
+            raise ValueError('Cannot apply essential boundary condition\
+                    along periodic direction x3')
+
+        elif bc.boundary.ext == -1 and s3 == 0:
+            a[:, :, s3 + bc.order, :, :, :] = 0.
+
+        elif bc.boundary.ext == 1 and e3 == n3 - 1:
+            a[:, :, e3 - bc.order, :, :, :] = 0.
+
+    # wrong direction
+    else:
+        raise ValueError('Cannot apply boundary condition along axis {} in 3D'\
+                .format(bc.boundary.axis))
 
 #==============================================================================
 def apply_essential_bc_1d_StencilInterfaceMatrix(V, bc, a):


### PR DESCRIPTION
- Fix bug in `apply_essential_bc_{2|3}d_StencilMatrix` when `domain != codomain`;
- Add consistency checks to the same functions;
- Clean up functions`apply_essential_bc_{1|2|3}d_StencilVector` for consistency.