### PR TITLE
Fix assembly code when multiple FemField objects are free arguments

### DIFF
--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -1,4 +1,4 @@
-from sympde.topology import Square
+from sympde.topology import Line, Square
 from sympde.topology import ScalarFunctionSpace
 from sympde.topology import element_of
 from sympde.core     import Constant
@@ -47,5 +47,45 @@ def test_field_and_constant():
     print("PASSED")
 
 #==============================================================================
+def test_multiple_fields():
+
+    domain = Line()
+    V = ScalarFunctionSpace('V', domain)
+    u = element_of(V, name='u')
+    v = element_of(V, name='v')
+
+    f1 = element_of(V, name='f1')
+    f2 = element_of(V, name='f2')
+
+    g = 0.5 * (f1**2 + f2)
+    a = BilinearForm((u, v), integral(domain, u * v * g))
+    l = LinearForm(v, integral(domain, g * v))
+
+    ncells = (5,)
+    degree = (3,)
+    domain_h = discretize(domain, ncells=ncells)
+    Vh = discretize(V, domain_h, degree=degree)
+    ah = discretize(a, domain_h, [Vh, Vh])
+    lh = discretize(l, domain_h, Vh)
+
+    fh = FemField(Vh)
+    fh.coeffs[:] = 1
+
+    # Assembly call should not crash if correct arguments are used
+    A = ah.assemble(f1=fh, f2=fh)
+    b = lh.assemble(f1=fh, f2=fh)
+
+    # Test matrix A
+    x = fh.coeffs
+    assert abs(A.dot(x).dot(x) - 1) < 1e-12
+
+    # Test vector b
+    b_arr = b.toarray()
+    assert abs(b.toarray().sum() - 1) < 1e-12
+
+    print("PASSED")
+
+#==============================================================================
 if __name__ == '__main__':
     test_field_and_constant()
+    test_multiple_fields()

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -80,7 +80,6 @@ def test_multiple_fields():
     assert abs(A.dot(x).dot(x) - 1) < 1e-12
 
     # Test vector b
-    b_arr = b.toarray()
     assert abs(b.toarray().sum() - 1) < 1e-12
 
     print("PASSED")


### PR DESCRIPTION
Fix bug in class `AST` from module `psydac.api.ast.fem`: in the generated code for the assembly of linear and bilinear forms, only the instructions for evaluating the last `FemField` argument were printed. We now print all the instructions required instead. This fixes #113.