### PR TITLE
Add basic support for distributed multi-dimensional FFTs

### DIFF
--- a/psydac/linalg/direct_solvers.py
+++ b/psydac/linalg/direct_solvers.py
@@ -80,7 +80,8 @@ class BandedSolver ( DirectSolver ):
         assert rhs.shape[0] == self._bmat.shape[1]
 
         if out is None:
-            out, self._sinfo = dgbtrs(self._bmat, self._l, self._u, rhs, self._ipiv, trans=transposed)
+            preout, self._sinfo = dgbtrs(self._bmat, self._l, self._u, rhs.T, self._ipiv, trans=transposed)
+            out = preout.T
 
         else :
             assert out.shape == rhs.shape
@@ -91,7 +92,8 @@ class BandedSolver ( DirectSolver ):
 
             # TODO: handle non-contiguous views?
             
-            _, self._sinfo = dgbtrs(self._bmat, self._l, self._u, out, self._ipiv, overwrite_b=True, trans=transposed)
+            # we want FORTRAN-contiguous data (default is assumed to be C contiguous)
+            _, self._sinfo = dgbtrs(self._bmat, self._l, self._u, out.T, self._ipiv, overwrite_b=True, trans=transposed)
 
         return out
 
@@ -126,13 +128,13 @@ class SparseSolver ( DirectSolver ):
         assert rhs.shape[0] == self._splu.shape[1]
 
         if out is None:
-            out = self._splu.solve( rhs, trans='T' if transposed else 'N' )
+            out = self._splu.solve( rhs.T, trans='T' if transposed else 'N' ).T
 
         else:
             assert out.shape == rhs.shape
 
             # currently no in-place solve exposed
-            out[:] = self._splu.solve( rhs, trans='T' if transposed else 'N' )
+            out[:] = self._splu.solve( rhs.T, trans='T' if transposed else 'N' ).T
 
         return out
 

--- a/psydac/linalg/direct_solvers.py
+++ b/psydac/linalg/direct_solvers.py
@@ -76,8 +76,24 @@ class BandedSolver ( DirectSolver ):
 
     #...
     def solve( self, rhs, out=None, transposed=False ):
+        """
+        Solves for the given right-hand side.
 
-        assert rhs.shape[0] == self._bmat.shape[1]
+        Parameters
+        ----------
+        rhs : ndarray
+            The right-hand sides to solve for. The vectors are assumed to be given in C-contiguous order,
+            i.e. if multiple right-hand sides are given, then rhs is a two-dimensional array with the 0-th
+            index denoting the number of the right-hand side, and the 1-st index denoting the element inside
+            a right-hand side.
+        
+        out : ndarray | NoneType
+            Output vector. If given, it has to have the same shape and datatype as rhs.
+        
+        transposed : bool
+            If and only if set to true, we solve against the transposed matrix. (supported by the underlying solver)
+        """
+        assert rhs.T.shape[0] == self._bmat.shape[1]
 
         if out is None:
             preout, self._sinfo = dgbtrs(self._bmat, self._l, self._u, rhs.T, self._ipiv, trans=transposed)
@@ -85,6 +101,7 @@ class BandedSolver ( DirectSolver ):
 
         else :
             assert out.shape == rhs.shape
+            assert out.dtype == rhs.dtype
 
             # support in-place operations
             if rhs is not out:
@@ -124,14 +141,32 @@ class SparseSolver ( DirectSolver ):
 
     #...
     def solve( self, rhs, out=None, transposed=False ):
+        """
+        Solves for the given right-hand side.
 
-        assert rhs.shape[0] == self._splu.shape[1]
+        Parameters
+        ----------
+        rhs : ndarray
+            The right-hand sides to solve for. The vectors are assumed to be given in C-contiguous order,
+            i.e. if multiple right-hand sides are given, then rhs is a two-dimensional array with the 0-th
+            index denoting the number of the right-hand side, and the 1-st index denoting the element inside
+            a right-hand side.
+        
+        out : ndarray | NoneType
+            Output vector. If given, it has to have the same shape and datatype as rhs.
+        
+        transposed : bool
+            If and only if set to true, we solve against the transposed matrix. (supported by the underlying solver)
+        """
+        
+        assert rhs.T.shape[0] == self._splu.shape[1]
 
         if out is None:
             out = self._splu.solve( rhs.T, trans='T' if transposed else 'N' ).T
 
         else:
             assert out.shape == rhs.shape
+            assert out.dtype == rhs.dtype
 
             # currently no in-place solve exposed
             out[:] = self._splu.solve( rhs.T, trans='T' if transposed else 'N' ).T

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -44,10 +44,10 @@ class DistributedFFTBase(LinearOperator):
         
         def solve(self, rhs, out=None, transposed=False):
             if out is None:
-                out = np.empty_like(v)
+                out = np.empty_like(rhs)
             
-            if out is not v:
-                out[:] = v
+            if out is not rhs:
+                out[:] = rhs
             
             self._function(out)
 

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -142,10 +142,13 @@ class DistributedDCT(DistributedFFTBase):
     workers : Union[int, NoneType]
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dct parameter.
+    
+    ttype : int
+        The DCT type to use. (the name of this parameter in the underlying method is actually `type`).
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), ttype=2):
         super().__init__(space, lambda out: scifft.dct(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type))
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=ttype))
 
 class DistributedIDCT(DistributedFFTBase):
     """
@@ -164,10 +167,13 @@ class DistributedIDCT(DistributedFFTBase):
     workers : Union[int, NoneType]
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idct parameter.
+    
+    ttype : int
+        The DCT type to use. (the name of this parameter in the underlying method is actually `type`).
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), ttype=2):
         super().__init__(space, lambda out: scifft.idct(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type)) 
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=ttype)) 
 
 class DistributedDST(DistributedFFTBase):
     """
@@ -186,10 +192,13 @@ class DistributedDST(DistributedFFTBase):
     workers : Union[int, NoneType]
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dst parameter.
+    
+    ttype : int
+        The DCT type to use. (the name of this parameter in the underlying method is actually `type`).
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), ttype=2):
         super().__init__(space, lambda out: scifft.dst(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type))
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=ttype))
 
 class DistributedIDST(DistributedFFTBase):
     """
@@ -208,7 +217,10 @@ class DistributedIDST(DistributedFFTBase):
     workers : Union[int, NoneType]
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idst parameter.
+    
+    ttype : int
+        The DCT type to use. (the name of this parameter in the underlying method is actually `type`).
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), ttype=2):
         super().__init__(space, lambda out: scifft.idst(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type)) 
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=ttype)) 

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -91,7 +91,7 @@ class DistributedFFT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.fft parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         # only allow complex data types
         assert isinstance(space, StencilVectorSpace)
         assert np.dtype(space.dtype).kind == 'c'
@@ -117,7 +117,7 @@ class DistributedIFFT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.ifft parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         # only allow complex data types
         assert isinstance(space, StencilVectorSpace)
         assert np.dtype(space.dtype).kind == 'c'
@@ -143,7 +143,7 @@ class DistributedDCT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dct parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         super().__init__(space, lambda out: scifft.dct(
                 out, axis=1, overwrite_x=True, workers=workers, norm=norm))
 
@@ -165,7 +165,7 @@ class DistributedIDCT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idct parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         super().__init__(space, lambda out: scifft.idct(
                 out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 
 
@@ -187,7 +187,7 @@ class DistributedDST(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dst parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         super().__init__(space, lambda out: scifft.dst(
                 out, axis=1, overwrite_x=True, workers=workers, norm=norm))
 
@@ -209,6 +209,6 @@ class DistributedIDST(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idst parameter.
     """
-    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
         super().__init__(space, lambda out: scifft.idst(
                 out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -1,0 +1,214 @@
+from psydac.linalg.basic import LinearOperator, LinearSolver
+from psydac.linalg.stencil import StencilVectorSpace
+from psydac.linalg.kron import KroneckerLinearSolver
+
+import numpy as np
+import scipy.fft as scifft
+import os
+
+class DistributedFFTBase(LinearOperator):
+    """
+    A base class for the distributed FFT, DCT and DST.
+    Internally calls a KroneckerLinearSolver on a solver which just applies the FFT or some other function.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The vector space needed for the KroneckerLinearSolver internally.
+    
+    function : Callable
+        A callable function with one parameter x which applies some function in-place on x.
+    """
+
+    # Possible additions for the future:
+    # * split off the LinearSolver class when used with the space ndarray (as used in the KroneckerLinearSolver),
+    #   and make it state if it works in-place (or if it needs temporary memory), and what its optimal
+    #   size is (FFT might work faster with padding)
+    # * include FFTW support (e.g. pyfftw)
+
+    class OneDimSolver(LinearSolver):
+        """
+        A one-dimensional solver which just applies a given function.
+
+        Parameters
+        ----------
+        function : Callable
+            The given function.
+        """
+        def __init__(self, function):
+            self._function = function
+
+        @property
+        def space(self):
+            return np.ndarray
+        
+        def solve(self, v, out=None, transposed=False):
+            if out is None:
+                out = np.empty_like(v)
+            
+            if out is not v:
+                out[:] = v
+            
+            self._function(out)
+
+            return out
+
+    def __init__(self, space, function):
+        assert isinstance(space, StencilVectorSpace)
+        onedimsolver = DistributedFFTBase.OneDimSolver(function)
+        self._isolver = KroneckerLinearSolver(space, [onedimsolver] * space.ndim)
+    
+    @property
+    def domain(self):
+        return self._isolver.space
+    
+    @property
+    def codomain(self):
+        return self._isolver.space
+    
+    def dot(self, v, out=None):
+        # just call the KroneckerLinearSolver
+        return self._isolver.solve(v, out=out)
+
+# IMPORTANT NOTE: All of these scifft.fft functions currently trust that overwrite_x=True will yield an in-place fft...
+# (this is not completely given to hold forever, so in case these tests fail in some future version, change this)
+
+class DistributedFFT(DistributedFFTBase):
+    """
+    Equals an n-dimensional FFT operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.fft for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional FFT should be run on. Must have a complex data type (i.e. space.dtype.kind == 'c').
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.fft parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.fft parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        # only allow complex data types
+        assert isinstance(space, StencilVectorSpace)
+        assert np.dtype(space.dtype).kind == 'c'
+
+        super().__init__(space, lambda out: scifft.fft(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+
+class DistributedIFFT(DistributedFFTBase):
+    """
+    Equals an n-dimensional IFFT operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.ifft for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional IFFT should be run on. Must have a complex data type (i.e. space.dtype.kind == 'c').
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.ifft parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.ifft parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        # only allow complex data types
+        assert isinstance(space, StencilVectorSpace)
+        assert np.dtype(space.dtype).kind == 'c'
+        
+        super().__init__(space, lambda out: scifft.ifft(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+
+class DistributedDCT(DistributedFFTBase):
+    """
+    Equals an n-dimensional DCT operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.dct for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional DCT should be run on.
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.dct parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.dct parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        super().__init__(space, lambda out: scifft.dct(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+
+class DistributedIDCT(DistributedFFTBase):
+    """
+    Equals an n-dimensional IDCT operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.idct for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional IDCT should be run on.
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.idct parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.idct parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        super().__init__(space, lambda out: scifft.idct(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 
+
+class DistributedDST(DistributedFFTBase):
+    """
+    Equals an n-dimensional DST operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.dst for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional DST should be run on.
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.dst parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.dst parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        super().__init__(space, lambda out: scifft.dst(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+
+class DistributedIDST(DistributedFFTBase):
+    """
+    Equals an n-dimensional IDST operation, except that it works on a distributed/parallel StencilVector.
+
+    Internally calls scipy.fft.idst for each direction.
+
+    Parameters
+    ----------
+    space : StencilVectorSpace
+        The space the n-dimensional IDST should be run on.
+    
+    norm : str
+        Specifies the normalization factor. See the documentation of the corresponding scipy.fft.idst parameter.
+    
+    workers : Union[int, NoneType]
+        Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
+        See also the documentation of the corresponding scipy.fft.idst parameter.
+    """
+    def __init__(self, space, norm='backward', workers=os.environ.get('OMP_NUM_THREADS', None)):
+        super().__init__(space, lambda out: scifft.idst(
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -143,9 +143,9 @@ class DistributedDCT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dct parameter.
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
         super().__init__(space, lambda out: scifft.dct(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type))
 
 class DistributedIDCT(DistributedFFTBase):
     """
@@ -165,9 +165,9 @@ class DistributedIDCT(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idct parameter.
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
         super().__init__(space, lambda out: scifft.idct(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type)) 
 
 class DistributedDST(DistributedFFTBase):
     """
@@ -187,9 +187,9 @@ class DistributedDST(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.dst parameter.
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
         super().__init__(space, lambda out: scifft.dst(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm))
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type))
 
 class DistributedIDST(DistributedFFTBase):
     """
@@ -209,6 +209,6 @@ class DistributedIDST(DistributedFFTBase):
         Specifies the number of worker threads. By default set to the number of OpenMP threads, if given.
         See also the documentation of the corresponding scipy.fft.idst parameter.
     """
-    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None)):
+    def __init__(self, space, norm=None, workers=os.environ.get('OMP_NUM_THREADS', None), type=2):
         super().__init__(space, lambda out: scifft.idst(
-                out, axis=1, overwrite_x=True, workers=workers, norm=norm)) 
+                out, axis=1, overwrite_x=True, workers=workers, norm=norm, type=type)) 

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -16,8 +16,10 @@ class DistributedFFTBase(LinearOperator):
     space : StencilVectorSpace
         The vector space needed for the KroneckerLinearSolver internally.
     
-    function : Callable
-        A callable function with one parameter x which applies some function in-place on x.
+    function : callable | list/tuple of callables
+        A list/tuple of callables function, each with one parameter x which applies some function in-place on x.
+        The function at position i is applied to the i-th tensor direction.
+        If only a single callable is given, it is used for all directions.
     """
 
     # Possible additions for the future:

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -53,10 +53,14 @@ class DistributedFFTBase(LinearOperator):
 
             return out
 
-    def __init__(self, space, function):
+    def __init__(self, space, functions):
         assert isinstance(space, StencilVectorSpace)
-        onedimsolver = DistributedFFTBase.OneDimSolver(function)
-        self._isolver = KroneckerLinearSolver(space, [onedimsolver] * space.ndim)
+        if isinstance(functions, list) or isinstance(functions, tuple):
+            solvers = [DistributedFFTBase.OneDimSolver(function) for function in functions]
+        else:
+            onedimsolver = DistributedFFTBase.OneDimSolver(functions)
+            solvers = [onedimsolver] * space.ndim
+        self._isolver = KroneckerLinearSolver(space, solvers)
     
     @property
     def domain(self):

--- a/psydac/linalg/fft.py
+++ b/psydac/linalg/fft.py
@@ -42,7 +42,7 @@ class DistributedFFTBase(LinearOperator):
         def space(self):
             return np.ndarray
         
-        def solve(self, v, out=None, transposed=False):
+        def solve(self, rhs, out=None, transposed=False):
             if out is None:
                 out = np.empty_like(v)
             

--- a/psydac/linalg/kron.py
+++ b/psydac/linalg/kron.py
@@ -500,12 +500,8 @@ class KroneckerLinearSolver( LinearSolver ):
             view = workmem[:self._datasize]
             view.shape = (self._numrhs,self._dimrhs)
 
-            # the solvers want the FORTRAN-contiguous format
-            # (TODO: push this into the DirectSolver?)
-            view_T = view.transpose()
-
             # call solver in in-place mode
-            self._solver.solve(view_T, out=view_T, transposed=transposed)
+            self._solver.solve(view, out=view, transposed=transposed)
 
     class KroneckerSolverParallelPass:
         """
@@ -739,4 +735,3 @@ def kronecker_solve( solvers, rhs, out=None, transposed=False ):
 
     kronsolver = KroneckerLinearSolver(rhs.space, solvers)
     return kronsolver.solve(rhs, out=out, transposed=transposed)
-

--- a/psydac/linalg/kron.py
+++ b/psydac/linalg/kron.py
@@ -252,6 +252,7 @@ class KroneckerLinearSolver( LinearSolver ):
         self._space = V
         self._solvers = solvers
         self._parallel = self._space.parallel
+        self._dtype = self._space._dtype
         if self._parallel:
             self._mpi_type = V._mpi_type
         else:
@@ -340,13 +341,13 @@ class KroneckerLinearSolver( LinearSolver ):
         """
         Allocates all temporary data needed for the solve operation.
         """
-        temp1 = np.empty((self._tempsize,))
+        temp1 = np.empty((self._tempsize,), dtype=self._dtype)
         if self._ndim <= 1 and self._allserial:
             # if ndim==1 and we have no parallelism,
             # we can avoid allocating a second temp array
             temp2 = None
         else:
-            temp2 = np.empty((self._tempsize,))
+            temp2 = np.empty((self._tempsize,), dtype=self._dtype)
         return temp1, temp2
     
     @property

--- a/psydac/linalg/tests/test_fft.py
+++ b/psydac/linalg/tests/test_fft.py
@@ -1,0 +1,94 @@
+from psydac.linalg.fft import *
+from psydac.ddm.cart               import CartDecomposition
+from psydac.linalg.stencil import StencilVector
+
+import scipy.fft as scifft
+import numpy as np
+from mpi4py                     import MPI
+
+import pytest
+
+def decode_fft_type(ffttype):
+    if ffttype == 'fft':
+        return (complex, DistributedFFT, scifft.fftn)
+    elif ffttype == 'ifft':
+        return (complex, DistributedIFFT, scifft.ifftn)
+    elif ffttype == 'dct':
+        return (complex, DistributedDCT, scifft.dctn)
+    elif ffttype == 'idct':
+        return (complex, DistributedIDCT, scifft.idctn)
+    elif ffttype == 'dst':
+        return (complex, DistributedDST, scifft.dstn)
+    elif ffttype == 'idst':
+        return (complex, DistributedIDST, scifft.idstn)
+    else:
+        raise NotImplementedError()
+
+def method_test(seed, comm, config, dtype, classtype, comparison, verbose=False):
+    np.random.seed(seed)
+
+    if comm is None:
+        rank = -1
+    else:
+        rank = comm.Get_rank()
+    
+    npts, pads, periods = config
+
+    if verbose:
+        print(f'[{rank}] Test start', flush=True)
+
+    # vector spaces
+    if comm is None:
+        V = StencilVectorSpace(npts, pads, periods, dtype=dtype)
+    else:
+        cart = CartDecomposition(
+            npts    = npts,
+            pads    = pads,
+            periods = periods,
+            reorder = True,
+            comm    = comm
+        )
+        V = StencilVectorSpace(cart, dtype=dtype)
+    localslice = tuple([slice(s, e+1) for s, e in zip(V.starts, V.ends)])
+
+    if verbose:
+        print(f'[{rank}] Vector spaces built', flush=True)
+
+    if np.dtype(dtype).kind == 'c':
+        Y_glob = np.random.random(V.npts) + np.random.random(V.npts) * 1j
+    else:
+        Y_glob = np.random.random(V.npts)
+
+    # vector to solve for (Y)
+    Y = StencilVector(V)
+    Y[localslice] = Y_glob[localslice]
+    Y.update_ghost_regions()
+
+    if verbose:
+        print(f'[{rank}] Vector built', flush=True)
+    
+    X_glob = comparison(Y_glob)
+
+    compare = classtype(V)
+    X = compare.dot(Y)
+
+    if verbose:
+        print(f'[{rank}] Functions have been run', flush=True)
+
+    assert np.allclose(X_glob[localslice], X[localslice], 1e-10, 1e-10)
+
+@pytest.mark.parametrize( 'seed', [0, 2] )
+@pytest.mark.parametrize( 'params', [([8], [2], [False]), ([8,9], [2,3], [False,True]), ([8,9,17], [2,3,7], [False,True,False])] )
+@pytest.mark.parametrize( 'ffttype', ['fft', 'ifft', 'dct', 'idct', 'dst', 'idst'] )
+def test_kron_fft_ser(seed, params, ffttype):
+    method_test(seed, None, params, *decode_fft_type(ffttype), verbose=False)
+
+@pytest.mark.parametrize( 'seed', [0, 2] )
+@pytest.mark.parametrize( 'params', [([8], [2], [False]), ([8,9], [2,3], [False,True]), ([8,9,17], [2,3,7], [False,True,False])] )
+@pytest.mark.parametrize( 'ffttype', ['fft', 'ifft', 'dct', 'idct', 'dst', 'idst'] )
+@pytest.mark.parallel
+def test_kron_fft_par(seed, params, ffttype):
+    method_test(seed, MPI.COMM_WORLD, params, *decode_fft_type(ffttype), verbose=False)
+
+if __name__ == '__main__':
+    method_test(0, MPI.COMM_WORLD, ([8,9,5], [2,3,7], [False,True,False]), *decode_fft_type('fft'), verbose=True)

--- a/psydac/linalg/tests/test_kron_direct_solver.py
+++ b/psydac/linalg/tests/test_kron_direct_solver.py
@@ -153,7 +153,7 @@ def test_direct_solvers(seed, n, p, P, nrhs, direct_solver, transposed):
     solver = direct_solver(A)
 
     # vector to solve for (Y)
-    Y_glob = np.stack([random_vectordata(seed + i, [n]) for i in range(nrhs)], axis=0).T
+    Y_glob = np.stack([random_vectordata(seed + i, [n]) for i in range(nrhs)], axis=0)
 
     # ref solve
     preC = A.tosparse().tocsc()
@@ -163,17 +163,17 @@ def test_direct_solvers(seed, n, p, P, nrhs, direct_solver, transposed):
 
     C_op  = splu(C)
 
-    X_glob = C_op.solve(Y_glob)
+    X_glob = C_op.solve(Y_glob.T).T
 
     # new vector allocation
     X_glob2 = solver.solve(Y_glob, transposed=transposed)
 
     # solve with out vector
-    X_glob3 = Y_glob.T.copy().T
+    X_glob3 = Y_glob.copy()
     X_glob4 = solver.solve(Y_glob, out=X_glob3, transposed=transposed)
 
     # solve in-place
-    X_glob5 = Y_glob.T.copy().T
+    X_glob5 = Y_glob.copy()
     X_glob6 = solver.solve(X_glob5, out=X_glob5, transposed=transposed)
 
     # compare results


### PR DESCRIPTION
This PR adds some basic multi-dimensional FFT methods which work in a distributed environment (i.e. it enables us to compute `fftn`, `ifftn`, `dctn`, etc. in a distributed/parallel setting for `StencilVector`s).

* Implements FFT, DCT, DST, and all their inverse methods (for compatibility).
* Internally, it uses a `KroneckerLinearSolver` to do the FFT/DCT/DST in each direction. Currently, it uses `scipy.fft` without additional padding for the one-dimensional FFTs; the normalization and worker parameters are forwarded to the methods. (future optimization, like padding, FFTW support, slab distribution or support for `mpi4py_fft` etc. are subject of future PRs)
* To support all this, we also propagated the `StencilVectorSpace.dtype` to the datatype of the temporary arrays.
* Includes basic tests.