### PR TITLE
Improve solution of vector problems

### DIFF
--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -17,11 +17,14 @@ from sympde.expr     import Integral
 from sympde.expr     import Equation as sym_Equation
 from sympde.expr     import Norm as sym_Norm
 from sympde.expr     import TerminalExpr
+from sympde.calculus import dot
 from sympde.topology import Domain, Interface
 from sympde.topology import Line, Square, Cube
 from sympde.topology import BasicFunctionSpace
-from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace, Derham
+from sympde.topology import ScalarFunctionSpace, ScalarFunction
+from sympde.topology import VectorFunctionSpace, VectorFunction
 from sympde.topology import ProductSpace
+from sympde.topology import Derham
 from sympde.topology import Mapping, IdentityMapping, LogicalExpr
 from sympde.topology import H1SpaceType, HcurlSpaceType, HdivSpaceType, L2SpaceType, UndefinedSpaceType
 from sympde.topology.basic import Union
@@ -239,9 +242,8 @@ class DiscreteEquation(BasicDiscrete):
                 # we will select the correct test function using a dictionary.
                 test_dict = dict(zip(u, v))
 
-                # TODO: use dot product for vector quantities
-#                product  = lambda f, g: (f * g if isinstance(g, ScalarFunction) else dot(f, g))
-                product  = lambda f, g: f * g
+                # Compute product of (u, v) using dot product for vector quantities
+                product  = lambda f, g: (f * g if isinstance(g, ScalarFunction) else dot(f, g))
 
                 # Construct variational formulation that performs L2 projection
                 # of boundary conditions onto the correct space

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -38,7 +38,7 @@ from psydac.api.glt                  import DiscreteGltExpr
 from psydac.api.expr                 import DiscreteExpr
 from psydac.api.essential_bc         import apply_essential_bc
 from psydac.api.utilities            import flatten
-from psydac.linalg.iterative_solvers import cg
+from psydac.linalg.iterative_solvers import cg, pcg, bicg
 from psydac.fem.basic                import FemField
 from psydac.fem.splines              import SplineSpace
 from psydac.fem.tensor               import TensorFemSpace
@@ -63,15 +63,17 @@ def driver_solve(L, **kwargs):
 
     name        = kwargs.pop('solver')
     return_info = kwargs.pop('info', False)
+
     if name == 'cg':
         x, info = cg( M, rhs, **kwargs )
-        if return_info:
-            return x, info
-        else:
-            return x
+    elif name == 'pcg':
+        x, info = pcg( M, rhs, **kwargs )
+    elif name == 'bicg':
+        x, info = bicg( M, M.T, rhs, **kwargs )
     else:
-        raise NotImplementedError('Only cg solver is available')
+        raise NotImplementedError("Solver '{}' is not available".format(name))
 
+    return (x, info) if return_info else x
 
 #==============================================================================
 class DiscreteEquation(BasicDiscrete):
@@ -256,7 +258,8 @@ class DiscreteEquation(BasicDiscrete):
                 # Find inhomogeneous solution (use CG as system is symmetric)
                 loc_settings = settings.copy()
                 loc_settings['solver'] = 'cg'
-                loc_settings.pop('info',False)
+                loc_settings.pop('info', False)
+                loc_settings.pop('pc'  , False)
                 uh = equation_h.solve(**loc_settings)
 
                 # Use inhomogeneous solution as initial guess to solver
@@ -264,9 +267,15 @@ class DiscreteEquation(BasicDiscrete):
 
         #----------------------------------------------------------------------
 
-        X = driver_solve(self.linear_system, **settings)
+        if settings.get('info', False):
+            X, info = driver_solve(self.linear_system, **settings)
+            uh = FemField(self.trial_space, coeffs=X)
+            return uh, info
 
-        return FemField(self.trial_space, coeffs=X)
+        else:
+            X  = driver_solve(self.linear_system, **settings)
+            uh = FemField(self.trial_space, coeffs=X)
+            return uh
 
 #==============================================================================           
 def discretize_derham(derham, domain_h, *args, **kwargs):

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -107,7 +107,7 @@ def run_stokes_2d_dir(f, ue, pe, *, ncells, degree, scipy=False):
     x, y  = domain.coordinates
     int_0 = lambda expr: integral(domain , expr)
 
-    a  = BilinearForm(((u, p),(v,q)), int_0(inner(grad(u), grad(v)) + div(u)*q - p*div(v)) )
+    a  = BilinearForm(((u, p), (v, q)), int_0(inner(grad(u), grad(v)) - div(u)*q - p*div(v)) )
     l  = LinearForm((v, q), int_0(dot(f, v)))
     bc = EssentialBC(u, 0, domain.boundary)
 

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -321,9 +321,9 @@ def test_stokes_2d_dir_homogeneous(scipy):
             homogeneous=True, ncells=[2**3, 2**3], degree=[2, 2], scipy=scipy)
 
     # Check that expected absolute error on velocity and pressure fields
-    # is obtained with at least 8 digits of accuracy
-    assert abs(1 - namespace['l2_error_u'] / 1.860723830885487e-05) < 1e-8
-    assert abs(1 - namespace['l2_error_p'] / 0.024428172461038290 ) < 1e-8
+    # is obtained with at least 7 digits of accuracy
+    assert abs(1 - namespace['l2_error_u'] / 1.860723830885487e-05) < 1e-7
+    assert abs(1 - namespace['l2_error_p'] / 0.024428172461038290 ) < 1e-7
 
 #------------------------------------------------------------------------------
 @pytest.mark.parametrize('scipy', (True, False))
@@ -361,9 +361,9 @@ def test_stokes_2d_dir_non_homogeneous(scipy):
             homogeneous=False, ncells=[10, 10], degree=[3, 3], scipy=scipy)
 
     # Check that expected absolute error on velocity and pressure fields
-    # is obtained with at least 8 digits of accuracy
-    assert abs(1 - namespace['l2_error_u'] / 8.658427958128542e-06) < 1e-8
-    assert abs(1 - namespace['l2_error_p'] / 0.007600728271522273 ) < 1e-8
+    # is obtained with at least 7 digits of accuracy
+    assert abs(1 - namespace['l2_error_u'] / 8.658427958128542e-06) < 1e-7
+    assert abs(1 - namespace['l2_error_p'] / 0.007600728271522273 ) < 1e-7
 
 #------------------------------------------------------------------------------
 def test_maxwell_time_harmonic_2d_dir_1():

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -107,6 +107,9 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
     a  = BilinearForm(((u, p), (v, q)), int_0(inner(grad(u), grad(v)) - div(u)*q - p*div(v)) )
     l  = LinearForm((v, q), int_0(dot(f, v)))
 
+    # Dirichlet boundary conditions are given in the form u = g where g may be
+    # just 0 (hence homogeneous BCs are prescribed) or a symbolic expression
+    # g(x, y) that represents the boundary data. Here we use the exact solution
     if homogeneous:
         bc = EssentialBC(u, 0, domain.boundary)
     else:

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -5,6 +5,7 @@ from sympy import pi, cos, sin, Matrix, Tuple
 from scipy import linalg
 from scipy.sparse.linalg import spsolve
 from scipy.sparse.linalg import gmres as sp_gmres
+from scipy.sparse.linalg import minres as sp_minres
 from scipy.sparse.linalg import bicg as sp_bicg
 from scipy.sparse.linalg import bicgstab as sp_bicgstab
 
@@ -140,10 +141,10 @@ def run_stokes_2d_dir(f, ue, pe, *, ncells, degree, scipy=False):
     # ... solve linear system
     if scipy:
         # Select Scipy's sparse iterative solver among 3 available
-        sp_solver = [sp_gmres, sp_bicg, sp_bicgstab][2]
+        sp_solver = [sp_gmres, sp_minres, sp_bicg, sp_bicgstab][1]
         As = equation_h.linear_system.lhs.tosparse()
         bs = equation_h.linear_system.rhs.toarray()
-        xs, info = sp_solver(As, bs, atol=1e-12)
+        xs, info = sp_solver(As, bs, tol=1e-12)
         x = array_to_stencil(xs, Xh.vector_space)
         print('\n', info)
 

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -124,8 +124,8 @@ def run_stokes_2d_dir(f, ue, pe, *, ncells, degree, scipy=False):
 
     # ... discrete spaces
     V1h = discretize(V1, domain_h, degree=degree)
-    V2h = discretize(V2, domain_h, degree=degree)
-    Xh  = discretize(X , domain_h, degree=degree)
+    V2h = discretize(V2, domain_h, degree=degree, basis='M')
+    Xh  = discretize(X , domain_h, degree=degree, basis='M')
 
     # ... discretize the equation using Dirichlet bc
     equation_h = discretize(equation, domain_h, [Xh, Xh])

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -26,7 +26,7 @@ from psydac.linalg.utilities   import array_to_stencil
 from psydac.linalg.iterative_solvers import pcg, bicg
 
 #==============================================================================
-def run_system_1_2d_dir(f0, sol, ncells, degree):
+def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     # ... abstract model
     domain = Square()
 
@@ -185,7 +185,7 @@ def run_stokes_2d_dir(f, ue, pe, *, ncells, degree, scipy=False):
     return locals()
 
 #==============================================================================
-def run_system_3_2d_dir(uex, f, alpha, ncells, degree):
+def run_maxwell_time_harmonic_2d_dir(uex, f, alpha, ncells, degree):
 
     # ... abstract model
     domain = Square('A')
@@ -246,14 +246,14 @@ def run_system_3_2d_dir(uex, f, alpha, ncells, degree):
 ###############################################################################
 #            SERIAL TESTS
 ###############################################################################
-def test_api_system_1_2d_dir_1():
+def test_poisson_mixed_form_2d_dir_1():
     from sympy import symbols
     x1, x2 = symbols('x1, x2')
 
     f0 =  -2*x1*(1-x1) -2*x2*(1-x2)
     u  = x1*(1-x1)*x2*(1-x2)
 
-    l2_error = run_system_1_2d_dir(f0,u, ncells=[2**3,2**3], degree=[2,2])
+    l2_error = run_poisson_mixed_form_2d_dir(f0, u, ncells=[2**3, 2**3], degree=[2, 2])
     assert l2_error-0.00030070020628128664<1e-13
 
 #------------------------------------------------------------------------------
@@ -326,7 +326,7 @@ def test_stokes_2d_dir_2():
     namespace = run_stokes_2d_dir(f, ue, pe, ncells=[2**3, 2**3], degree=[4, 4], scipy=True)
 
 #------------------------------------------------------------------------------
-def test_api_system_3_2d_dir_1():
+def test_maxwell_time_harmonic_2d_dir_1():
     from sympy import symbols
     x,y,z    = symbols('x1, x2, x3')
 
@@ -335,7 +335,7 @@ def test_api_system_3_2d_dir_1():
     f        = Tuple(alpha*sin(pi*y) - pi**2*sin(pi*y)*cos(pi*x) + pi**2*sin(pi*y),
                      alpha*sin(pi*x)*cos(pi*y) + pi**2*sin(pi*x)*cos(pi*y))
 
-    l2_error = run_system_3_2d_dir(uex, f, alpha, ncells=[2**3,2**3], degree=[2,2])
+    l2_error = run_maxwell_time_harmonic_2d_dir(uex, f, alpha, ncells=[2**3,2**3], degree=[2,2])
     assert abs(l2_error-0.0029394893438220502)<1e-13
 
 #==============================================================================

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -195,7 +195,7 @@ def test_api_system_1_2d_dir_1():
     assert l2_error-0.00030070020628128664<1e-13
 
 #------------------------------------------------------------------------------
-def test_stokes_2d_dir():
+def test_stokes_2d_dir_1():
 
     # ... Exact solution
     from sympy import symbols
@@ -233,3 +233,32 @@ def test_stokes_2d_dir():
     assert abs(namespace['l2_error_p'] - 2.44281724609567e-2) < 1e-13
 
     #TODO verify convergence rate
+
+#------------------------------------------------------------------------------
+def test_stokes_2d_dir_2():
+
+    # ... Exact solution
+    from sympy import symbols
+    x1, x2 = symbols('x1, x2')
+
+    u1 =  2000 * x1**2 * (1-x1)**2 * x2 * (1-x2) * (1-2*x2)
+    u2 = -2000 * x2**2 * (1-x2)**2 * x1 * (1-x1) * (1-2*x1)
+    ue = Tuple(u1, u2)
+    pe = x1**2 + x2**2 - 2/3
+    # ...
+
+    # Verify that div(u) = 0
+    assert (u1.diff(x1) + u2.diff(x2)).simplify() == 0
+
+    # ... Compute right-hand side
+    from sympde.calculus import laplace, grad
+    from sympde.expr import TerminalExpr
+
+    kwargs = dict(dim=2, logical=True)
+    a = TerminalExpr(-laplace(ue), **kwargs)
+    b = TerminalExpr(    grad(pe), **kwargs)
+    f = (a.T + b).simplify()
+    # ...
+
+    # Run test
+    namespace = run_stokes_2d_dir(f, ue, pe, ncells=[2**3, 2**3], degree=[4, 4], scipy=True)


### PR DESCRIPTION
Improve `Equation.solve()`:

- In addition to `cg` (conjugate gradient = CG) solver, allow `pcg` (pre-conditioned CG) and `bicg` (bi-CG);
- Fix bug when 'info = True' argument is passed to function;
- Correctly apply non-homogeneous Dirichlet boundary conditions to vector quantities.

Further improvements:

- Fix bug in `BlockMatrix.tosparse()` when `scipy.sparse.bmat()` computes wrong shape because of too many empty blocks;
- Extend 2D Stokes unit tests (add non-homogeneous test, verify results with Scipy).