### PR TITLE
Support Ubuntu 20.04 LTS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,13 +52,28 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
-    - name: Install Python dependencies
-#      if: steps.pip-cache.outputs.cache-hit != 'true'
+    - name: Install Python dependencies - wheel, numpy, mpi4py
       run: |
-        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
         python -m pip install wheel
         python -m pip install numpy>=1.16
-        python -m pip install -r requirements.txt
+        python -m pip install mpi4py
+
+    - name: Install Python dependencies - h5py
+      run: |
+        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+        python -m pip install h5py --no-binary h5py --no-deps
+
+    - name: Install Python dependencies - igakit
+      run: |
+        python -m pip install https://bitbucket.org/dalcinl/igakit/get/master.tar.gz
+
+#    - name: Install Python dependencies
+##      if: steps.pip-cache.outputs.cache-hit != 'true'
+#      run: |
+#        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#        python -m pip install wheel
+#        python -m pip install numpy>=1.16
+#        python -m pip install -r requirements.txt
       
     - name: Install project
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,28 +63,13 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
-    - name: Install Python dependencies - wheel, numpy, mpi4py
-      run: |
-        python -m pip install wheel
-        python -m pip install numpy>=1.16
-        python -m pip install mpi4py
-
-    - name: Install Python dependencies - h5py
+    - name: Install Python dependencies
+#      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install h5py --no-binary h5py --no-deps
-
-    - name: Install Python dependencies - igakit
-      run: |
-        python -m pip install https://bitbucket.org/dalcinl/igakit/get/master.tar.gz
-
-#    - name: Install Python dependencies
-##      if: steps.pip-cache.outputs.cache-hit != 'true'
-#      run: |
-#        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-#        python -m pip install wheel
-#        python -m pip install numpy>=1.16
-#        python -m pip install -r requirements.txt
+        python -m pip install wheel
+        python -m pip install numpy>=1.16
+        python -m pip install -r requirements.txt
       
     - name: Install project
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,11 +11,12 @@ on:
 
 jobs:
   build:
-
+    name: ${{ matrix.os }} - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+#        python-version: [3.6, 3.7, 3.8]
         include:
         - os: ubuntu-18.04
           python-version: 3.6
@@ -25,8 +26,6 @@ jobs:
 
         - os: ubuntu-20.04
           python-version: 3.8
-
-#        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,9 +48,9 @@ jobs:
       id: pip-cache
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-${{ matrix.python-version }}-pip-
 
     - name: Install Python dependencies
 #      if: steps.pip-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,10 +18,13 @@ jobs:
       matrix:
         include:
         - os: ubuntu-18.04
-          python-version: [3.6, 3.7]
+          python-version: 3.6
+
+        - os: ubuntu-18.04
+          python-version: 3.7
 
         - os: ubuntu-20.04
-          python-version: [3.8]
+          python-version: 3.8
 
 #        python-version: [3.6, 3.7, 3.8]
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,6 +27,7 @@ jobs:
 
     - name: Install non-Python dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install gfortran
         sudo apt-get install openmpi-bin libopenmpi-dev
         sudo apt-get install libhdf5-openmpi-dev

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
+#        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
 #        python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.8, 3.9]
 #        python-version: [3.6, 3.7, 3.8]
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -55,6 +55,7 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+        python -m pip install wheel
         python -m pip install numpy>=1.16
         python -m pip install -r requirements.txt
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,11 +12,17 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        include:
+        - os: ubuntu-18.04
+          python-version: [3.6, 3.7]
+
+        - os: ubuntu-20.04
+          python-version: [3.8]
+
 #        python-version: [3.6, 3.7, 3.8]
 
     steps:
@@ -50,9 +56,9 @@ jobs:
       id: pip-cache
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
+        key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.python-version }}-pip-
+          ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
     - name: Install Python dependencies - wheel, numpy, mpi4py
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies and run tests with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Unit tests
+name: Run tests
 
 on:
   push:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8]
 #        python-version: [3.6, 3.7, 3.8]


### PR DESCRIPTION
On 9 March 2021 GitHub Actions changed the value of `ubuntu-latest` from `ubuntu-18.04` to `ubuntu-20.04`. As a result all of our builds failed because of installation problems for both `mpi4py` and `h5py`. This PR addresses this problem and cleans up our configuration:

- Use "apt-get update" before installing packages;
- Run tests with Python 3.6 and 3.7 on Ubuntu 18.04;
- Run tests with Python 3.8 on Ubuntu 20.04;
- Use separate pip cache files based on operating system and Python version;
- Customize jobs names based on operating system and Python version;
- Do not stop all jobs when one fails.
