### PR TITLE
Add function `build_pyccel_types_decorators` to psydac.ast.utilities

### DIFF
--- a/psydac/api/ast/evaluation.py
+++ b/psydac/api/ast/evaluation.py
@@ -14,10 +14,10 @@ from pyccel.ast.core      import For
 from pyccel.ast.core      import Assign
 from pyccel.ast.core      import Slice
 from pyccel.ast.core      import FunctionDef
-from pyccel.ast.utilities import build_types_decorator
 
 from .basic     import SplBasic
 from .utilities import build_pythran_types_header, variables
+from .utilities import build_pyccel_types_decorator
 from .utilities import rationalize_eval_mapping
 from .utilities import compute_atoms_expr_mapping
 from .utilities import compute_atoms_expr_field
@@ -174,7 +174,7 @@ class EvalArrayField(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_types_decorator(func_args)}
+            decorators = {'types': build_pyccel_types_decorator(func_args)}
         elif self.backend['name'] == 'numba':
             decorators = {'jit':[]}
         elif self.backend['name'] == 'pythran':
@@ -411,7 +411,7 @@ class EvalArrayMapping(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_types_decorator(func_args)}
+            decorators = {'types': build_pyccel_types_decorator(func_args)}
         elif self.backend['name'] == 'numba':
             decorators = {'jit':[]}
         elif self.backend['name'] == 'pythran':

--- a/psydac/api/ast/expr.py
+++ b/psydac/api/ast/expr.py
@@ -32,6 +32,7 @@ from sympde.calculus.matrices    import SymbolicDeterminant
 from .basic      import SplBasic
 from .utilities  import random_string
 from .utilities  import build_pythran_types_header, variables
+from .utilities  import build_pyccel_types_decorator
 from .utilities  import math_atoms_as_str
 
 from psydac.fem.vector import ProductFemSpace
@@ -432,7 +433,7 @@ class ExprKernel(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_types_decorator(func_args)}
+            decorators = {'types': build_pyccel_types_decorator(func_args)}
         elif self.backend['name'] == 'numba':
             decorators = {'jit':[]}
         elif self.backend['name'] == 'pythran':

--- a/psydac/api/ast/glt.py
+++ b/psydac/api/ast/glt.py
@@ -41,6 +41,7 @@ from gelato.expr import gelatize
 from .basic      import SplBasic
 from .utilities  import random_string
 from .utilities  import build_pythran_types_header, variables
+from .utilities  import build_pyccel_types_decorator
 from .utilities  import is_mapping
 from .utilities  import math_atoms_as_str
 from .evaluation import EvalArrayMapping, EvalArrayField
@@ -557,7 +558,7 @@ class GltKernel(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_types_decorator(func_args)}
+            decorators = {'types': build_pyccel_types_decorator(func_args)}
         elif self.backend['name'] == 'numba':
             decorators = {'jit':[]}
         elif self.backend['name'] == 'pythran':

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -22,7 +22,6 @@ from pyccel.ast.core import Product
 from pyccel.ast.core import FunctionDef
 from pyccel.ast.core import FunctionCall
 from pyccel.ast.core import Import
-from pyccel.ast.utilities import build_pyccel_types_decorator
 
 from psydac.api.ast.utilities import variables, math_atoms_as_str
 from psydac.api.ast.utilities import build_pyccel_types_decorator

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -3,6 +3,9 @@
 import sys
 import os
 import importlib
+from functools import lru_cache
+
+from mpi4py import MPI
 
 from sympy import Mul, Tuple
 from sympy import Mod, Abs, Range, Symbol
@@ -11,7 +14,6 @@ from sympy import Function
 from pyccel.ast.core import Variable, IndexedVariable
 from pyccel.ast.core import For
 from pyccel.ast.core import Slice, String
-
 from pyccel.ast.datatypes import NativeInteger
 from pyccel.ast.core import ValuedArgument
 from pyccel.ast.core import Assign
@@ -20,23 +22,19 @@ from pyccel.ast.core import Product
 from pyccel.ast.core import FunctionDef
 from pyccel.ast.core import FunctionCall
 from pyccel.ast.core import Import
-from pyccel.ast.utilities import build_types_decorator
-
-from functools import lru_cache
+from pyccel.ast.utilities import build_pyccel_types_decorator
 
 from psydac.api.ast.utilities import variables, math_atoms_as_str
+from psydac.api.ast.utilities import build_pyccel_types_decorator
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
 from psydac.fem.vector  import ProductFemSpace
-
 from psydac.api.ast.basic import SplBasic
 from psydac.api.printing import pycode
-
 from psydac.api.settings        import PSYDAC_BACKENDS, PSYDAC_DEFAULT_FOLDER
 from psydac.api.utilities       import mkdir_p, touch_init_file, random_string, write_code
 
-from mpi4py import MPI
-
+#==============================================================================
 def variable_to_sympy(x):
     if isinstance(x, Variable) and isinstance(x.dtype, NativeInteger):
         x = Symbol(x.name, integer=True)
@@ -184,7 +182,7 @@ class LinearOperatorDot(SplBasic):
 
         if backend:
             if backend['name'] == 'pyccel':
-                a = [String(str(i)) for i in build_types_decorator(func_args)]
+                a = [String(str(i)) for i in build_pyccel_types_decorator(func_args)]
                 decorators = {'types': Function('types')(*a)}
             elif backend['name'] == 'numba':
                 decorators = {'njit': Function('njit')(ValuedArgument(Symbol('fastmath'), backend['fastmath']))}
@@ -320,7 +318,7 @@ class VectorDot(SplBasic):
         header = None
 
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_types_decorator(func_args), 'external':[]}
+            decorators = {'types': build_pyccel_types_decorator(func_args), 'external':[]}
         elif self.backend['name'] == 'numba':
             decorators = {'jit':[]}
         elif self.backend['name'] == 'pythran':

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -11,7 +11,6 @@ from sympy.simplify import cse_main
 from sympy.core.containers import Tuple
 
 
-from pyccel.ast.utilities import build_types_decorator
 from pyccel.ast.core      import Assign, Product, AugAssign, For
 from pyccel.ast.core      import Variable, IndexedVariable, IndexedElement
 from pyccel.ast.core      import Slice, String, ValuedArgument
@@ -74,6 +73,7 @@ from .fem import expand, expand_hdiv_hcurl
 from psydac.api.ast.utilities import variables, math_atoms_as_str
 from psydac.api.utilities     import flatten
 from psydac.api.ast.utilities import build_pythran_types_header
+from psydac.api.ast.utilities import build_pyccel_types_decorator
 
 #==============================================================================
 # TODO move it
@@ -441,7 +441,7 @@ class Parser(object):
         imports = [Import('numpy', imports)]
 
         if self.backend['name'] == 'pyccel':
-            a = [String(str(i)) for i in build_types_decorator(arguments)]
+            a = [String(str(i)) for i in build_pyccel_types_decorator(arguments)]
             decorators = {'types': Function('types')(*a)}
         elif self.backend['name'] == 'numba':
             decorators = {'njit': Function('njit')(ValuedArgument(Symbol('fastmath'), self.backend['fastmath']))}

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -29,6 +29,7 @@ from pyccel.ast.core import AugAssign
 from pyccel.ast.core import Product
 from pyccel.ast.core import _atomic
 from pyccel.ast.core import Comment
+from pyccel.ast.core import String
 
 #==============================================================================
 def random_string( n ):
@@ -813,11 +814,35 @@ def variables(names, dtype, **args):
     else:
         raise TypeError('Expecting a string')
 
+#==============================================================================
+def build_pyccel_types_decorator(args, order=None):
+    """
+    builds a types decorator from a list of arguments (of FunctionDef)
+    """
+    types = []
+    for a in args:
+        if isinstance(a, Variable):
+            dtype = a.dtype.name.lower()
 
+        elif isinstance(a, IndexedVariable):
+            dtype = a.dtype.name.lower()
 
+        else:
+            raise TypeError('unexpected type for {}'.format(a))
+
+        if a.rank > 0:
+            shape = [':' for i in range(0, a.rank)]
+            shape = ','.join(i for i in shape)
+            dtype = '{dtype}[{shape}]'.format(dtype=dtype, shape=shape)
+            if order and a.rank > 1:
+                dtype = "{dtype}(order={ordering})".format(dtype=dtype, ordering=order)
+
+        dtype = String(dtype)
+        types.append(dtype)
+
+    return types
 
 #==============================================================================
-
 def build_pythran_types_header(name, args, order=None):
     """
     builds a types decorator from a list of arguments (of FunctionDef)


### PR DESCRIPTION
Move function `build_types_decorators` to Psydac:

- Copied from `pyccel.ast.utilities` (Pyccel version 0.10.1);
- Renamed as `build_pyccel_types_decorators`.