### PR TITLE
Add `BlockDiagonalSolver` for combining `LinearSolver`s

### DIFF
--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -3,7 +3,7 @@
 from psydac.linalg.utilities      import array_to_stencil
 from psydac.linalg.kron           import KroneckerLinearSolver
 from psydac.linalg.stencil        import StencilVector
-from psydac.linalg.block          import BlockLinearSolver, BlockVector
+from psydac.linalg.block          import BlockDiagonalSolver, BlockVector
 from psydac.core.bsplines         import quadrature_grid
 from psydac.utilities.quadratures import gauss_legendre
 from psydac.fem.basic             import FemField
@@ -192,7 +192,7 @@ class Projector_Hcurl:
             raise NotImplementedError('Hcurl projector is only available in 2D or 3D.')
 
         solverblocks =  [KroneckerLinearSolver(block.vector_space, self.mats[i]) for i, block in enumerate(Hcurl.spaces)]
-        self.solver = BlockLinearSolver(Hcurl.vector_space, blocks=solverblocks)
+        self.solver = BlockDiagonalSolver(Hcurl.vector_space, blocks=solverblocks)
 
     #--------------------------------------------------------------------------
     def __call__(self, fun):
@@ -332,7 +332,7 @@ class Projector_Hdiv:
             raise NotImplementedError('Hdiv projector is only available in 2D or 3D.')
 
         solverblocks =  [KroneckerLinearSolver(block.vector_space, self.mats[i]) for i, block in enumerate(Hdiv.spaces)]
-        self.solver = BlockLinearSolver(Hdiv.vector_space, blocks=solverblocks)
+        self.solver = BlockDiagonalSolver(Hdiv.vector_space, blocks=solverblocks)
 
     #--------------------------------------------------------------------------
     def __call__(self, fun):

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -8,7 +8,7 @@ from scipy.sparse import bmat, lil_matrix
 
 from psydac.linalg.basic import VectorSpace, Vector, LinearOperator, LinearSolver, Matrix
 
-__all__ = ['BlockVectorSpace', 'BlockVector', 'BlockLinearOperator', 'BlockMatrix', 'BlockLinearSolver']
+__all__ = ['BlockVectorSpace', 'BlockVector', 'BlockLinearOperator', 'BlockMatrix', 'BlockDiagonalSolver']
 
 #===============================================================================
 class BlockVectorSpace( VectorSpace ):
@@ -647,9 +647,11 @@ class BlockMatrix( BlockLinearOperator, Matrix ):
         return petsccart.petsc.Mat().createNest(blocks, comm=cart.comm)
 
 #===============================================================================
-class BlockLinearSolver( LinearSolver ):
+class BlockDiagonalSolver( LinearSolver ):
     """
-    Linear solver that can be written as blocks of other LinearSolvers.
+    A LinearSolver that can be written as blocks of other LinearSolvers,
+    i.e. it can be seen as a solver for linear equations with block-diagonal matrices.
+    
     The space of this solver has to be of the type BlockVectorSpace.
 
     Parameters

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -661,7 +661,7 @@ class BlockLinearSolver( LinearSolver ):
         LinearSolver objects (optional).
 
         a) 'blocks' can be dictionary with
-            . key   = tuple (i, i), where i is an integer >= 0 (compatibility with the other block operators)
+            . key   = integer i >= 0
             . value = corresponding LinearSolver Lii
 
         b) 'blocks' can be list of LinearSolvers (or tuple of these) where blocks[i]
@@ -675,15 +675,14 @@ class BlockLinearSolver( LinearSolver ):
         self._space   = V
         self._nblocks = V.n_blocks
 
-        # Store blocks in list (hence they can be manually changed later)
+        # Store blocks in list (hence, they can be manually changed later)
         self._blocks   = [None] * self._nblocks
 
         if blocks:
 
             if isinstance( blocks, dict ):
-                for (i,j), Lij in blocks.items():
-                    assert i == j
-                    self[i] = Lij
+                for i, L in blocks.items():
+                    self[i] = L
 
             elif isinstance( blocks, (list, tuple) ):
                 for i, L in enumerate( blocks ):

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -700,19 +700,19 @@ class BlockLinearSolver( LinearSolver ):
         return self._space
 
     # ...
-    def solve( self, v, out=None, transposed=False ):
-        assert isinstance(v, BlockVector)
-        assert v.space is self.space
+    def solve( self, rhs, out=None, transposed=False ):
+        assert isinstance(rhs, BlockVector)
+        assert rhs.space is self.space
         if out is not None:
             assert isinstance(out, BlockVector)
             out *= 0.0
         else:
             out = self.space.zeros()
 
-        v.update_ghost_regions()
+        rhs.update_ghost_regions()
 
         for i, L in enumerate(self._blocks):
-            L.solve(v[i], out=out[i], transposed=transposed)
+            L.solve(rhs[i], out=out[i], transposed=transposed)
 
         return out
 

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -8,7 +8,7 @@ from random import random, seed
 from psydac.linalg.direct_solvers import SparseSolver
 from psydac.linalg.stencil        import StencilVectorSpace, StencilVector, StencilMatrix
 from psydac.linalg.block          import BlockVectorSpace, BlockVector
-from psydac.linalg.block          import BlockLinearOperator, BlockLinearSolver, BlockMatrix
+from psydac.linalg.block          import BlockLinearOperator, BlockDiagonalSolver, BlockMatrix
 from psydac.linalg.utilities      import array_to_stencil
 from psydac.linalg.kron           import KroneckerLinearSolver
 
@@ -105,7 +105,7 @@ def test_block_linear_operator_serial_dot( n1, n2, p1, p2, P1, P2  ):
 @pytest.mark.parametrize( 'p2', [1,2,3] )
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True, False] )
-def test_block_linear_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
+def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
     # set seed for reproducability
     seed(n1*n2*p1*p2)
 
@@ -142,7 +142,7 @@ def test_block_linear_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
 
     W = BlockVectorSpace(V, V)
 
-    # Construct a BlockLinearSolver object containing M1, M2 using 3 ways
+    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
     #     |M1  0 |
     # L = |      |
     #     |0   M2|
@@ -150,10 +150,10 @@ def test_block_linear_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
     dict_blocks = {0:M1, 1:M2}
     list_blocks = [M1, M2]
 
-    L1 = BlockLinearSolver( W, blocks=dict_blocks )
-    L2 = BlockLinearSolver( W, blocks=list_blocks )
+    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
+    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
 
-    L3 = BlockLinearSolver( W )
+    L3 = BlockDiagonalSolver( W )
     L3[0] = M1
     L3[1] = M2
 
@@ -173,7 +173,7 @@ def test_block_linear_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
     X[0] = x1
     X[1] = x2
 
-    # Compute BlockLinearSolver product
+    # Compute BlockDiagonalSolver product
     Y1 = L1.solve(X)
     Y2 = L2.solve(X)
     Y3 = L3.solve(X)
@@ -433,7 +433,7 @@ def test_block_linear_operator_parallel_dot( n1, n2, p1, p2, P1, P2, reorder ):
 @pytest.mark.parametrize( 'P2', [True, False] )
 @pytest.mark.parametrize( 'reorder', [True, False] )
 @pytest.mark.parallel
-def test_block_linear_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
+def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
     # set seed for reproducability
     seed(n1*n2*p1*p2)
 
@@ -485,7 +485,7 @@ def test_block_linear_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
 
     W = BlockVectorSpace(V, V)
 
-    # Construct a BlockLinearSolver object containing M1, M2 using 3 ways
+    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
     #     |M1  0 |
     # L = |      |
     #     |0   M2|
@@ -493,10 +493,10 @@ def test_block_linear_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
     dict_blocks = {0:M1, 1:M2}
     list_blocks = [M1, M2]
 
-    L1 = BlockLinearSolver( W, blocks=dict_blocks )
-    L2 = BlockLinearSolver( W, blocks=list_blocks )
+    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
+    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
 
-    L3 = BlockLinearSolver( W )
+    L3 = BlockDiagonalSolver( W )
     L3[0] = M1
     L3[1] = M2
 
@@ -517,7 +517,7 @@ def test_block_linear_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
     X[0] = x1
     X[1] = x2
 
-    # Compute BlockLinearSolver product
+    # Compute BlockDiagonalSolver product
     Y1 = L1.solve(X)
     Y2 = L2.solve(X)
     Y3 = L3.solve(X)

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -23,7 +23,7 @@ from psydac.linalg.kron           import KroneckerLinearSolver
 @pytest.mark.parametrize( 'P2', [True, False] )
 
 def test_block_linear_operator_serial_dot( n1, n2, p1, p2, P1, P2  ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     # Create vector spaces, stencil matrices, and stencil vectors
@@ -106,7 +106,7 @@ def test_block_linear_operator_serial_dot( n1, n2, p1, p2, P1, P2  ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True, False] )
 def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     # Create vector spaces, stencil matrices, and stencil vectors
@@ -142,21 +142,6 @@ def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
 
     W = BlockVectorSpace(V, V)
 
-    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
-    #     |M1  0 |
-    # L = |      |
-    #     |0   M2|
-
-    dict_blocks = {0:M1, 1:M2}
-    list_blocks = [M1, M2]
-
-    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
-    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
-
-    L3 = BlockDiagonalSolver( W )
-    L3[0] = M1
-    L3[1] = M2
-
     # Fill in vector with random values, then update ghost regions
     for i1 in range(n1):
         x1[i1] = 2.0*random() - 1.0
@@ -173,14 +158,55 @@ def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
     X[0] = x1
     X[1] = x2
 
+    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
+    #     |M1  0 |
+    # L = |      |
+    #     |0   M2|
+
+    dict_blocks = {0:M1, 1:M2}
+    list_blocks = [M1, M2]
+
+    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
+    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
+
+    L3 = BlockDiagonalSolver( W )
+
+    # Test for not allowing undefinedness
+    errresult = False
+    try:
+        L3.solve(X)
+    except NotImplementedError:
+        errresult = True
+    assert errresult
+
+    L3[0] = M1
+    L3[1] = M2
+
     # Compute BlockDiagonalSolver product
     Y1 = L1.solve(X)
     Y2 = L2.solve(X)
     Y3 = L3.solve(X)
 
+    # Transposed
+    Yt = L1.solve(X, transposed=True)
+
+    # Test other in/out methods
+    Y4a = W.zeros()
+    Y4b = L1.solve(X, out=Y4a)
+    assert Y4b is Y4a
+
+    Y5a = W.zeros()
+    Y5a[0] = x1.copy()
+    Y5a[1] = x2.copy()
+    Y5b = L1.solve(Y5a, out=Y5a)
+    assert Y5b is Y5a
+
     # Solve linear equations for each block
     y1 = M1.solve(x1)
     y2 = M2.solve(x2)
+
+    y1t = M1.solve(x1, transposed=True)
+    y2t = M2.solve(x2, transposed=True)
 
     # Check data in 1D array
     assert np.allclose( Y1.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
@@ -192,6 +218,15 @@ def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
     assert np.allclose( Y3.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
     assert np.allclose( Y3.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
 
+    assert np.allclose( Y4a.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Y4a.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
+
+    assert np.allclose( Y5a.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Y5a.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
+
+    assert np.allclose( Yt.blocks[0].toarray(), y1t.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Yt.blocks[1].toarray(), y2t.toarray(), rtol=1e-14, atol=1e-14 )
+
 #===============================================================================
 @pytest.mark.parametrize( 'n1', [8,16] )
 @pytest.mark.parametrize( 'n2', [8,12] )
@@ -201,7 +236,7 @@ def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
 @pytest.mark.parametrize( 'P2', [True, False] )
 
 def test_block_matrix( n1, n2, p1, p2, P1, P2  ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     # Create vector spaces, stencil matrices, and stencil vectors
@@ -282,7 +317,7 @@ def test_block_matrix( n1, n2, p1, p2, P1, P2  ):
 @pytest.mark.parametrize( 'P2', [True, False] )
 
 def test_block_2d_array_to_stencil_1( n1, n2, p1, p2, P1, P2 ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     # Create vector spaces, and stencil vectors
@@ -314,7 +349,7 @@ def test_block_2d_array_to_stencil_1( n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'P2', [True, False] )
 
 def test_block_2d_array_to_stencil_2( n1, n2, p1, p2, P1, P2 ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     # Create vector spaces, and stencil vectors
@@ -352,7 +387,7 @@ def test_block_2d_array_to_stencil_2( n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parallel
 
 def test_block_linear_operator_parallel_dot( n1, n2, p1, p2, P1, P2, reorder ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     from mpi4py       import MPI
@@ -434,7 +469,7 @@ def test_block_linear_operator_parallel_dot( n1, n2, p1, p2, P1, P2, reorder ):
 @pytest.mark.parametrize( 'reorder', [True, False] )
 @pytest.mark.parallel
 def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
-    # set seed for reproducability
+    # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
     from mpi4py       import MPI
@@ -485,26 +520,10 @@ def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
 
     W = BlockVectorSpace(V, V)
 
-    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
-    #     |M1  0 |
-    # L = |      |
-    #     |0   M2|
-
-    dict_blocks = {0:M1, 1:M2}
-    list_blocks = [M1, M2]
-
-    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
-    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
-
-    L3 = BlockDiagonalSolver( W )
-    L3[0] = M1
-    L3[1] = M2
-
     # Fill in vector with random values, then update ghost regions
-    for i1 in range(s1,e1+1):
-        for i2 in range(s2,e2+1):
-            x1[i1,i2] = 2.0*random() - 1.0
-            x2[i1,i2] = 5.0*random() - 1.0
+    for i1 in range(n1):
+        x1[i1] = 2.0*random() - 1.0
+        x2[i1] = 5.0*random() - 1.0
     x1.update_ghost_regions()
     x2.update_ghost_regions()
 
@@ -517,14 +536,55 @@ def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
     X[0] = x1
     X[1] = x2
 
+    # Construct a BlockDiagonalSolver object containing M1, M2 using 3 ways
+    #     |M1  0 |
+    # L = |      |
+    #     |0   M2|
+
+    dict_blocks = {0:M1, 1:M2}
+    list_blocks = [M1, M2]
+
+    L1 = BlockDiagonalSolver( W, blocks=dict_blocks )
+    L2 = BlockDiagonalSolver( W, blocks=list_blocks )
+
+    L3 = BlockDiagonalSolver( W )
+
+    # Test for not allowing undefinedness
+    errresult = False
+    try:
+        L3.solve(X)
+    except NotImplementedError:
+        errresult = True
+    assert errresult
+
+    L3[0] = M1
+    L3[1] = M2
+
     # Compute BlockDiagonalSolver product
     Y1 = L1.solve(X)
     Y2 = L2.solve(X)
     Y3 = L3.solve(X)
 
+    # Transposed
+    Yt = L1.solve(X, transposed=True)
+
+    # Test other in/out methods
+    Y4a = W.zeros()
+    Y4b = L1.solve(X, out=Y4a)
+    assert Y4b is Y4a
+
+    Y5a = W.zeros()
+    Y5a[0] = x1.copy()
+    Y5a[1] = x2.copy()
+    Y5b = L1.solve(Y5a, out=Y5a)
+    assert Y5b is Y5a
+
     # Solve linear equations for each block
     y1 = M1.solve(x1)
     y2 = M2.solve(x2)
+
+    y1t = M1.solve(x1, transposed=True)
+    y2t = M2.solve(x2, transposed=True)
 
     # Check data in 1D array
     assert np.allclose( Y1.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
@@ -535,6 +595,15 @@ def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
 
     assert np.allclose( Y3.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
     assert np.allclose( Y3.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
+
+    assert np.allclose( Y4a.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Y4a.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
+
+    assert np.allclose( Y5a.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Y5a.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
+
+    assert np.allclose( Yt.blocks[0].toarray(), y1t.toarray(), rtol=1e-14, atol=1e-14 )
+    assert np.allclose( Yt.blocks[1].toarray(), y2t.toarray(), rtol=1e-14, atol=1e-14 )
 
 #===============================================================================
 # SCRIPT FUNCTIONALITY

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -144,8 +144,9 @@ def test_block_diagonal_solver_serial_dot( n1, n2, p1, p2, P1, P2  ):
 
     # Fill in vector with random values, then update ghost regions
     for i1 in range(n1):
-        x1[i1] = 2.0*random() - 1.0
-        x2[i1] = 5.0*random() - 1.0
+        for i2 in range(n2):
+            x1[i1,i2] = 2.0*random() - 1.0
+            x2[i1,i2] = 5.0*random() - 1.0
     x1.update_ghost_regions()
     x2.update_ghost_regions()
 
@@ -521,9 +522,10 @@ def test_block_diagonal_solver_parallel_dot( n1, n2, p1, p2, P1, P2, reorder  ):
     W = BlockVectorSpace(V, V)
 
     # Fill in vector with random values, then update ghost regions
-    for i1 in range(n1):
-        x1[i1] = 2.0*random() - 1.0
-        x2[i1] = 5.0*random() - 1.0
+    for i1 in range(s1,e1+1):
+        for i2 in range(s2,e2+1):
+            x1[i1,i2] = 2.0*random() - 1.0
+            x2[i1,i2] = 5.0*random() - 1.0
     x1.update_ghost_regions()
     x2.update_ghost_regions()
 


### PR DESCRIPTION
This PR introduces a new class `BlockDiagonalSolver`. The features are:
* Applies several `LinearSolvers` to parts of a `BlockVector`.
* Works as a `LinearSolver` on `BlockVectorSpace`s. (it also inherits from `LinearSolver`)
* Includes tests.
* Updates projector code to use `KroneckerLinearSolver` and the introduced `BlockDiagonalSolver`.