### PR TITLE
Add `DirectionalDerivativeOperator` for matrix-free derivative computation

### DIFF
--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -161,7 +161,7 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
         if bc_mode == 'strong':
             from psydac.api.essential_bc import apply_essential_bc
             M0_dir   = M0.copy()
-            D0_T_dir = D0_T.copy()
+            D0_T_dir = D0_T.tokronstencil().tostencil().copy()
             apply_essential_bc(  M0_dir, *bcs)
             apply_essential_bc(D0_T_dir, *bcs)
 

--- a/psydac/api/tests/test_api_feec_3d.py
+++ b/psydac/api/tests/test_api_feec_3d.py
@@ -115,7 +115,7 @@ def run_maxwell_3d_scipy(logical_domain, mapping, e_ex, b_ex, ncells, degree, pe
     # Porjectors
     P0, P1, P2, P3  = derham_h.projectors(nquads=[5,5,5])
 
-    CURL     = CURL.tosparse().tocsr()
+    CURL = CURL.transform(lambda block: block.tokronstencil().tostencil()).tomatrix().tosparse().tocsr()
 
     # initial conditions
     e0_1 = lambda x, y, z: e_ex[0](0, x, y, z)

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -250,7 +250,7 @@ class DirectionalDerivativeOperator(Matrix):
         out : ndarray
             The resulting matrix.
         """
-        return self.tosparse().todense()
+        return self.tosparse().toarray()
     
     def toarray_nopads(self):
         """
@@ -262,7 +262,7 @@ class DirectionalDerivativeOperator(Matrix):
         out : ndarray
             The resulting matrix.
         """
-        return self.tosparse_nopads().todense()
+        return self.tosparse_nopads().toarray()
     
     def tosparse(self):
         """

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from psydac.linalg.stencil  import StencilVector, StencilMatrix, StencilVectorSpace
 from psydac.linalg.kron     import KroneckerStencilMatrix
-from psydac.linalg.block    import BlockVectorSpace, BlockVector, BlockLinearOperator, BlockLinearOperator
+from psydac.linalg.block    import BlockVector, BlockLinearOperator, BlockLinearOperator
 from psydac.fem.vector      import ProductFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.identity import IdentityLinearOperator, IdentityStencilMatrix as IdentityMatrix

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -240,25 +240,55 @@ class DirectionalDerivativeOperator(Matrix):
         return DirectionalDerivativeOperator(self._spaceV, self._spaceW,
                 self._diffdir, negative=not self._negative, transposed=self._transposed)
     
-    def toarray(self, *, with_pads=True):
+    def toarray(self):
         """
         Transforms this operator into a dense matrix.
-        Includes padding in both domain and codomain which is optional, if the domain is serial,
-        but mandatory if the domain is parallel.
-
-        Parameters
-        ----------
-        with_pads : Bool
-            If true, then padding in domain and codomain direction is included. Enabled by default.
+        Includes padding in both domain and codomain.
 
         Returns
         -------
         out : ndarray
             The resulting matrix.
         """
-        return self.tosparse(with_pads=with_pads).todense()
+        return self.tosparse().todense()
+    
+    def toarray_nopads(self):
+        """
+        Transforms this operator into a dense matrix.
+        Does not include padding. Does only work is the domain is not parallel.
 
-    def tosparse(self, *, with_pads=True):
+        Returns
+        -------
+        out : ndarray
+            The resulting matrix.
+        """
+        return self.tosparse_nopads().todense()
+    
+    def tosparse(self):
+        """
+        Transforms this operator into a sparse matrix in COO format.
+        Includes padding in both domain and codomain.
+
+        Returns
+        -------
+        out : COOMatrix
+            The resulting matrix.
+        """
+        return self._tosparse(True)
+    
+    def tosparse_nopads(self):
+        """
+        Transforms this operator into a sparse matrix in COO format.
+        Does not include padding. Does only work is the domain is not parallel.
+
+        Returns
+        -------
+        out : COOMatrix
+            The resulting matrix.
+        """
+        return self._tosparse(False)
+
+    def _tosparse(self, with_pads):
         """
         Transforms this operator into a sparse matrix in COO format.
         Includes padding in both domain and codomain which is optional, if the domain is serial,

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -241,24 +241,24 @@ class KroneckerDirectionalDerivativeOperator(Matrix):
     
     def toarray(self):
         """
-        Transforms this operator into a dense matrix.
+        Transforms this operator into a dense matrix. Includes padding in both domain and codomain.
 
-        Parameters
-        ----------
-        with_pads : Bool
-            If true, the paddings will be contained in the matrix as well.
+        Returns
+        -------
+        out : CSRMatrix | CSCMatrix
+            The resulting matrix.
         """
         return self.tosparse().todense()
 
     def tosparse(self):
         """
         Transforms this operator into a sparse matrix in CSR format (if not transposed),
-        or CSC format (if transposed).
+        or CSC format (if transposed). Includes padding in both domain and codomain.
 
-        Parameters
-        ----------
-        with_pads : Bool
-            If true, the paddings will be contained in the matrix as well.
+        Returns
+        -------
+        out : CSRMatrix | CSCMatrix
+            The resulting matrix.
         """
         # again, we do the transposition later
 
@@ -272,7 +272,7 @@ class KroneckerDirectionalDerivativeOperator(Matrix):
         spaceVsize = np.prod(spaceVdims)
         spaceWsize = np.prod(spaceWdims)
 
-        # dimensions with padding (equals without padding, if with_pads==False)
+        # dimensions with padding
         spaceVdimsP = spaceVdims + 2*pads
         spaceWdimsP = spaceWdims + 2*pads
         spaceVsizeP = np.prod(spaceVdimsP)
@@ -281,9 +281,6 @@ class KroneckerDirectionalDerivativeOperator(Matrix):
         # shape of the output array
         shapeT = (spaceVsizeP, spaceWsizeP)
         shape = (spaceWsizeP, spaceVsizeP)
-
-        print(f'{spaceVdims} {spaceVsize} {spaceVdimsP} {spaceVsizeP}')
-        print(f'{spaceWdims} {spaceWsize} {spaceWdimsP} {spaceWsizeP}')
 
         # compute CSR parameters
         # per (non-padded) row, we have only 1 and -1 as entries

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from psydac.linalg.stencil  import StencilVector, StencilMatrix, StencilVectorSpace
 from psydac.linalg.kron     import KroneckerStencilMatrix
-from psydac.linalg.block    import BlockVector, BlockLinearOperator, BlockLinearOperator
+from psydac.linalg.block    import BlockVector, BlockLinearOperator
 from psydac.fem.vector      import ProductFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.identity import IdentityLinearOperator, IdentityStencilMatrix as IdentityMatrix

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -495,10 +495,10 @@ class Curl_3D(DiffOperator):
 
         # ...
         # Build Curl matrix block by block
-        f = KroneckerDifferentialOperator
-        blocks = [[ None               , -f(B_M_B, B_M_M, 2) ,  f(B_B_M, B_M_M, 1)],
-                  [ f(M_B_B, M_B_M, 2) ,  None,                -f(B_B_M, M_B_M, 0)],
-                  [-f(M_B_B, M_M_B, 1) ,  f(B_M_B, M_M_B, 0) ,  None              ]]
+        D = KroneckerDifferentialOperator
+        blocks = [[       None         , -D(B_M_B, B_M_M, 2) ,  D(B_B_M, B_M_M, 1)],
+                  [ D(M_B_B, M_B_M, 2) ,        None,          -D(B_B_M, M_B_M, 0)],
+                  [-D(M_B_B, M_M_B, 1) ,  D(B_M_B, M_M_B, 0) ,        None        ]]
 
         matrix = BlockLinearOperator(Hcurl.vector_space, Hdiv.vector_space, blocks=blocks)
         # ...

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -97,8 +97,8 @@ class KroneckerDifferentialOperator(LinearOperator):
             self._codomain = W
         
         # the local area in the codomain without padding
-        self._idslice = [slice(pad, e-s+1+pad) for pad, s, e
-            in zip(self._codomain.pads, self._codomain.starts, self._codomain.ends)]
+        self._idslice = tuple([slice(pad, e-s+1+pad) for pad, s, e
+            in zip(self._codomain.pads, self._codomain.starts, self._codomain.ends)])
 
         # prepare the slices (they are of the right size then, we checked this already)
         # identity slice
@@ -115,8 +115,8 @@ class KroneckerDifferentialOperator(LinearOperator):
         else:
             diff_partslice = slice(diff_pad+1, diff_e-diff_s+1+diff_pad+1)
         
-        diffslice = [diff_partslice if i==self._diffdir else idslice[i]
-                            for i in range(self._domain.ndim)]
+        diffslice = tuple([diff_partslice if i==self._diffdir else idslice[i]
+                            for i in range(self._domain.ndim)])
         
 
         # define differentiation lambda based on the parameter negative (or sign)

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -198,8 +198,8 @@ def test_directional_derivative_operator_transposition_correctness():
 
     M = diff.tosparse()
     MT = diff.T.tosparse()
-    assert np.allclose(M.T.todense(), MT.todense())
-    assert np.allclose(M.todense(), MT.T.todense())
+    assert np.allclose(M.T.toarray(), MT.toarray())
+    assert np.allclose(M.toarray(), MT.T.toarray())
 
 def test_directional_derivative_operator_interface():
     # interface tests, to see if negation and transposition work as their methods suggest

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -102,9 +102,13 @@ def run_kronecker_directional_derivative_operator(comm, domain, ncells, degree, 
         res3 = matrix.dot(v)
         assert np.allclose(ref._data[localslice], res3._data[localslice])
 
-        assert np.allclose(matrix.tosparse(with_pads=False).toarray(), diffop.tosparse(with_pads=False).toarray())
+        assert np.array_equal(matrix.tosparse(with_pads=True).toarray(), diffop.tosparse(with_pads=True).toarray())
 
-        assert np.allclose(matrix.tosparse(with_pads=True).toarray(), diffop.tosparse(with_pads=True).toarray())
+        if not (diffop._spaceV.parallel):
+            assert np.array_equal(matrix.tosparse(with_pads=False).toarray(), diffop.tosparse(with_pads=False).toarray())
+        else:
+            with pytest.raises(AssertionError):
+                diffop.tosparse(with_pads=False)
 
 def compare_diff_operators_by_matrixassembly(lo1, lo2):
     m1 = lo1.tokronstencil().tostencil()

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -102,9 +102,13 @@ def run_kronecker_directional_derivative_operator(comm, domain, ncells, degree, 
         res3 = matrix.dot(v)
         assert np.allclose(ref._data[localslice], res3._data[localslice])
 
+        # compare matrix assembly (in non-parallel case at least)
+        if not diffop.domain.parallel:
+            assert np.array_equal(diffop.toarray(with_pads=False), matrix.toarray(with_pads=False))
+
     # case four: tosparse().dot(v._data)
-    res4 = diffop.tosparse().dot(v._data)
-    assert np.allclose(ref._data[localslice], res4[localslice])
+    res4 = diffop.tosparse(with_pads=True).dot(v._data.flatten())
+    assert np.allclose(ref._data[localslice], res4.reshape(ref._data.shape)[localslice])
 
 def compare_diff_operators_by_matrixassembly(lo1, lo2):
     m1 = lo1.tokronstencil().tostencil()
@@ -292,7 +296,7 @@ def test_kronecker_directional_derivative_operator_1d_par(domain, ncells, degree
 @pytest.mark.parametrize('seed', [1,3])
 @pytest.mark.parallel
 def test_kronecker_directional_derivative_operator_2d_par(domain, ncells, degree, periodic, direction, negative, transposed, seed):
-    run_kronecker_directional_derivative_operator(MPI.COMM_WORLD, domain, ncells, degree, periodic, direction, negative, transposed, seed, True) 
+    run_kronecker_directional_derivative_operator(MPI.COMM_WORLD, domain, ncells, degree, periodic, direction, negative, transposed, seed) 
 
 @pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  
 @pytest.mark.parametrize('ncells', [(5, 5, 7)])                       

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -104,10 +104,10 @@ def run_directional_derivative_operator(comm, domain, ncells, degree, periodic, 
 
         # compare matrix assembly (in non-parallel case at least)
         if not diffop.domain.parallel:
-            assert np.array_equal(diffop.toarray(with_pads=False), matrix.toarray(with_pads=False))
+            assert np.array_equal(diffop.toarray_nopads(), matrix.toarray(with_pads=False))
 
     # case four: tosparse().dot(v._data)
-    res4 = diffop.tosparse(with_pads=True).dot(v._data.flatten())
+    res4 = diffop.tosparse().dot(v._data.flatten())
     assert np.allclose(ref._data[localslice], res4.reshape(ref._data.shape)[localslice])
 
 def compare_diff_operators_by_matrixassembly(lo1, lo2):
@@ -176,7 +176,6 @@ def test_directional_derivative_operator_transposition_correctness():
     ncells = [8, 8]
     degree = [3, 3]
     direction = 0
-    negative = False
 
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
 
@@ -196,6 +195,11 @@ def test_directional_derivative_operator_transposition_correctness():
     MT = diff.T.tokronstencil().tostencil()
     assert np.allclose(M.T._data, MT._data)
     assert np.allclose(M._data, MT.T._data)
+
+    M = diff.tosparse()
+    MT = diff.T.tosparse()
+    assert np.allclose(M.T.todense(), MT.todense())
+    assert np.allclose(M.todense(), MT.T.todense())
 
 def test_directional_derivative_operator_interface():
     # interface tests, to see if negation and transposition work as their methods suggest

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -132,7 +132,7 @@ def test_kronecker_differential_operator_invalid_wrongsized1():
     # reduced space
     V1 = V0.reduce_degree(axes=[1], basis='M')
 
-    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative)
+    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
 
 @pytest.mark.xfail
 def test_kronecker_differential_operator_invalid_wrongspace2():
@@ -157,7 +157,7 @@ def test_kronecker_differential_operator_invalid_wrongspace2():
     # reduced space
     V1 = TensorFemSpace(*Ms)
 
-    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative)
+    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
 
 def test_kronecker_differential_operator_transposition_correctness():
     # interface tests, to see if negation and transposition work as their methods suggest
@@ -180,7 +180,7 @@ def test_kronecker_differential_operator_transposition_correctness():
     # reduced space
     V1 = V0.reduce_degree(axes=[0], basis='M')
 
-    diff = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, False, False)
+    diff = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=False, transposed=False)
 
     # compare, if the transpose is actually correct
     M = diff.tokronstencil().tostencil()
@@ -208,10 +208,10 @@ def test_kronecker_differential_operator_interface():
     # reduced space
     V1 = V0.reduce_degree(axes=[0], basis='M')
 
-    diff = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, False, False)
-    diffT = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, False, True)
-    diffN = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, True, False)
-    diffNT = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, True, True)
+    diff = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=False, transposed=False)
+    diffT = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=False, transposed=True)
+    diffN = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=True, transposed=False)
+    diffNT = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=True, transposed=True)
 
     # compare all with all by assembling matrices
     compare_diff_operators_by_matrixassembly(diff.T, diffT)

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -113,7 +113,6 @@ def compare_diff_operators_by_matrixassembly(lo1, lo2):
     m2.update_ghost_regions()
     assert np.allclose(m1._data, m2._data)
 
-@pytest.mark.xfail
 def test_kronecker_directional_derivative_operator_invalid_wrongsized1():
     # test if we detect incorrectly-sized spaces
     # i.e. V0.vector_space.npts != V1.vector_space.npts
@@ -137,9 +136,9 @@ def test_kronecker_directional_derivative_operator_invalid_wrongsized1():
     # reduced space
     V1 = V0.reduce_degree(axes=[1], basis='M')
 
-    _ = KroneckerDirectionalDerivativeOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
+    with pytest.raises(AssertionError):
+        _ = KroneckerDirectionalDerivativeOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
 
-@pytest.mark.xfail
 def test_kronecker_directional_derivative_operator_invalid_wrongspace2():
     # test, if it fails when the pads are not the same
     periodic = [False, False]
@@ -162,7 +161,8 @@ def test_kronecker_directional_derivative_operator_invalid_wrongspace2():
     # reduced space
     V1 = TensorFemSpace(*Ms)
 
-    _ = KroneckerDirectionalDerivativeOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
+    with pytest.raises(AssertionError):
+        _ = KroneckerDirectionalDerivativeOperator(V0.vector_space, V1.vector_space, direction, negative=negative)
 
 def test_kronecker_directional_derivative_operator_transposition_correctness():
     # interface tests, to see if negation and transposition work as their methods suggest

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -85,7 +85,6 @@ def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, 
 
     # case one: dot(v, out=None)
     res1 = diffop.dot(v)
-    print(res1._data)
     assert np.allclose(ref._data[localslice], res1._data[localslice])
 
     # case two: dot(v, out=w)

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -102,13 +102,10 @@ def run_kronecker_directional_derivative_operator(comm, domain, ncells, degree, 
         res3 = matrix.dot(v)
         assert np.allclose(ref._data[localslice], res3._data[localslice])
 
-        assert np.array_equal(matrix.tosparse(with_pads=True).toarray(), diffop.tosparse(with_pads=True).toarray())
+        print(matrix.tosparse(with_pads=True))
+        print(diffop.tosparse())
 
-        if not (diffop._spaceV.parallel):
-            assert np.array_equal(matrix.tosparse(with_pads=False).toarray(), diffop.tosparse(with_pads=False).toarray())
-        else:
-            with pytest.raises(AssertionError):
-                diffop.tosparse(with_pads=False)
+        assert np.array_equal(matrix.tosparse(with_pads=True).toarray(), diffop.tosparse().toarray())
 
 def compare_diff_operators_by_matrixassembly(lo1, lo2):
     m1 = lo1.tokronstencil().tostencil()

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -102,10 +102,9 @@ def run_kronecker_directional_derivative_operator(comm, domain, ncells, degree, 
         res3 = matrix.dot(v)
         assert np.allclose(ref._data[localslice], res3._data[localslice])
 
-        print(matrix.tosparse(with_pads=True))
-        print(diffop.tosparse())
-
-        assert np.array_equal(matrix.tosparse(with_pads=True).toarray(), diffop.tosparse().toarray())
+    # case four: tosparse().dot(v._data)
+    res4 = diffop.tosparse().dot(v._data)
+    assert np.allclose(ref._data[localslice], res4[localslice])
 
 def compare_diff_operators_by_matrixassembly(lo1, lo2):
     m1 = lo1.tokronstencil().tostencil()

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -196,10 +196,18 @@ def test_directional_derivative_operator_transposition_correctness():
     assert np.allclose(M.T._data, MT._data)
     assert np.allclose(M._data, MT.T._data)
 
-    M = diff.tosparse()
-    MT = diff.T.tosparse()
-    assert np.allclose(M.T.toarray(), MT.toarray())
-    assert np.allclose(M.toarray(), MT.T.toarray())
+    sparseM = diff.tosparse().tocoo()
+    sparseMT = diff.T.tosparse().tocoo()
+
+    sparseM_T = sparseM.T.tocoo()
+    sparseMT_T = sparseMT.tocoo()
+
+    assert np.array_equal( sparseMT.col , sparseM_T.col  )
+    assert np.array_equal( sparseMT.row , sparseM_T.row  )
+    assert np.array_equal( sparseMT.data, sparseM_T.data )
+    assert np.array_equal( sparseM.col , sparseMT_T.col  )
+    assert np.array_equal( sparseM.row , sparseMT_T.row  )
+    assert np.array_equal( sparseM.data, sparseMT_T.data )
 
 def test_directional_derivative_operator_interface():
     # interface tests, to see if negation and transposition work as their methods suggest

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -7,17 +7,210 @@ from psydac.fem.splines      import SplineSpace
 from psydac.fem.tensor       import TensorFemSpace
 from psydac.fem.vector       import ProductFemSpace
 
+from psydac.feec.derivatives import KroneckerDifferentialOperator
 from psydac.feec.derivatives import Derivative_1D, Gradient_2D, Gradient_3D
 from psydac.feec.derivatives import ScalarCurl_2D, VectorCurl_2D, Curl_3D
 from psydac.feec.derivatives import Divergence_2D, Divergence_3D
+
+from mpi4py                  import MPI
+
+#==============================================================================
+
+# these tests test the KroneckerDifferentialOperator structurally.
+# They do not check, if it really computes the derivatives
+# (this is done in the gradient etc. tests below already)
+def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, direction, sign, seed):
+    # determinize tests
+    np.random.seed(seed)
+
+    breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
+
+    Ns = [SplineSpace(degree=d, grid=g, periodic=p, basis='B') \
+                                  for d, g, p in zip(degree, breaks, periodic)]
+    
+    # original space
+    V0 = TensorFemSpace(*Ns, comm=comm)
+
+    # reduced space
+    V1 = V0.reduce_degree(axes=[direction], basis='M')
+
+    diffop = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, sign)
+
+    localslice = [slice(p,-p) for p in V1.vector_space.pads]
+
+    # random vector
+    v = V0.vector_space.zeros()
+    v._data[:] = np.random.random(v._data.shape)
+    v.update_ghost_regions()
+
+    # compute reference solution (do it element-wise for now...)
+    # (but we only test small domains here)
+    ref = V1.vector_space.zeros()
+    vstarts = np.array(V0.vector_space.pads, dtype=int)
+    starts = np.array(V1.vector_space.pads, dtype=int)
+    counts = np.array(V1.vector_space.ends, dtype=int) - np.array(V1.vector_space.starts, dtype=int) + 1
+    diffadd = np.zeros((len(ncells),), dtype=int)
+    diffadd[direction] = 1
+
+    outslice = [slice(s, s+c) for s,c in zip(starts, counts)]
+    idslice = [slice(s, s+c) for s,c in zip(vstarts, counts)]
+    diffslice = [slice(s+d, s+c+d) for s,c,d in zip(vstarts, counts, diffadd)]
+    if sign:
+        for ii in np.ndindex(*counts):
+            ref._data[outslice] = v._data[idslice] - v._data[diffslice]
+    else:
+        for ii in np.ndindex(*counts):
+            ref._data[outslice] = v._data[diffslice] - v._data[idslice]
+    ref.update_ghost_regions()
+
+    # compute and compare
+
+    # case one: dot(v, out=None)
+    res1 = diffop.dot(v)
+    assert np.allclose(ref._data[localslice], res1._data[localslice])
+
+    # case two: dot(v, out=w)
+    out = V1.vector_space.zeros()
+    res2 = diffop.dot(v, out=out)
+
+    assert res2 is out
+    assert np.allclose(ref._data[localslice], res2._data[localslice])
+    
+    # case three: tokronstencil().dot(v)
+    # (i.e. test matrix conversion)
+    res3 = diffop.tokronstencil().dot(v)
+    assert np.allclose(ref._data[localslice], res3._data[localslice])
+
+@pytest.mark.xfail
+def test_kronecker_differential_operator_invalid_wrongsized1():
+    # test if we detect incorrectly-sized spaces
+    # i.e. V0.vector_space.npts != V1.vector_space.npts
+    # (NOTE: if periodic was [True,True], this test would most likely pass)
+
+    periodic = [False, False]
+    domain = [(0,1),(0,1)]
+    ncells = [8, 8]
+    degree = [3, 3]
+    direction = 0
+    sign = False
+
+    breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
+
+    Ns = [SplineSpace(degree=d, grid=g, periodic=p, basis='B') \
+                                  for d, g, p in zip(degree, breaks, periodic)]
+    
+    # original space
+    V0 = TensorFemSpace(*Ns)
+
+    # reduced space
+    V1 = V0.reduce_degree(axes=[1], basis='M')
+
+    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, sign)
+
+@pytest.mark.xfail
+def test_kronecker_differential_operator_invalid_wrongspace2():
+    # test, if it fails when the pads are not the same
+    periodic = [False, False]
+    domain = [(0,1),(0,1)]
+    ncells = [8, 8]
+    degree = [3, 3]
+    direction = 0
+    sign = False
+
+    breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
+
+    Ns = [SplineSpace(degree=d, grid=g, periodic=p, basis='B') \
+                                  for d, g, p in zip(degree, breaks, periodic)]
+    Ms = [SplineSpace(degree=d-1, grid=g, periodic=p, basis='B') \
+                                  for d, g, p in zip(degree, breaks, periodic)]
+    
+    # original space
+    V0 = TensorFemSpace(*Ns)
+
+    # reduced space
+    V1 = TensorFemSpace(*Ms)
+
+    _ = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, sign)
+
+@pytest.mark.parametrize('domain', [(0, 1), (-2, 3)])
+@pytest.mark.parametrize('ncells', [11, 37])
+@pytest.mark.parametrize('degree', [2, 3, 4, 5])
+@pytest.mark.parametrize('periodic', [True, False])
+@pytest.mark.parametrize('direction', [0])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
+def test_kronecker_differential_operator_1d_ser(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(None, [domain], [ncells], [degree], [periodic], direction, sign, seed)
+
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8])])              
+@pytest.mark.parametrize('ncells', [(10, 9), (27, 15)])              
+@pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 
+@pytest.mark.parametrize('periodic', [(True, False), (False, True)]) 
+@pytest.mark.parametrize('direction', [0,1])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
+def test_kronecker_differential_operator_2d_ser(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(None, domain, ncells, degree, periodic, direction, sign, seed) 
+
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  
+@pytest.mark.parametrize('ncells', [(4, 5, 7)])                       
+@pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7)])            
+@pytest.mark.parametrize('periodic', [( True, False, False),          
+                                      (False,  True, False),
+                                      (False, False,  True)])
+@pytest.mark.parametrize('direction', [0,1,2])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
+def test_kronecker_differential_operator_3d_ser(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(None, domain, ncells, degree, periodic, direction, sign, seed) 
+
+@pytest.mark.parametrize('domain', [(0, 1), (-2, 3)])
+@pytest.mark.parametrize('ncells', [11, 37])
+@pytest.mark.parametrize('degree', [2, 3, 4, 5])
+@pytest.mark.parametrize('periodic', [True, False])
+@pytest.mark.parametrize('direction', [0])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
+@pytest.mark.parallel
+def test_kronecker_differential_operator_1d_par(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(None, [domain], [ncells], [degree], [periodic], direction, sign, seed)
+
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8])])              
+@pytest.mark.parametrize('ncells', [(10, 11), (27, 15)])              
+@pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 
+@pytest.mark.parametrize('periodic', [(True, False), (False, True)]) 
+@pytest.mark.parametrize('direction', [0,1])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
+@pytest.mark.parallel
+def test_kronecker_differential_operator_2d_par(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(MPI.COMM_WORLD, domain, ncells, degree, periodic, direction, sign, seed) 
+
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  
+@pytest.mark.parametrize('ncells', [(5, 5, 7)])                       
+@pytest.mark.parametrize('degree', [(2, 2, 3)])            
+@pytest.mark.parametrize('periodic', [( True, False, False),          
+                                      (False,  True, False),
+                                      (False, False,  True)])
+@pytest.mark.parametrize('direction', [0,1,2])
+@pytest.mark.parametrize('sign', [True, False])
+@pytest.mark.parametrize('seed', [3])
+@pytest.mark.parallel
+def test_kronecker_differential_operator_3d_par(domain, ncells, degree, periodic, direction, sign, seed):
+    run_kronecker_differential_operator(MPI.COMM_WORLD, domain, ncells, degree, periodic, direction, sign, seed) 
+
+# (higher dimensions are not tested here for now)
 
 #==============================================================================
 @pytest.mark.parametrize('domain', [(0, 1), (-2, 3)])
 @pytest.mark.parametrize('ncells', [11, 37])
 @pytest.mark.parametrize('degree', [2, 3, 4, 5])
 @pytest.mark.parametrize('periodic', [True, False])
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Derivative_1D(domain, ncells, degree, periodic):
+def test_Derivative_1D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     breaks = np.linspace(*domain, num=ncells+1)
     knots  = make_knots(breaks, degree, periodic)
@@ -58,8 +251,11 @@ def test_Derivative_1D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('ncells', [(10, 9), (27, 15)])              # 2 cases
 @pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 # 2 cases
 @pytest.mark.parametrize('periodic', [(True, False), (False, True)]) # 2 cases
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Gradient_2D(domain, ncells, degree, periodic):
+def test_Gradient_2D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -114,8 +310,11 @@ def test_Gradient_2D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
                                       (False, False,  True)])
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Gradient_3D(domain, ncells, degree, periodic):
+def test_Gradient_3D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -169,8 +368,11 @@ def test_Gradient_3D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('ncells', [(10, 9), (27, 15)])              # 2 cases
 @pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 # 2 cases
 @pytest.mark.parametrize('periodic', [(True, False), (False, True)]) # 2 cases
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_ScalarCurl_2D(domain, ncells, degree, periodic):
+def test_ScalarCurl_2D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -237,8 +439,11 @@ def test_ScalarCurl_2D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('ncells', [(10, 9), (27, 15)])              # 2 cases
 @pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 # 2 cases
 @pytest.mark.parametrize('periodic', [(True, False), (False, True)]) # 2 cases
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_VectorCurl_2D(domain, ncells, degree, periodic):
+def test_VectorCurl_2D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -297,8 +502,11 @@ def test_VectorCurl_2D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
                                       (False, False,  True)])
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Curl_3D(domain, ncells, degree, periodic):
+def test_Curl_3D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -378,8 +586,11 @@ def test_Curl_3D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('ncells', [(10, 9), (27, 15)])              # 2 cases
 @pytest.mark.parametrize('degree', [(3, 2), (4, 5)])                 # 2 cases
 @pytest.mark.parametrize('periodic', [(True, False), (False, True)]) # 2 cases
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Divergence_2D(domain, ncells, degree, periodic):
+def test_Divergence_2D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -447,8 +658,11 @@ def test_Divergence_2D(domain, ncells, degree, periodic):
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
                                       (False, False,  True)])
+@pytest.mark.parametrize('seed', [1,3])
 
-def test_Divergence_3D(domain, ncells, degree, periodic):
+def test_Divergence_3D(domain, ncells, degree, periodic, seed):
+    # determinize tests
+    np.random.seed(seed)
 
     # Compute breakpoints along each direction
     breaks = [np.linspace(*lims, num=n+1) for lims, n in zip(domain, ncells)]
@@ -518,54 +732,61 @@ def test_Divergence_3D(domain, ncells, degree, periodic):
 #==============================================================================
 if __name__ == '__main__':
 
-    test_Derivative_1D(domain=[0, 1], ncells=12, degree=3, periodic=False)
-    test_Derivative_1D(domain=[0, 1], ncells=12, degree=3, periodic=True)
+    test_Derivative_1D(domain=[0, 1], ncells=12, degree=3, periodic=False, seed=1)
+    test_Derivative_1D(domain=[0, 1], ncells=12, degree=3, periodic=True, seed=1)
 
     test_Gradient_2D(
         domain   = ([0, 1], [0, 1]),
         ncells   = (10, 15),
         degree   = (3, 2),
-        periodic = (False, True)
+        periodic = (False, True),
+        seed     = 1
     )
 
     test_Gradient_3D(
         domain   = ([0, 1], [0, 1], [0, 1]),
         ncells   = (5, 8, 4),
         degree   = (3, 2, 3),
-        periodic = (False, True, True)
+        periodic = (False, True, True),
+        seed     = 1
     )
 
     test_ScalarCurl_2D(
         domain   = ([0, 1], [0, 1]),
         ncells   = (10, 15),
         degree   = (3, 2),
-        periodic = (False, True)
+        periodic = (False, True),
+        seed     = 1
     )
 
     test_VectorCurl_2D(
         domain   = ([0, 1], [0, 1]),
         ncells   = (10, 15),
         degree   = (3, 2),
-        periodic = (False, True)
+        periodic = (False, True),
+        seed     = 1
     )
 
     test_Curl_3D(
         domain   = ([0, 1], [0, 1], [0, 1]),
         ncells   = (5, 8, 4),
         degree   = (3, 2, 3),
-        periodic = (False, True, True)
+        periodic = (False, True, True),
+        seed     = 1
     )
 
     test_Divergence_2D(
         domain   = ([0, 1], [0, 1]),
         ncells   = (10, 15),
         degree   = (3, 2),
-        periodic = (False, True)
+        periodic = (False, True),
+        seed     = 1
     )
 
     test_Divergence_3D(
         domain   = ([0, 1], [0, 1], [0, 1]),
         ncells   = (5, 8, 4),
         degree   = (3, 2, 3),
-        periodic = (False, True, True)
+        periodic = (False, True, True),
+        seed     = 1
     )

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -48,7 +48,7 @@ def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, 
     diffadd = np.zeros((len(ncells),), dtype=int)
     diffadd[direction] = 1
 
-    localslice = [slice(p,-p) for p in V1.vector_space.pads]
+    localslice = tuple([slice(p,-p) for p in V1.vector_space.pads])
 
     # random vector, scaled-up data (with fixed seed)
     v = V0.vector_space.zeros()
@@ -59,9 +59,9 @@ def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, 
     # (but we only test small domains here)
     ref = V1.vector_space.zeros()
 
-    outslice = [slice(s, s+c) for s,c in zip(pads, counts)]
-    idslice = [slice(s, s+c) for s,c in zip(vpads, counts)]
-    diffslice = [slice(s+d, s+c+d) for s,c,d in zip(vpads, counts, diffadd)]
+    outslice = tuple([slice(s, s+c) for s,c in zip(pads, counts)])
+    idslice = tuple([slice(s, s+c) for s,c in zip(vpads, counts)])
+    diffslice = tuple([slice(s+d, s+c+d) for s,c,d in zip(vpads, counts, diffadd)])
     if transposed:
         ref._data[idslice] -= v._data[outslice]
         ref._data[diffslice] += v._data[outslice]
@@ -74,7 +74,7 @@ def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, 
         ref_restslice[direction] = slice(vpads[direction], vpads[direction] + 1)
         v_restslice = [c for c in outslice]
         v_restslice[direction] = slice(pads[direction] - 1, pads[direction])
-        ref._data[ref_restslice] += v._data[v_restslice]
+        ref._data[tuple(ref_restslice)] += v._data[tuple(v_restslice)]
     else:
         ref._data[outslice] = v._data[diffslice] - v._data[idslice]
     if negative:

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -200,7 +200,7 @@ def test_directional_derivative_operator_transposition_correctness():
     sparseMT = diff.T.tosparse().tocoo()
 
     sparseM_T = sparseM.T.tocoo()
-    sparseMT_T = sparseMT.tocoo()
+    sparseMT_T = sparseMT.T.tocoo()
 
     assert np.array_equal( sparseMT.col , sparseM_T.col  )
     assert np.array_equal( sparseMT.row , sparseM_T.row  )

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -37,42 +37,59 @@ def run_kronecker_differential_operator(comm, domain, ncells, degree, periodic, 
     diffop = KroneckerDifferentialOperator(V0.vector_space, V1.vector_space, direction, negative=negative, transposed=transposed)
 
     # some boundary, and transposed handling
-    vstarts = np.array(V0.vector_space.pads, dtype=int)
-    starts = np.array(V1.vector_space.pads, dtype=int)
+    vpads = np.array(V0.vector_space.pads, dtype=int)
+    pads = np.array(V1.vector_space.pads, dtype=int)
+
+    # transpose, if needed
+    if transposed:
+        V0, V1 = V1, V0
+    
     counts = np.array(V1.vector_space.ends, dtype=int) - np.array(V1.vector_space.starts, dtype=int) + 1
     diffadd = np.zeros((len(ncells),), dtype=int)
     diffadd[direction] = 1
 
-    if transposed:
-        V0, V1 = V1, V0
-
     localslice = [slice(p,-p) for p in V1.vector_space.pads]
 
-    # random vector
+    # random vector, scaled-up data (with fixed seed)
     v = V0.vector_space.zeros()
-    v._data[:] = np.random.random(v._data.shape)
+    v._data[:] = np.random.random(v._data.shape) * 100
     v.update_ghost_regions()
 
     # compute reference solution (do it element-wise for now...)
     # (but we only test small domains here)
     ref = V1.vector_space.zeros()
+    print(v._data)
 
-    outslice = [slice(s, s+c) for s,c in zip(starts, counts)]
-    idslice = [slice(s, s+c) for s,c in zip(vstarts, counts)]
-    diffslice = [slice(s+d, s+c+d) for s,c,d in zip(vstarts, counts, diffadd)]
+    outslice = [slice(s, s+c) for s,c in zip(pads, counts)]
+    idslice = [slice(s, s+c) for s,c in zip(vpads, counts)]
+    diffslice = [slice(s+d, s+c+d) for s,c,d in zip(vpads, counts, diffadd)]
     if transposed:
-        ref._data[diffslice] += v._data[outslice]
         ref._data[idslice] -= v._data[outslice]
+        ref._data[diffslice] += v._data[outslice]
+        print(ref._data)
+
+        # we need to account for the ghost region write which diffslice does,
+        # i.e. the part which might be sent to another process, or even swapped to the other side
+        # since the ghost layers of v are updated, we update the data on the other side
+        # (also update_ghost_regions won't preserve the data we wrote there)
+        ref_restslice = [c for c in idslice]
+        ref_restslice[direction] = slice(vpads[direction], vpads[direction] + 1)
+        v_restslice = [c for c in outslice]
+        v_restslice[direction] = slice(pads[direction] - 1, pads[direction])
+        ref._data[ref_restslice] += v._data[v_restslice]
+        print(ref._data)
     else:
         ref._data[outslice] = v._data[diffslice] - v._data[idslice]
     if negative:
         ref._data[localslice] = -ref._data[localslice]
     ref.update_ghost_regions()
+    print(ref._data)
 
     # compute and compare
 
     # case one: dot(v, out=None)
     res1 = diffop.dot(v)
+    print(res1._data)
     assert np.allclose(ref._data[localslice], res1._data[localslice])
 
     # case two: dot(v, out=w)

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -442,6 +442,25 @@ class BlockLinearOperator( LinearOperator ):
 
         self._blocks[i,j] = value
     
+    def transform(self, operation):
+        """
+        Applies an operation on each block in this BlockLinearOperator.
+
+        Parameters
+        ----------
+        operation : LinearOperator -> LinearOperator
+            The operation which transforms each block.
+        """
+        blocks = {ij: operation(Bij) for ij, Bij in self._blocks.items()}
+        return BlockLinearOperator(self.domain, self.codomain, blocks=blocks)
+    
+    def tomatrix(self):
+        """
+        Returns a BlockMatrix with the same blocks as this BlockLinearOperator.
+        Does only work, if all blocks are matrices (i.e. type Matrix) as well.
+        """
+        return BlockMatrix(self.domain, self.codomain, blocks=self._blocks)
+
     # ...
     def transpose(self):
         blocks = {(j, i): b.transpose() for (i, j), b in self._blocks.items()}

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -441,6 +441,16 @@ class BlockLinearOperator( LinearOperator ):
             assert value.codomain is self.codomain[i]
 
         self._blocks[i,j] = value
+    
+    # ...
+    def transpose(self):
+        blocks = {(j, i): b.transpose() for (i, j), b in self._blocks.items()}
+        return BlockLinearOperator(self.codomain, self.domain, blocks=blocks)
+
+    # ...
+    @property
+    def T(self):
+        return self.transpose()
 
 #===============================================================================
 class BlockMatrix( BlockLinearOperator, Matrix ):
@@ -622,11 +632,6 @@ class BlockMatrix( BlockLinearOperator, Matrix ):
     def transpose(self):
         blocks = {(j, i): b.transpose() for (i, j), b in self._blocks.items()}
         return BlockMatrix(self.codomain, self.domain, blocks=blocks)
-
-    # ...
-    @property
-    def T(self):
-        return self.transpose()
 
     # ...
     def topetsc( self ):


### PR DESCRIPTION
This PR adds a class `DirectionalDerivativeOperator` which can differentiate `StencilVector`s from a `StencilVectorSpace`, ideally associated to some `TensorFemSpace`. Its features are:

* Matrix-free computation (just one array subtraction, i.e. `np.subtract`; no additional temporary memory needed) of derivatives for a `TensorFemSpace` and its `StencilVectorSpace`.
* Inherits from `psydac.linalg.basic.Matrix`.
* Can be converted to a `KroneckerStencilMatrix` which in turn can be converted into a `StencilMatrix`. Also supports conversion to the COO format.
* Can also be transposed and negated.

Additionally, this PR features:

* Small clean-up of the `DiffOperator` subclasses.
* Includes tests; also fixed the seed for the existing differential operator tests.
* Some fixes for the tests to run: the `tostencil` method of the `KroneckerStencilMatrix` now handles `nrows_extra` as in the `StencilMatrix._dot`. (the `KroneckerStencilMatrix.dot` method is not updated in this commit) Also, the `BlockLinearOperator` got some convenience methods.
