### PR TITLE
Propagate the `quad_order` parameter in the space discretization

### DIFF
--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -134,6 +134,7 @@ def discretize_space(V, domain_h, *args, **kwargs):
     ldim                = V.ldim
     periodic            = kwargs.pop('periodic', [False]*ldim)
     basis               = kwargs.pop('basis', 'B')
+    quad_order          = kwargs.pop('quad_order', None)
     is_rational_mapping = False
 
     # from a discrete geoemtry
@@ -214,12 +215,12 @@ def discretize_space(V, domain_h, *args, **kwargs):
                         nprocs = None
                         if comm is not None:
                             nprocs = g_spaces[interiors[index]].vector_space.cart.nprocs
-                        Vh = TensorFemSpace( *spaces, comm=comm, nprocs=nprocs, reverse_axis=e.axis)
+                        Vh = TensorFemSpace( *spaces, comm=comm, quad_order=quad_order, nprocs=nprocs, reverse_axis=e.axis)
                         break
                 else:
-                    Vh = TensorFemSpace( *spaces, comm=comm)
+                    Vh = TensorFemSpace( *spaces, comm=comm, quad_order=quad_order)
             else:
-                Vh = TensorFemSpace( *spaces, comm=comm)
+                Vh = TensorFemSpace( *spaces, comm=comm, quad_order=quad_order)
 
             if Vh is None:
                 raise ValueError('Unable to discretize the space')

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -154,10 +154,11 @@ class DiscreteBilinearForm(BasicDiscrete):
         kwargs['mapping']             = self.spaces[0].symbolic_mapping
         kwargs['is_rational_mapping'] = is_rational_mapping
         kwargs['comm']                = domain_h.comm
-        quad_order                    = kwargs.pop('quad_order', get_quad_order(self.spaces[1]))
+        space_quad_order = [qo - 1 for qo in get_quad_order(self.spaces[1])]
+        quad_order       = [qo + 1 for qo in kwargs.pop('quad_order', space_quad_order)]
 
         # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert quad_order == get_quad_order(self.spaces[1])
+        assert np.array_equal(quad_order, get_quad_order(self.spaces[1]))
 
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 
@@ -445,10 +446,12 @@ class DiscreteLinearForm(BasicDiscrete):
         kwargs['mapping']             = self.space.symbolic_mapping
         kwargs['is_rational_mapping'] = is_rational_mapping
         kwargs['comm']                = domain_h.comm
-        quad_order                    = kwargs.pop('quad_order', get_quad_order(self.space))
+
+        space_quad_order = [qo - 1 for qo in get_quad_order(self.space)]
+        quad_order       = [qo + 1 for qo in kwargs.pop('quad_order', space_quad_order)]
 
         # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert quad_order == get_quad_order(self.space)
+        assert np.array_equal(quad_order, get_quad_order(self.space))
 
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 
@@ -680,10 +683,12 @@ class DiscreteFunctional(BasicDiscrete):
         kwargs['mapping']             = self.space.symbolic_mapping
         kwargs['is_rational_mapping'] = is_rational_mapping
         kwargs['comm']                = domain_h.comm
-        quad_order                    = kwargs.pop('quad_order', get_quad_order(self.space))
+
+        space_quad_order = [qo - 1 for qo in get_quad_order(self.space)]
+        quad_order       = [qo + 1 for qo in kwargs.pop('quad_order', space_quad_order)]
 
         # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert quad_order == get_quad_order(self.space)
+        assert np.array_equal(quad_order, get_quad_order(self.space))
 
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -156,6 +156,9 @@ class DiscreteBilinearForm(BasicDiscrete):
         kwargs['comm']                = domain_h.comm
         quad_order                    = kwargs.pop('quad_order', get_quad_order(self.spaces[1]))
 
+        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
+        assert quad_order == get_quad_order(self.spaces[1])
+
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 
         # ...
@@ -444,6 +447,9 @@ class DiscreteLinearForm(BasicDiscrete):
         kwargs['comm']                = domain_h.comm
         quad_order                    = kwargs.pop('quad_order', get_quad_order(self.space))
 
+        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
+        assert quad_order == get_quad_order(self.space)
+
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 
         # ...
@@ -675,6 +681,9 @@ class DiscreteFunctional(BasicDiscrete):
         kwargs['is_rational_mapping'] = is_rational_mapping
         kwargs['comm']                = domain_h.comm
         quad_order                    = kwargs.pop('quad_order', get_quad_order(self.space))
+
+        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
+        assert quad_order == get_quad_order(self.space)
 
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
 

--- a/psydac/api/tests/test_quadorder.py
+++ b/psydac/api/tests/test_quadorder.py
@@ -1,0 +1,45 @@
+import pytest
+
+from sympde.topology import Line, Square
+from sympde.topology import ScalarFunctionSpace
+from sympde.topology import element_of
+from sympde.core     import Constant
+from sympde.expr     import BilinearForm
+from sympde.expr     import LinearForm
+from sympde.expr     import integral
+
+import numpy as np
+
+from psydac.api.discretization import discretize
+from psydac.api.settings       import PSYDAC_BACKEND_PYTHON
+
+#==============================================================================
+@pytest.mark.parametrize( 'test_quad_order', [(3,3), (4,4), (5,3)] )
+def test_custom_quad_order(test_quad_order):
+
+    # If 'backend' is specified, accelerate Python code by passing **kwargs
+    # to discretization of bilinear forms, linear forms and functionals.
+
+    domain = Square()
+    V = ScalarFunctionSpace('V', domain)
+    u = element_of(V, name='u')
+    v = element_of(V, name='v')
+    c = Constant(name='c')
+
+    a = BilinearForm((u, v), integral(domain, u * v))
+    l = LinearForm(v, integral(domain, v))
+
+    ncells = (12, 12)
+    degree = (2, 2)
+
+    domain_h = discretize(domain, ncells=ncells)
+
+    # TODO for future (once fixed/solved): remove the quad_order=(10,10) here again
+    Vh = discretize(V, domain_h, degree=degree, quad_order=test_quad_order)
+
+    # NOTE: we _need_ the Python backend here for range checking, otherwise we'd only get segfaults at best
+    _ = discretize(a, domain_h, [Vh, Vh], quad_order=test_quad_order, backend=PSYDAC_BACKEND_PYTHON).assemble()
+    _ = discretize(l, domain_h,      Vh , quad_order=test_quad_order, backend=PSYDAC_BACKEND_PYTHON).assemble()
+
+    for space in Vh.spaces:
+        assert np.array_equal(space.quad_order, test_quad_order)

--- a/psydac/api/tests/test_quadorder.py
+++ b/psydac/api/tests/test_quadorder.py
@@ -41,5 +41,4 @@ def test_custom_quad_order(test_quad_order):
     _ = discretize(a, domain_h, [Vh, Vh], quad_order=test_quad_order, backend=PSYDAC_BACKEND_PYTHON).assemble()
     _ = discretize(l, domain_h,      Vh , quad_order=test_quad_order, backend=PSYDAC_BACKEND_PYTHON).assemble()
 
-    for space in Vh.spaces:
-        assert np.array_equal(space.quad_order, test_quad_order)
+    assert np.array_equal(Vh.quad_order, test_quad_order)

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -36,7 +36,8 @@ class TensorFemSpace( FemSpace ):
         self._spaces = tuple(args)
 
         npts    = [V.nbasis   for V in self.spaces]
-        pads    = [V.degree   for V in self.spaces]
+        pads    = [V._pads    for V in self.spaces]
+        degree  = [V.degree   for V in self.spaces]
         periods = [V.periodic for V in self.spaces]
         basis   = [V.basis    for V in self.spaces]
 
@@ -71,9 +72,11 @@ class TensorFemSpace( FemSpace ):
         # Shortcut
         v = self._vector_space
 
+        self._quad_order = kwargs.pop('quad_order', [sp.degree for sp in self.spaces])
+
         # Compute extended 1D quadrature grids (local to process) along each direction
-        self._quad_grids = tuple( FemAssemblyGrid( V,s,e, nderiv=V.degree)
-                                  for V,s,e in zip( self.spaces, v.starts, v.ends ) )
+        self._quad_grids = tuple( FemAssemblyGrid( V,s,e, nderiv=V.degree, pad=p, quad_order=q)
+                                  for V,s,e,p,q in zip( self.spaces, v.starts, v.ends, v.pads, self._quad_order ) )
 
         # Determine portion of logical domain local to process
         self._element_starts = tuple( g.indices[g.local_element_start] for g in self.quad_grids )
@@ -344,6 +347,10 @@ class TensorFemSpace( FemSpace ):
     @property
     def spaces( self ):
         return self._spaces
+    
+    @property
+    def quad_order( self ):
+        return self._quad_order
 
     @property
     def quad_grids( self ):
@@ -503,7 +510,7 @@ class TensorFemSpace( FemSpace ):
                 global_starts[axis][0] = 0
 
         cart = v._cart.reduce_grid(global_starts, global_ends)
-        V    = TensorFemSpace(*spaces, cart=cart)
+        V    = TensorFemSpace(*spaces, cart=cart, quad_order=self._quad_order)
         return V
 
     # ...
@@ -611,31 +618,11 @@ class TensorFemSpace( FemSpace ):
         periods = [V.periodic for V in spaces]
         # create new Tensor Vector
         if v.cart:
-
-            tensor_vec = TensorFemSpace(*spaces, comm=v.cart.comm)
             red_cart = v.cart.remove_last_element(axes)
-            v = StencilVectorSpace(red_cart)
-            tensor_vec._vector_space = v
+            tensor_vec = TensorFemSpace(*spaces, cart=red_cart, quad_order=self._quad_order)
         else:
-            tensor_vec = TensorFemSpace(*spaces)
-            v = self._vector_space
-            tensor_vec._vector_space = StencilVectorSpace(npts, v.pads, v.periods)
-            v = tensor_vec._vector_space
-
-        tensor_vec._spaces = tuple(spaces)
-
-       # Compute extended 1D quadrature grids (local to process) along each direction
-       
-        tensor_vec._quad_grids = tuple( FemAssemblyGrid( V,s,e,quad_order=q, pad=q )
-                                  for V,s,e,q in zip( spaces, v.starts, v.ends, self.degree ) )
-
-        tensor_vec._element_starts, tensor_vec._element_ends =  self._element_starts, self._element_ends
-
-        # Compute limits of eta_0, eta_1, eta_2, etc... in subdomain local to process
-        tensor_vec._eta_limits = tuple( (space.breaks[s], space.breaks[e+1])
-        for s,e,space in zip( self._element_starts, self._element_ends, spaces ) )
-
-        # Store flag: object NOT YET prepared for interpolation
+            tensor_vec = TensorFemSpace(*spaces, quad_order=self._quad_order)
+        
         tensor_vec._interpolation_ready = False
 
         return tensor_vec

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -607,7 +607,7 @@ class TensorFemSpace( FemSpace ):
             space = spaces[axis]
             reduced_space = SplineSpace(
                 degree    = space.degree - 1,
-                pads      = space.degree,
+                pads      = space._pads,
                 grid      = space.breaks,
                 periodic  = space.periodic,
                 dirichlet = space.dirichlet,
@@ -615,9 +615,6 @@ class TensorFemSpace( FemSpace ):
             )
             spaces[axis] = reduced_space
 
-        npts = [V.nbasis for V in spaces]
-        pads = v.pads
-        periods = [V.periodic for V in spaces]
         # create new Tensor Vector
         if v.cart:
             red_cart = v.cart.remove_last_element(axes)

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -72,7 +72,9 @@ class TensorFemSpace( FemSpace ):
         # Shortcut
         v = self._vector_space
 
-        self._quad_order = kwargs.pop('quad_order', [sp.degree for sp in self.spaces])
+        self._quad_order = kwargs.pop('quad_order', None)
+        if self._quad_order is None:
+            self._quad_order = [sp.degree for sp in self.spaces]
 
         # Compute extended 1D quadrature grids (local to process) along each direction
         self._quad_grids = tuple( FemAssemblyGrid( V,s,e, nderiv=V.degree, pad=p, quad_order=q)


### PR DESCRIPTION
This PR fixes a bug which could cause segmentation faults / out of bounds errors (depending on the backend used) when using the `quad_order` parameter with the `discretize` method.

* Discretization to a `TensorFEMSpace` now properly processes the `quad_order` parameter.
* (Bi)linear forms etc. need to have the same `quad_order` for now, as they use the underlying `TensorFEMSpace` quadrature grids. (allowing deviations here, e.g. by generating new quadrature grids on-demand may be done in a future PR) If we inserted a larger `quad_order` than there would be given to the space, we would get an out of bounds error (or segfault when compiling with pyccel; or just incorrect results), and if we chose a too small `quad_order` here, we would only use some quadrature points from the larger quadrature grid.
* Includes tests.