### PR TITLE
Accelerate matrix-vector multiplication with backends

### DIFF
--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -1,10 +1,18 @@
 # coding: utf-8
 
+import sys
+import os
+import importlib
+
 from sympy import Mul, Tuple
-from sympy import Mod, Abs, Range
+from sympy import Mod, Abs, Range, Symbol
+from sympy import Function
 
 from pyccel.ast.core import Variable, IndexedVariable
 from pyccel.ast.core import For
+from pyccel.ast.core import Slice, String
+
+from pyccel.ast.datatypes import NativeInteger
 from pyccel.ast.core import Assign
 from pyccel.ast.core import AugAssign
 from pyccel.ast.core import Product
@@ -19,67 +27,97 @@ from psydac.fem.tensor  import TensorFemSpace
 from psydac.fem.vector  import ProductFemSpace
 
 from psydac.api.ast.basic import SplBasic
+from psydac.api.printing import pycode
+
+from psydac.api.settings        import PSYDAC_BACKENDS, PSYDAC_DEFAULT_FOLDER
+from psydac.api.utilities       import mkdir_p, touch_init_file, random_string, write_code
+
+from mpi4py import MPI
+
+def variable_to_sympy(x):
+    if isinstance(x, Variable) and isinstance(x.dtype, NativeInteger):
+        x = Symbol(x.name, integer=True)
+    return x
 
 class LinearOperatorDot(SplBasic):
 
-    def __new__(cls, ndim, backend=None):
+    def __new__(cls, ndim, **kwargs):
+        return SplBasic.__new__(cls, 'dot', name='lo_dot', prefix='lo_dot')
 
+    def __init__(self, ndim, **kwargs):
+        code             = self._initialize(ndim, **kwargs)
+        self._arguments = dict((str(a.name),a) for a in code.arguments)
+        self._code      = code
+        self._folder    = self._initialize_folder()
 
-        obj = SplBasic.__new__(cls, 'dot',name='lo_dot',prefix='lo_dot')
-        obj._ndim = ndim
-        obj._backend = backend
-        obj._func = obj._initialize()
-        return obj
-
-    @property
-    def ndim(self):
-        return self._ndim
+        backend = kwargs.pop('backend')
+        self._generate_code(backend=backend)
+        self._compile(backend=backend)
 
     @property
     def func(self):
         return self._func
 
     @property
-    def backend(self):
-        return self._backend
+    def arguments(self):
+        return self._arguments
 
+    @property
+    def code(self):
+        return self._code
 
-    def _initialize(self):
+    @property
+    def folder(self):
+        return self._folder
 
-        ndim = self.ndim
-        nrows           = variables('n1:%s'%(ndim+1),  'int')
-        pads            = variables('p1:%s'%(ndim+1),  'int')
-        indices1        = variables('ind1:%s'%(ndim+1),'int')
-        indices2        = variables('i1:%s'%(ndim+1),  'int')
-        extra_rows      = variables('extra_rows','int',rank=1,cls=IndexedVariable)
+    def _initialize(self, ndim, **kwargs):
 
-        ex,v            = variables('ex','int'), variables('v','real')
+        nrows           = kwargs.pop('nrows', variables('n1:%s'%(ndim+1),  'int'))
+        nrows_extra     = kwargs.pop('nrows_extra', variables('ne1:%s'%(ndim+1),  'int'))
+        pads            = kwargs.pop('pads', variables('p1:%s'%(ndim+1),  'int'))
+        gpads           = kwargs.pop('gpads', variables('gp1:%s'%(ndim+1), 'int'))
+        indices1        = variables('i1:%s'%(ndim+1),  'int')
+        indices2        = variables('k1:%s'%(ndim+1),  'int')
+
+        v               = variables('v','real')
         x, out          = variables('x, out','real',cls=IndexedVariable, rank=ndim)
         mat             = variables('mat','real',cls=IndexedVariable, rank=2*ndim)
 
+        backend         = kwargs.pop('backend', None)
+
         body = []
-        ranges = [Range(2*p+1) for p in pads]
+        ranges = [Range(2*variable_to_sympy(p)+1) for p in pads]
         target = Product(*ranges)
 
+        diff = [variable_to_sympy(gp)-variable_to_sympy(p) for gp,p in zip(gpads, pads)]
 
-        v1 = x[tuple(i+j for i,j in zip(indices1,indices2))]
-        v2 = mat[tuple(i+j for i,j in zip(indices1,pads))+tuple(indices2)]
-        v3 = out[tuple(i+j for i,j in zip(indices1,pads))]
+        v1 = x[tuple(i+j+d for i,j,d in zip(indices1,indices2, diff))]
+        v2 = mat[tuple(i+j for i,j in zip(indices1,gpads))+ tuple(indices2)]
+        v3 = out[tuple(i+j for i,j in zip(indices1,gpads))]
 
-        body = [AugAssign(v,'+' ,Mul(v1,v2))]
-        body = [For(indices2, target, body)]
+        body = [AugAssign(v,'+' ,Mul(v2, v1))]
+
+        if ndim>1 and backend and backend['name'] == 'numba':
+            for i,j in zip(indices2[::-1], target.args[::-1]):
+                body = [For(i,j, body)]
+        else:
+            body = [For(indices2, target, body)]
+
         body.insert(0,Assign(v, 0.0))
         body.append(Assign(v3,v))
-        ranges = [Range(i) for i in nrows]
+        ranges = [Range(variable_to_sympy(i)) for i in nrows]
         target = Product(*ranges)
-        body = [For(indices1,target,body)]
+
+        if ndim>1 and backend and backend['name'] == 'numba':
+            for i,j in zip(indices1[::-1], target.args[::-1]):
+                body = [For(i,j, body)]
+        else:
+            body = [For(indices1,target,body)]
 
         for dim in range(ndim):
-            body.append(Assign(ex,extra_rows[dim]))
 
-
-            v1 = [i+j for i,j in zip(indices1, indices2)]
-            v2 = [i+j for i,j in zip(indices1, pads)]
+            v1 = [i+j+d for i,j,d in zip(indices1, indices2, diff)]
+            v2 = [i+j for i,j in zip(indices1, gpads)]
             v1[dim] += nrows[dim]
             v2[dim] += nrows[dim]
             v3 = v2
@@ -88,39 +126,137 @@ class LinearOperatorDot(SplBasic):
             v3 = out[tuple(v3)]
 
             rows = list(nrows)
-            rows[dim] = ex
-            ranges = [2*p+1 for p in pads]
-            ranges[dim] -= indices1[dim] + 1
+            rows[dim] = nrows_extra[dim]
+            ranges = [2*variable_to_sympy(p)+1 for p in pads]
+            ranges[dim] -= variable_to_sympy(indices1[dim]) + 1
             ranges =[Range(i) for i in ranges]
             target = Product(*ranges)
 
             for_body = [AugAssign(v, '+',Mul(v1,v2))]
-            for_body = [For(indices2, target, for_body)]
+
+            if ndim>1 and backend and backend['name'] == 'numba':
+                for i,j in zip(indices2[::-1], target.args[::-1]):
+                    for_body = [For(i,j, for_body)]
+            else:
+                for_body = [For(indices2, target, for_body)]
+
             for_body.insert(0,Assign(v, 0.0))
             for_body.append(Assign(v3,v))
 
-            ranges = [Range(i) for i in rows]
+            ranges = [Range(variable_to_sympy(i)) for i in rows]
             target = Product(*ranges)
-            body += [For(indices1, target, for_body)]
 
+            if ndim>1 and backend and backend['name'] == 'numba':
+                for i,j in zip(indices1[::-1], target.args[::-1]):
+                    for_body = [For(i,j, for_body)]
+                body += for_body
+            else:
+                body  += [For(indices1, target, for_body)]
 
-        func_args =  (extra_rows, mat, x, out) + nrows + pads
+        func_args =  (mat, x, out)
 
-        self._imports = [Import('product','itertools')]
+        if isinstance(nrows[0], Variable):
+            func_args = func_args + tuple(nrows)
+
+        if isinstance(nrows_extra[0], Variable):
+            func_args = func_args + tuple(nrows_extra)
+
+        if isinstance(gpads[0], Variable):
+            func_args = func_args + tuple(gpads)
+
+        if isinstance(pads[0],  Variable):
+            func_args = func_args + tuple(pads)
 
         decorators = {}
-        header = None
+        header     = None
 
-#        if self.backend['name'] == 'pyccel':
-#            decorators = {'types': build_types_decorator(func_args), 'external_call':[]}
-#        elif self.backend['name'] == 'numba':
-#            decorators = {'jit':[]}
-#        elif self.backend['name'] == 'pythran':
-#            header = build_pythran_types_header(self.name, func_args)
+        if backend and backend['name'] == 'numba':
+            imports = []
+        else:
+            imports = [Import('itertools', 'product')]
 
-        return FunctionDef(self.name, list(func_args), [], body,
-                           decorators=decorators,header=header)
+        if backend:
+            if backend['name'] == 'pyccel':
+                a = [String(str(i)) for i in build_types_decorator(func_args)]
+                decorators = {'types': Function('types')(*a)}
+            elif backend['name'] == 'pythran':
+                header = build_pythran_types_header(name, func_args)
 
+        func = FunctionDef(self.name, list(func_args), [], body, imports=imports, decorators=decorators)
+        return func
+
+    def _initialize_folder(self, folder=None):
+        # ...
+        if folder is None:
+            basedir = os.getcwd()
+            folder = PSYDAC_DEFAULT_FOLDER
+            folder = os.path.join( basedir, folder )
+
+            # ... add __init__ to all directories to be able to
+            touch_init_file('__pycache__')
+            for root, dirs, files in os.walk(folder):
+                touch_init_file(root)
+            # ...
+
+        else:
+            raise NotImplementedError('user output folder not yet available')
+
+        folder = os.path.abspath( folder )
+        mkdir_p(folder)
+        # ...
+
+        return folder
+
+    def _generate_code(self, backend=None):
+        code = ''
+        tag = random_string( 8 )
+        if backend and backend['name'] == 'pyccel':
+            imports = 'from pyccel.decorators import types'
+        elif backend and backend['name'] == 'numba':
+            imports = 'from numba import jit'
+
+        code = '{imports}\n{code}'.format(imports=imports, code=pycode.pycode(self.code))
+
+        if MPI.COMM_WORLD.rank == 0:
+            modname = 'dependencies_{}'.format(tag)
+            write_code(modname+ '.py', code, folder = self.folder)
+        else:
+            modname = None
+
+        self._modname =  MPI.COMM_WORLD.bcast( modname, root=0 )
+
+    def _compile(self, backend=None):
+
+        module_name = self._modname
+        sys.path.append(self.folder)
+        package = importlib.import_module( module_name )
+        sys.path.remove(self.folder)
+
+        if backend and backend['name'] == 'pyccel':
+            package = self._compile_pyccel(package, backend)
+
+        self._func = getattr(package, 'lo_dot')
+
+    def _compile_pyccel(self, mod, backend, verbose=False):
+
+        # ... convert python to fortran using pyccel
+        compiler       = backend['compiler']
+        fflags         = backend['flags']
+        accelerator    = backend['accelerator']
+        _PYCCEL_FOLDER = backend['folder']
+
+        from pyccel.epyccel import epyccel
+
+        fmod = epyccel(mod,
+                       compiler    = compiler,
+                       fflags      = fflags,
+                       accelerator = accelerator,
+                       comm        = MPI.COMM_WORLD,
+                       bcast       = True,
+                       folder      = _PYCCEL_FOLDER,
+                       verbose     = verbose)
+
+        return fmod
 
 class VectorDot(SplBasic):
 

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -48,12 +48,13 @@ class LinearOperatorDot(SplBasic):
         return SplBasic.__new__(cls, 'dot', name='lo_dot', prefix='lo_dot')
 
     def __init__(self, ndim, **kwargs):
-        code             = self._initialize(ndim, **kwargs)
+
+        backend = dict(kwargs.pop('backend'))
+        code             = self._initialize(ndim, backend=backend, **kwargs)
         self._arguments = dict((str(a.name),a) for a in code.arguments)
         self._code      = code
         self._folder    = self._initialize_folder()
 
-        backend = kwargs.pop('backend')
         self._generate_code(backend=backend)
         self._compile(backend=backend)
 

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -116,6 +116,8 @@ class LinearOperatorDot(SplBasic):
 
         for dim in range(ndim):
 
+            if nrows_extra[dim] == 0:continue
+
             v1 = [i+j+d for i,j,d in zip(indices1, indices2, diff)]
             v2 = [i+j for i,j in zip(indices1, gpads)]
             v1[dim] += nrows[dim]

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -21,7 +21,7 @@ from pyccel.ast.core import FunctionCall
 from pyccel.ast.core import Import
 from pyccel.ast.utilities import build_types_decorator
 
-from fastcache import lru_cache
+from functools import lru_cache
 
 from psydac.api.ast.utilities import variables, math_atoms_as_str
 from psydac.fem.splines import SplineSpace
@@ -221,10 +221,9 @@ class LinearOperatorDot(SplBasic):
         elif backend and backend['name'] == 'numba':
             imports = 'from numba import jit'
 
-        code = '{imports}\n{code}'.format(imports=imports, code=pycode.pycode(self.code))
-
         if MPI.COMM_WORLD.rank == 0:
             modname = 'dependencies_{}'.format(tag)
+            code = '{imports}\n{code}'.format(imports=imports, code=pycode.pycode(self.code))
             write_code(modname+ '.py', code, folder = self.folder)
         else:
             modname = None

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -20,8 +20,10 @@ from pyccel.ast.core import FunctionDef
 from pyccel.ast.core import FunctionCall
 from pyccel.ast.core import Import
 from pyccel.ast.utilities import build_types_decorator
-from psydac.api.ast.utilities import variables, math_atoms_as_str
 
+from fastcache import lru_cache
+
+from psydac.api.ast.utilities import variables, math_atoms_as_str
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
 from psydac.fem.vector  import ProductFemSpace
@@ -39,6 +41,7 @@ def variable_to_sympy(x):
         x = Symbol(x.name, integer=True)
     return x
 
+@lru_cache(maxsize=32)
 class LinearOperatorDot(SplBasic):
 
     def __new__(cls, ndim, **kwargs):

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -2,12 +2,15 @@
 #
 # Copyright 2018 Yaman Güçlü
 
+import os
+from collections import OrderedDict
+
 import numpy as np
 from scipy.sparse import coo_matrix
 from mpi4py import MPI
 
-from psydac.linalg.basic import VectorSpace, Vector, Matrix
-from psydac.ddm.cart     import find_mpi_type, CartDecomposition, CartDataExchanger
+from psydac.linalg.basic   import VectorSpace, Vector, Matrix
+from psydac.ddm.cart       import find_mpi_type, CartDecomposition, CartDataExchanger
 
 __all__ = ['StencilVectorSpace','StencilVector','StencilMatrix', 'StencilInterfaceMatrix']
 
@@ -557,7 +560,7 @@ class StencilMatrix( Matrix ):
         Codomain of the new linear operator.
 
     """
-    def __init__( self, V, W, pads=None ):
+    def __init__( self, V, W, pads=None , backend=None):
 
         assert isinstance( V, StencilVectorSpace )
         assert isinstance( W, StencilVectorSpace )
@@ -587,6 +590,28 @@ class StencilMatrix( Matrix ):
         # Flag ghost regions as not up-to-date (conservative choice)
         self._sync = False
 
+        # prepare the arguments
+        # Number of rows in matrix (along each dimension)
+        nrows       = [ed-s+1 for s,ed in zip(V.starts, V.ends)]
+        nrows_extra = [0 if ec<=ed else ec-ed for ec,ed in zip(W.ends,V.ends)]
+
+        args                 = OrderedDict()
+        args['mat']          = self._data
+        args['x']            = None
+        args['out']          = None
+        args['nrows']        = nrows
+        args['nrows_extra']  = nrows_extra
+        args['gpads']        = V.pads
+        args['pads']         = self._pads
+
+        self._args = args
+
+        if backend is None:
+            backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND'))
+
+        if backend:
+            self.set_backend(backend)
+
     #--------------------------------------
     # Abstract interface
     #--------------------------------------
@@ -615,19 +640,10 @@ class StencilMatrix( Matrix ):
         else:
             out = StencilVector( self.codomain )
 
-        # Shortcuts
-        ssc   = self.codomain.starts
-        eec   = self.codomain.ends
-        ssd   = self.domain.starts
-        eed   = self.domain.ends
-        pads  = self.pads
-        xpads = self.domain.pads
+        self._args['x']   = v._data
+        self._args['out'] = out._data
 
-        # Number of rows in matrix (along each dimension)
-        nrows       = [ed-s+1 for s,ed in zip(ssd, eed)]
-        nrows_extra = [0 if ec<=ed else ec-ed for ec,ed in zip(eec,eed)]
-
-        self._dot(self._data, v._data, out._data, nrows, nrows_extra, xpads, pads)
+        self._dot(**self._args)
 
         # IMPORTANT: flag that ghost regions are not up-to-date
         out.ghost_regions_in_sync = False
@@ -635,15 +651,16 @@ class StencilMatrix( Matrix ):
 
     # ...
     @staticmethod
-    def _dot(mat, x, out, nrows, nrows_extra, xpads, pads):
+    def _dot(mat, x, out, nrows, nrows_extra, gpads, pads):
 
         # Index for k=i-j
         ndim = len(x.shape)
         kk   = [slice(None)]*ndim
-        diff = [xp-p for xp,p in zip(xpads, pads)]
+        # pads are <= gpads
+        diff = [gp-p for gp,p in zip(gpads, pads)]
         for xx in np.ndindex( *nrows ):
 
-            ii    = tuple( xp+x for xp,x in zip(xpads,xx) )
+            ii    = tuple( xp+x for xp,x in zip(gpads,xx) )
             jj    = tuple( slice(d+x,d+x+2*p+1) for x,p,d in zip(xx,pads,diff) )
             ii_kk = tuple( list(ii) + kk )
 
@@ -660,7 +677,7 @@ class StencilMatrix( Matrix ):
                     xx = list(xx)
                     xx.insert(d, nrows[d]+n)
 
-                    ii     = tuple(x+xp for x,xp in zip(xx, xpads))
+                    ii     = tuple(x+xp for x,xp in zip(xx, gpads))
                     ee     = [max(x-l+1,0) for x,l in zip(xx, nrows)]
                     jj     = tuple( slice(x+d, x+d+2*p+1-e) for x,p,d,e in zip(xx, pads, diff, ee) )
                     ndiags = [2*p + 1-e for p,e in zip(pads,ee)]
@@ -1246,6 +1263,19 @@ class StencilMatrix( Matrix ):
             idx_ghost = tuple( idx_front + [slice(-p,None)] + idx_back )
             self._data[idx_ghost] = 0
 
+    def set_backend(self, backend):
+        from psydac.api.ast.linalg import LinearOperatorDot
+        dot = LinearOperatorDot(self._ndim,
+                                backend=backend,
+                                nrows=self._args['nrows'],
+                                nrows_extra=self._args['nrows_extra'],
+                                gpads=self._args['gpads'],
+                                pads=self._args['pads'])
+        self._args.pop('nrows')
+        self._args.pop('nrows_extra')
+        self._args.pop('gpads')
+        self._args.pop('pads')
+        self._dot = dot.func
 #===============================================================================
 # TODO [YG, 28.01.2021]:
 # - Check if StencilMatrix should be subclassed
@@ -1653,4 +1683,5 @@ class StencilInterfaceMatrix(Matrix):
 
 
 #===============================================================================
+from psydac.api.settings   import PSYDAC_BACKENDS
 del VectorSpace, Vector, Matrix

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -606,6 +606,8 @@ class StencilMatrix( Matrix ):
 
         self._args = args
 
+        self._func = self._dot
+
         if backend is None:
             backend = PSYDAC_BACKENDS.get(os.environ.get('PSYDAC_BACKEND'))
 
@@ -643,7 +645,7 @@ class StencilMatrix( Matrix ):
         self._args['x']   = v._data
         self._args['out'] = out._data
 
-        self._dot(**self._args)
+        self._func(**self._args)
 
         # IMPORTANT: flag that ghost regions are not up-to-date
         out.ghost_regions_in_sync = False
@@ -1275,7 +1277,8 @@ class StencilMatrix( Matrix ):
         self._args.pop('nrows_extra')
         self._args.pop('gpads')
         self._args.pop('pads')
-        self._dot = dot.func
+        self._func = dot.func
+
 #===============================================================================
 # TODO [YG, 28.01.2021]:
 # - Check if StencilMatrix should be subclassed

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -1273,17 +1273,38 @@ class StencilMatrix( Matrix ):
 
     def set_backend(self, backend):
         from psydac.api.ast.linalg import LinearOperatorDot
-        dot = LinearOperatorDot(self._ndim,
-                                backend=backend,
-                                nrows=self._args['nrows'],
-                                nrows_extra=self._args['nrows_extra'],
-                                gpads=self._args['gpads'],
-                                pads=self._args['pads'])
-        self._args.pop('nrows')
-        self._args.pop('nrows_extra')
-        self._args.pop('gpads')
-        self._args.pop('pads')
-        self._func = dot.func
+
+        if self.domain.parallel:
+            dot = LinearOperatorDot(self._ndim,
+                                    backend=backend,
+                                    gpads=self._args['gpads'],
+                                    pads=self._args['pads'])
+
+            nrows = self._args.pop('nrows')
+            nrows_extra = self._args.pop('nrows_extra')
+
+            self._args.pop('gpads')
+            self._args.pop('pads')
+
+            for i in range(len(nrows)):
+                self._args['n{i}'.format(i=i+1)] = nrows[i]
+
+            for i in range(len(nrows)):
+                self._args['ne{i}'.format(i=i+1)] = nrows_extra[i]
+
+            self._func = dot.func
+        else:
+            dot = LinearOperatorDot(self._ndim,
+                                    backend=backend,
+                                    nrows=self._args['nrows'],
+                                    nrows_extra=self._args['nrows_extra'],
+                                    gpads=self._args['gpads'],
+                                    pads=self._args['pads'])
+            self._args.pop('nrows')
+            self._args.pop('nrows_extra')
+            self._args.pop('gpads')
+            self._args.pop('pads')
+            self._func = dot.func
 
 #===============================================================================
 # TODO [YG, 28.01.2021]:

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -731,12 +731,16 @@ class StencilMatrix( Matrix ):
     def copy( self ):
         M = StencilMatrix( self.domain, self.codomain, self._pads )
         M._data[:] = self._data[:]
+        M._func    = self._func
+        M._args    = self._arga
         return M
 
     #...
     def __mul__( self, a ):
         w = StencilMatrix( self._domain, self._codomain, self._pads )
         w._data = self._data * a
+        w._func = self._func
+        w._args = self._args
         w._sync = self._sync
         return w
 
@@ -744,6 +748,8 @@ class StencilMatrix( Matrix ):
     def __rmul__( self, a ):
         w = StencilMatrix( self._domain, self._codomain, self._pads )
         w._data = a * self._data
+        w._func = self._func
+        w._args = self._args
         w._sync = self._sync
         return w
 
@@ -759,6 +765,8 @@ class StencilMatrix( Matrix ):
         assert m._pads     == self._pads
         w = StencilMatrix(self._domain, self._codomain, self._pads)
         w._data = self._data  +  m._data
+        w._func = self._func
+        w._args = self._args
         w._sync = self._sync and m._sync
         return w
 
@@ -770,6 +778,8 @@ class StencilMatrix( Matrix ):
         assert m._pads     == self._pads
         w = StencilMatrix(self._domain, self._codomain, self._pads)
         w._data = self._data  -  m._data
+        w._func = self._func
+        w._args = self._args
         w._sync = self._sync and m._sync
         return w
 
@@ -802,6 +812,8 @@ class StencilMatrix( Matrix ):
     def __abs__( self ):
         w = StencilMatrix( self._domain, self._codomain, self._pads )
         w._data = abs(self._data)
+        w._func = self._func
+        w._args = self._args
         w._sync = self._sync
         return w
 

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -596,9 +596,6 @@ class StencilMatrix( Matrix ):
         nrows_extra = [0 if ec<=ed else ec-ed for ec,ed in zip(W.ends,V.ends)]
 
         args                 = OrderedDict()
-        args['mat']          = self._data
-        args['x']            = None
-        args['out']          = None
         args['nrows']        = nrows
         args['nrows_extra']  = nrows_extra
         args['gpads']        = V.pads
@@ -642,10 +639,7 @@ class StencilMatrix( Matrix ):
         else:
             out = StencilVector( self.codomain )
 
-        self._args['x']   = v._data
-        self._args['out'] = out._data
-
-        self._func(**self._args)
+        self._func(self._data, v._data, out._data, **self._args)
 
         # IMPORTANT: flag that ghost regions are not up-to-date
         out.ghost_regions_in_sync = False

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -596,7 +596,7 @@ class StencilMatrix( Matrix ):
         nrows_extra = [0 if ec<=ed else ec-ed for ec,ed in zip(W.ends,V.ends)]
 
         args                 = OrderedDict()
-        args['nrows']        = tuple(nrows)
+        args['nrows']        = nrows
         args['nrows_extra']  = tuple(nrows_extra)
         args['gpads']        = tuple(V.pads)
         args['pads']         = tuple(self._pads)
@@ -1313,7 +1313,7 @@ class StencilMatrix( Matrix ):
         else:
             dot = LinearOperatorDot(self._ndim,
                                     backend=frozenset(backend.items()),
-                                    nrows=self._args['nrows'],
+                                    nrows=tuple(self._args['nrows']),
                                     nrows_extra=self._args['nrows_extra'],
                                     gpads=self._args['gpads'],
                                     pads=self._args['pads'])

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -596,10 +596,10 @@ class StencilMatrix( Matrix ):
         nrows_extra = [0 if ec<=ed else ec-ed for ec,ed in zip(W.ends,V.ends)]
 
         args                 = OrderedDict()
-        args['nrows']        = nrows
-        args['nrows_extra']  = nrows_extra
-        args['gpads']        = V.pads
-        args['pads']         = self._pads
+        args['nrows']        = tuple(nrows)
+        args['nrows_extra']  = tuple(nrows_extra)
+        args['gpads']        = tuple(V.pads)
+        args['pads']         = tuple(self._pads)
 
         self._args = args
 
@@ -1278,7 +1278,7 @@ class StencilMatrix( Matrix ):
             if self.domain == self.codomain:
                 # In this case nrows_extra[i] == 0 for all i
                 dot = LinearOperatorDot(self._ndim,
-                                backend=backend,
+                                backend=frozenset(backend.items()),
                                 nrows_extra = self._args['nrows_extra'],
                                 gpads=self._args['gpads'],
                                 pads=self._args['pads'])
@@ -1294,7 +1294,7 @@ class StencilMatrix( Matrix ):
 
             else:
                 dot = LinearOperatorDot(self._ndim,
-                                        backend=backend,
+                                        backend=frozenset(backend.items()),
                                         gpads=self._args['gpads'],
                                         pads=self._args['pads'])
 
@@ -1312,7 +1312,7 @@ class StencilMatrix( Matrix ):
 
         else:
             dot = LinearOperatorDot(self._ndim,
-                                    backend=backend,
+                                    backend=frozenset(backend.items()),
                                     nrows=self._args['nrows'],
                                     nrows_extra=self._args['nrows_extra'],
                                     gpads=self._args['gpads'],

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -732,7 +732,7 @@ class StencilMatrix( Matrix ):
         M = StencilMatrix( self.domain, self.codomain, self._pads )
         M._data[:] = self._data[:]
         M._func    = self._func
-        M._args    = self._arga
+        M._args    = self._args
         return M
 
     #...

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -1275,24 +1275,41 @@ class StencilMatrix( Matrix ):
         from psydac.api.ast.linalg import LinearOperatorDot
 
         if self.domain.parallel:
-            dot = LinearOperatorDot(self._ndim,
-                                    backend=backend,
-                                    gpads=self._args['gpads'],
-                                    pads=self._args['pads'])
+            if self.domain == self.codomain:
+                # In this case nrows_extra[i] == 0 for all i
+                dot = LinearOperatorDot(self._ndim,
+                                backend=backend,
+                                nrows_extra = self._args['nrows_extra'],
+                                gpads=self._args['gpads'],
+                                pads=self._args['pads'])
 
-            nrows = self._args.pop('nrows')
-            nrows_extra = self._args.pop('nrows_extra')
+                nrows = self._args.pop('nrows')
 
-            self._args.pop('gpads')
-            self._args.pop('pads')
+                self._args.pop('nrows_extra')
+                self._args.pop('gpads')
+                self._args.pop('pads')
 
-            for i in range(len(nrows)):
-                self._args['n{i}'.format(i=i+1)] = nrows[i]
+                for i in range(len(nrows)):
+                    self._args['n{i}'.format(i=i+1)] = nrows[i]
 
-            for i in range(len(nrows)):
-                self._args['ne{i}'.format(i=i+1)] = nrows_extra[i]
+            else:
+                dot = LinearOperatorDot(self._ndim,
+                                        backend=backend,
+                                        gpads=self._args['gpads'],
+                                        pads=self._args['pads'])
 
-            self._func = dot.func
+                nrows = self._args.pop('nrows')
+                nrows_extra = self._args.pop('nrows_extra')
+
+                self._args.pop('gpads')
+                self._args.pop('pads')
+
+                for i in range(len(nrows)):
+                    self._args['n{i}'.format(i=i+1)] = nrows[i]
+
+                for i in range(len(nrows)):
+                    self._args['ne{i}'.format(i=i+1)] = nrows_extra[i]
+
         else:
             dot = LinearOperatorDot(self._ndim,
                                     backend=backend,
@@ -1304,7 +1321,8 @@ class StencilMatrix( Matrix ):
             self._args.pop('nrows_extra')
             self._args.pop('gpads')
             self._args.pop('pads')
-            self._func = dot.func
+
+        self._func = dot.func
 
 #===============================================================================
 # TODO [YG, 28.01.2021]:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ install_requires = [
     'pytest>=4.5',
     'pyyaml',
     'yamlloader',
-    'fastcache',
 
     # Our packages from PyPi
     'sympde==0.11',

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ install_requires = [
     'pytest>=4.5',
     'pyyaml',
     'yamlloader',
+    'fastcache',
 
     # Our packages from PyPi
     'sympde==0.11',


### PR DESCRIPTION
To accelerate the dot product, we first generate pure Python code specific to the dimensions and the format of the  `StencilMatrix` object,  after that, we use one of the backends to accelerate the Python code.
This is an example of the generated code for a StencilMatrix with dimensions = `(16, 16, 7,  7)`.
```python
from pyccel.decorators import types

@types("real[:,:,:,:]", "real[:,:]", "real[:,:]")
def dot_product(mat, x, out):

    from itertools import product
    for i1,i2 in product(range(0, 16, 1),range(0, 16, 1)):
        v = 0.0
        for k1,k2 in product(range(0, 7, 1),range(0, 7, 1)):
            v += mat[3 + i1,3 + i2,k1,k2]*x[i1 + k1,i2 + k2]
        
        out[3 + i1,3 + i2] = v
```
however, in the parallel case, we pass the number of rows as an argument, where processes can have a different number of rows.
The previous example executed in parallel will generate the following Python code:

```python
from pyccel.decorators import types

@types("real[:,:,:,:]", "real[:,:]", "real[:,:]", int, int )
def dot_product(mat, x, out, n1, n2):

    from itertools import product
    for i1,i2 in product(range(0, n1, 1),range(0, n2, 1)):
        v = 0.0
        for k1,k2 in product(range(0, 7, 1),range(0, 7, 1)):
            v += mat[3 + i1,3 + i2,k1,k2]*x[i1 + k1,i2 + k2]
        
        out[3 + i1,3 + i2] = v
```