### PR TITLE
Fix `__div__` -> `__truediv__`

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -95,10 +95,10 @@ class Vector( metaclass=ABCMeta ):
     #-------------------------------------
     # Methods with default implementation
     #-------------------------------------
-    def __div__( self, a ):
+    def __truediv__( self, a ):
         return self * (1.0 / a)
 
-    def __idiv__( self, a ):
+    def __itruediv__( self, a ):
         self *= 1.0 / a
         return self
 
@@ -190,11 +190,11 @@ class Matrix( LinearOperator ):
     #-------------------------------------
     # Methods with default implementation
     #-------------------------------------
-    def __div__(self, a):
+    def __truediv__(self, a):
         """ Divide by scalar. """
         return self * (1.0 / a)
 
-    def __idiv__(self, a):
+    def __itruediv__(self, a):
         """ Divide by scalar, in place. """
         self *= 1.0 / a
         return self

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -24,6 +24,46 @@ def test_stencil_matrix_2d_serial_init( n1, n2, p1, p2, P1=True, P2=False ):
     assert M.shape == (n1*n2, n1*n2)
 
 #===============================================================================
+# SERIAL TESTS
+#===============================================================================
+@pytest.mark.parametrize( 'n1', [7,15] )
+@pytest.mark.parametrize( 'n2', [8,12] )
+@pytest.mark.parametrize( 'p1', [1,2,3] )
+@pytest.mark.parametrize( 'p2', [1,2,3] )
+
+def test_stencil_matrix_2d_basic_ops( n1, n2, p1, p2, P1=True, P2=False ):
+
+    V = StencilVectorSpace( [n1,n2], [p1,p2], [P1,P1] )
+    M = StencilMatrix( V, V )
+
+    # take random data, but determinize it
+    np.random.seed(2)
+
+    M._data[:] = np.random.random(M._data.shape)
+
+    assert M._data.shape == (n1+2*p1, n2+2*p2, 1+2*p1, 1+2*p2)
+    assert M.shape == (n1*n2, n1*n2)
+
+    # we try to go for equality here...
+    assert np.array_equal((M * 2)._data, M._data * 2)
+    assert np.array_equal((M / 2)._data, M._data / 2)
+    assert np.array_equal((M + M)._data, M._data + M._data)
+    assert np.array_equal((M - M)._data, M._data - M._data)
+
+    M1 = M.copy()
+    M1 *= 2
+    M2 = M.copy()
+    M2 /= 2
+    M3 = M.copy()
+    M3 += M
+    M4 = M.copy()
+    M4 -= M
+    assert np.array_equal(M1._data, M._data * 2)
+    assert np.array_equal(M2._data, M._data / 2)
+    assert np.array_equal(M3._data, M._data + M._data)
+    assert np.array_equal(M4._data, M._data - M._data)
+
+#===============================================================================
 @pytest.mark.parametrize( 'n1', [7,15] )
 @pytest.mark.parametrize( 'n2', [8,12] )
 @pytest.mark.parametrize( 'p1', [1,2,3] )

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -24,8 +24,6 @@ def test_stencil_matrix_2d_serial_init( n1, n2, p1, p2, P1=True, P2=False ):
     assert M.shape == (n1*n2, n1*n2)
 
 #===============================================================================
-# SERIAL TESTS
-#===============================================================================
 @pytest.mark.parametrize( 'n1', [7,15] )
 @pytest.mark.parametrize( 'n2', [8,12] )
 @pytest.mark.parametrize( 'p1', [1,2,3] )

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -49,6 +49,41 @@ def test_stencil_vector_2d_serial_copy( n1, n2, p1, p2, P1=True, P2=False ):
     assert np.all( z[:,:] == x[:,:] )
 
 #===============================================================================
+@pytest.mark.parametrize( 'n1', [7,15] )
+@pytest.mark.parametrize( 'n2', [8,12] )
+@pytest.mark.parametrize( 'p1', [1,2,3] )
+@pytest.mark.parametrize( 'p2', [1,2,3] )
+
+def test_stencil_vector_2d_basic_ops( n1, n2, p1, p2, P1=True, P2=False ):
+
+    V = StencilVectorSpace( [n1,n2], [p1,p2], [P1,P1] )
+    M = StencilVector( V )
+
+    # take random data, but determinize it
+    np.random.seed(2)
+
+    M._data[:] = np.random.random(M._data.shape)
+
+    # we try to go for equality here...
+    assert np.array_equal((M * 2)._data, M._data * 2)
+    assert np.array_equal((M / 2)._data, M._data / 2)
+    assert np.array_equal((M + M)._data, M._data + M._data)
+    assert np.array_equal((M - M)._data, M._data - M._data)
+
+    M1 = M.copy()
+    M1 *= 2
+    M2 = M.copy()
+    M2 /= 2
+    M3 = M.copy()
+    M3 += M
+    M4 = M.copy()
+    M4 -= M
+    assert np.array_equal(M1._data, M._data * 2)
+    assert np.array_equal(M2._data, M._data / 2)
+    assert np.array_equal(M3._data, M._data + M._data)
+    assert np.array_equal(M4._data, M._data - M._data)
+
+#===============================================================================
 @pytest.mark.parametrize( 'n1', [1,7] )
 @pytest.mark.parametrize( 'n2', [1,5] )
 @pytest.mark.parametrize( 'p1', [1,2] )


### PR DESCRIPTION
This PR updates the division operator to Python 3 (assuming that Python 2 support is obsolete/removed already),
i.e. it enables us to do e.g. `M /= a` where `M` is a `Matrix` or `Vector` object, and `a` is something that we can invert and have `M *= a` implemented, e.g. `a` could be a scalar. Note that we do not implement `__floordiv__` here (if that should be needed at all).

* `__div__` -> `__truediv__`, `__idiv__` -> `__itruediv__`
* Adds simple tests for `StencilMatrix` and `StencilVector` concerning some of their operators.