### PR TITLE
Update PCG method to support `LinearSolver` and callable functions as input argument

### DIFF
--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -127,9 +127,13 @@ def pcg(A, b, pc, x0=None, tol=1e-6, maxiter=1000, verbose=False):
     b : psydac.linalg.stencil.StencilVector
         Right-hand-side vector of linear system.
 
-    pc: string
+    pc: NoneType | str | psydac.linalg.basic.LinearSolver | Callable
         Preconditioner for A, it should approximate the inverse of A.
-        "jacobi" and "weighted_jacobi" are available in this module.
+        Can either be:
+        * None, i.e. not pre-conditioning (this calls the standard `cg` method)
+        * The strings 'jacobi' or 'weighted_jacobi'. (rather obsolete, supply a callable instead, if possible)
+        * A LinearSolver object (in which case the out parameter is used)
+        * A callable with two parameters (A, r), where A is the LinearOperator from above, and r is the residual.
 
     x0 : psydac.linalg.basic.Vector
         First guess of solution for iterative solver (optional).


### PR DESCRIPTION
This PR slightly modifies the `psydac.linalg.iterative_solvers.pcg`, so that we may use a `LinearSolver` object or a callable function instead of a string, or simply input `None` as preconditioner. (note that as of now, this PR modifies as little as necessary)

* If we input no preconditioner (i.e. `pc is None`), the regular `cg` method is called.
* If a `LinearSolver` is used, it utilizes the `out` parameter of the `solve` method, i.e. we do not allocate a new vector for each round.
* If a callable function is used, the parameter format is as for the functions which are addressable as strings. I.e. we have `function(A, r)`, where we want to solve `As = r`. `s` is always re-allocated.
* The two string parameters `'jacobi', 'weighted_jacobi'` are kept for compatibility reasons with the existing code for now.
* Includes an interface test.