### PR TITLE
Fix distributed/parallel spline assembly when using DeRham complexes

### DIFF
--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -553,7 +553,9 @@ def test_maxwell_1d_periodic_par():
     assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
     assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
 
+# TODO: remove xfail after bug is fixed
 @pytest.mark.parallel
+@pytest.mark.xfail
 def test_maxwell_1d_dirichlet_strong_par():
 
     namespace = run_maxwell_1d(
@@ -577,9 +579,8 @@ def test_maxwell_1d_dirichlet_strong_par():
     ref = dict(error_E = 1.320471502738063e-03,
                error_B = 7.453774187340390e-04)
 
-    # TODO: re-enable once fixed
-    #assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
-    #assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
+    assert abs(namespace['error_E'] - ref['error_E']) / ref['error_E'] <= TOL
+    assert abs(namespace['error_B'] - ref['error_B']) / ref['error_B'] <= TOL
 
 @pytest.mark.parallel
 def test_maxwell_1d_dirichlet_penalization_par():

--- a/psydac/fem/grid.py
+++ b/psydac/fem/grid.py
@@ -89,47 +89,37 @@ class FemAssemblyGrid:
         indices = []
         ne      = 0
 
+        if pad==degree:
+            current_glob_spans  = glob_spans
+        elif pad-degree == 1:
+            elevated_T          = elevate_knots(T, degree, True)
+            current_glob_spans  = elements_spans( elevated_T, pad )
+        else:
+            raise NotImplementedError('TODO')
+
         # a) Periodic case only, left-most process in 1D domain
         if space.periodic:
-
-            if degree<pad:
-                if pad-degree == 1:
-                    elevated_T          = elevate_knots(T, degree, True)
-                    elevated_glob_spans = elements_spans( elevated_T, pad )
-                else:
-                    raise NotImplementedError('TODO')
-
-                for k in range( nc ):
-                    gk = elevated_glob_spans[k]
-                    if start <= gk-n and gk-n-pad <= end:
-                        spans  .append( glob_spans[k]-n )
-                        basis  .append( glob_basis  [k] )
-                        points .append( glob_points [k] )
-                        weights.append( glob_weights[k] )
-                        indices.append( k )
-                        ne += 1
-            else:
-                for k in range( nc ):
-                    gk = glob_spans[k]
-                    if start <= gk-n and gk-n-degree <= end:
-                        spans  .append( glob_spans[k]-n )
-                        basis  .append( glob_basis  [k] )
-                        points .append( glob_points [k] )
-                        weights.append( glob_weights[k] )
-                        indices.append( k )
-                        ne += 1
-
+            for k in range( nc ):
+                gk = current_glob_spans[k]
+                if start <= gk-n and gk-n-pad <= end:
+                    spans  .append( glob_spans[k]-n )
+                    basis  .append( glob_basis  [k] )
+                    points .append( glob_points [k] )
+                    weights.append( glob_weights[k] )
+                    indices.append( k )
+                    ne += 1
+        
         # b) All cases
         for k in range( nc ):
-            gk = glob_spans[k]
-            if start <= gk and gk-degree <= end:
+            gk = current_glob_spans[k]
+            if start <= gk and gk-pad <= end:
                 spans  .append( glob_spans  [k] )
                 basis  .append( glob_basis  [k] )
                 points .append( glob_points [k] )
                 weights.append( glob_weights[k] )
                 indices.append( k )
                 ne += 1
-
+        
         #-------------------------------------------
         # DATA STORAGE IN OBJECT
         #-------------------------------------------

--- a/psydac/fem/grid.py
+++ b/psydac/fem/grid.py
@@ -144,8 +144,14 @@ class FemAssemblyGrid:
             local_element_start = self._spans.searchsorted( degree + start )
             local_element_end   = self._spans.searchsorted( degree + end   )
         else:
-            local_element_start = self._spans.searchsorted( degree if start == 0   else 1 + start)
-            local_element_end   = self._spans.searchsorted( end if end   == n-1 else 1 + end )
+            if end+1 >= degree:
+                local_element_start = self._spans.searchsorted( degree if start == 0   else 1 + start)
+                local_element_end   = self._spans.searchsorted( end if end   == n-1 else 1 + end )
+            else:
+                # in this edge case: no local elements for now
+                local_element_start = 1
+                local_element_end = 0
+                
 
         # Local index of start/end elements of domain partitioning
         self._local_element_start = local_element_start

--- a/psydac/fem/grid.py
+++ b/psydac/fem/grid.py
@@ -45,7 +45,7 @@ class FemAssemblyGrid:
         points (default: 1).
 
     """
-    def __init__( self, space, start, end, *, quad_order=None, nderiv=1 , pad=None):
+    def __init__( self, space, start, end, *, quad_order=None, nderiv=1 ):
 
         T      = space.knots           # knots sequence
         degree = space.degree          # spline degree
@@ -53,7 +53,7 @@ class FemAssemblyGrid:
         grid   = space.breaks          # breakpoints
         nc     = space.ncells          # number of cells in domain (nc=len(grid)-1)
         k      = quad_order or degree  # polynomial order for which the mass matrix is exact
-        pad    = pad or degree         # padding to add in the periodic case
+        pad    = space.pads            # padding to add
 
         # Gauss-legendre quadrature rule
         u, w = gauss_legendre( k )
@@ -92,7 +92,7 @@ class FemAssemblyGrid:
         if pad==degree:
             current_glob_spans  = glob_spans
         elif pad-degree == 1:
-            elevated_T          = elevate_knots(T, degree, True)
+            elevated_T          = elevate_knots(T, degree, space.periodic)
             current_glob_spans  = elements_spans( elevated_T, pad )
         else:
             raise NotImplementedError('TODO')

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -207,6 +207,12 @@ class SplineSpace( FemSpace ):
         """ True if domain is periodic, False otherwise.
         """
         return self._periodic
+    
+    @property
+    def pads( self ):
+        """ Padding for potential parallel assembly.
+        """
+        return self._pads
 
     @property
     def mapping( self ):

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -159,21 +159,7 @@ class TensorFemSpace( FemSpace ):
         if not field.coeffs.ghost_regions_in_sync:
             field.coeffs.update_ghost_regions()
 
-        skip = False
         for (x, xlim, space) in zip( eta, self.eta_lims, self.spaces ):
-
-            domain = space.domain
-
-            if space.periodic:
-                while domain[0] > x:
-                    x += domain[1] - domain[0]
-                while domain[1] <= x:
-                    x -= domain[1] - domain[0]
-            
-            corner = domain[1] == xlim[1] and domain[1] == x
-            if (x >= xlim[1] or x < xlim[0]) and not(corner and not space.periodic):
-                skip = True
-                break
 
             knots  = space.knots
             degree = space.degree
@@ -193,44 +179,39 @@ class TensorFemSpace( FemSpace ):
             # If needed, rescale B-splines to get M-splines
             if space.basis == 'M':
                 basis *= space.scaling_array[span-degree : span+1]
-            
+
+            # Determine local span
+            wrap_x   = space.periodic and x > xlim[1]
+            loc_span = span - space.nbasis if wrap_x else span
+
             bases.append( basis )
-            index.append( slice( span-degree, span+1 ) )
+            index.append( slice( loc_span-degree, loc_span+1 ) )
 
-        if skip:
-            res = -np.inf
-        else:
-            # Get contiguous copy of the spline coefficients required for evaluation
-            index  = tuple( index )
-            coeffs = field.coeffs[index].copy()
+        # Get contiguous copy of the spline coefficients required for evaluation
+        index  = tuple( index )
+        coeffs = field.coeffs[index].copy()
+        if weights:
+            coeffs *= weights[index]
 
-            if weights:
-                coeffs *= weights[index]
+        # Evaluation of multi-dimensional spline
+        # TODO: optimize
 
-            # Evaluation of multi-dimensional spline
-            # TODO: optimize
-            # Option 1: contract indices one by one and store intermediate results
-            #   - Pros: small number of Python iterations = ldim
-            #   - Cons: we create ldim-1 temporary objects of decreasing size
-            #
-            res = coeffs
-            for basis in bases[::-1]:
-                # print(f'{self.vector_space.cart.comm.rank} {eta} {res.shape} {basis.shape}')
-                res = np.tensordot( res, basis, axes=((-1,),(0,)) )
+        # Option 1: contract indices one by one and store intermediate results
+        #   - Pros: small number of Python iterations = ldim
+        #   - Cons: we create ldim-1 temporary objects of decreasing size
+        #
+        res = coeffs
+        for basis in bases[::-1]:
+            res = np.dot( res, basis )
 
-    #        # Option 2: cycle over each element of 'coeffs' (touched only once)
-    #        #   - Pros: no temporary objects are created
-    #        #   - Cons: large number of Python iterations = number of elements in 'coeffs'
-    #        #
-    #        res = 0.0
-    #        for idx,c in np.ndenumerate( coeffs ):
-    #            ndbasis = np.prod( [b[i] for i,b in zip( idx, bases )] )
-    #            res    += c * ndbasis
-
-        if self.vector_space.parallel:
-            # only on one rank, skip should be false
-            mpi_comm = self.vector_space.cart.comm
-            res = mpi_comm.allreduce( res, MPI.MAX )
+#        # Option 2: cycle over each element of 'coeffs' (touched only once)
+#        #   - Pros: no temporary objects are created
+#        #   - Cons: large number of Python iterations = number of elements in 'coeffs'
+#        #
+#        res = 0.0
+#        for idx,c in np.ndenumerate( coeffs ):
+#            ndbasis = np.prod( [b[i] for i,b in zip( idx, bases )] )
+#            res    += c * ndbasis
 
         return res
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -154,7 +154,21 @@ class TensorFemSpace( FemSpace ):
         if not field.coeffs.ghost_regions_in_sync:
             field.coeffs.update_ghost_regions()
 
+        skip = False
         for (x, xlim, space) in zip( eta, self.eta_lims, self.spaces ):
+
+            domain = space.domain
+
+            if space.periodic:
+                while domain[0] > x:
+                    x += domain[1] - domain[0]
+                while domain[1] <= x:
+                    x -= domain[1] - domain[0]
+            
+            corner = domain[1] == xlim[1] and domain[1] == x
+            if (x >= xlim[1] or x < xlim[0]) and not(corner and not space.periodic):
+                skip = True
+                break
 
             knots  = space.knots
             degree = space.degree
@@ -174,39 +188,44 @@ class TensorFemSpace( FemSpace ):
             # If needed, rescale B-splines to get M-splines
             if space.basis == 'M':
                 basis *= space.scaling_array[span-degree : span+1]
-
-            # Determine local span
-            wrap_x   = space.periodic and x > xlim[1]
-            loc_span = span - space.nbasis if wrap_x else span
-
+            
             bases.append( basis )
-            index.append( slice( loc_span-degree, loc_span+1 ) )
+            index.append( slice( span-degree, span+1 ) )
 
-        # Get contiguous copy of the spline coefficients required for evaluation
-        index  = tuple( index )
-        coeffs = field.coeffs[index].copy()
-        if weights:
-            coeffs *= weights[index]
+        if skip:
+            res = -np.inf
+        else:
+            # Get contiguous copy of the spline coefficients required for evaluation
+            index  = tuple( index )
+            coeffs = field.coeffs[index].copy()
 
-        # Evaluation of multi-dimensional spline
-        # TODO: optimize
+            if weights:
+                coeffs *= weights[index]
 
-        # Option 1: contract indices one by one and store intermediate results
-        #   - Pros: small number of Python iterations = ldim
-        #   - Cons: we create ldim-1 temporary objects of decreasing size
-        #
-        res = coeffs
-        for basis in bases[::-1]:
-            res = np.dot( res, basis )
+            # Evaluation of multi-dimensional spline
+            # TODO: optimize
+            # Option 1: contract indices one by one and store intermediate results
+            #   - Pros: small number of Python iterations = ldim
+            #   - Cons: we create ldim-1 temporary objects of decreasing size
+            #
+            res = coeffs
+            for basis in bases[::-1]:
+                # print(f'{self.vector_space.cart.comm.rank} {eta} {res.shape} {basis.shape}')
+                res = np.tensordot( res, basis, axes=((-1,),(0,)) )
 
-#        # Option 2: cycle over each element of 'coeffs' (touched only once)
-#        #   - Pros: no temporary objects are created
-#        #   - Cons: large number of Python iterations = number of elements in 'coeffs'
-#        #
-#        res = 0.0
-#        for idx,c in np.ndenumerate( coeffs ):
-#            ndbasis = np.prod( [b[i] for i,b in zip( idx, bases )] )
-#            res    += c * ndbasis
+    #        # Option 2: cycle over each element of 'coeffs' (touched only once)
+    #        #   - Pros: no temporary objects are created
+    #        #   - Cons: large number of Python iterations = number of elements in 'coeffs'
+    #        #
+    #        res = 0.0
+    #        for idx,c in np.ndenumerate( coeffs ):
+    #            ndbasis = np.prod( [b[i] for i,b in zip( idx, bases )] )
+    #            res    += c * ndbasis
+
+        if self.vector_space.parallel:
+            # only on one rank, skip should be false
+            mpi_comm = self.vector_space.cart.comm
+            res = mpi_comm.allreduce( res, MPI.MAX )
 
         return res
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -626,7 +626,7 @@ class TensorFemSpace( FemSpace ):
 
        # Compute extended 1D quadrature grids (local to process) along each direction
        
-        tensor_vec._quad_grids = tuple( FemAssemblyGrid( V,s,e,quad_order=q, pad=q )
+        tensor_vec._quad_grids = tuple( FemAssemblyGrid( V,s,e,quad_order=q )
                                   for V,s,e,q in zip( spaces, v.starts, v.ends, self.degree ) )
 
         tensor_vec._element_starts, tensor_vec._element_ends =  self._element_starts, self._element_ends

--- a/psydac/fem/tests/test_grid_decomposition.py
+++ b/psydac/fem/tests/test_grid_decomposition.py
@@ -33,9 +33,11 @@ def test_grid_decomposition(periodic, degree, pad, localsizes, gridcnt=100):
         assert np.array_equal(grid.indices, [(i+n)%n for i in range(realstart, end+1)])
 
         # some more assertions
-        assert np.array_equal(grid.indices, (grid.spans - degree + n) % n)
-        assert grid.num_elements == end+1 - realstart
 
+        # in case this should fail due to a changed spline structure, feel free to remove it
+        assert np.array_equal(grid.indices, (grid.spans - degree + n) % n)
+
+        assert grid.num_elements == end+1 - realstart
         total += [grid.indices[i] for i in range(grid.local_element_start, grid.local_element_end+1)]
 
         start = end + 1
@@ -45,7 +47,7 @@ def test_grid_decomposition(periodic, degree, pad, localsizes, gridcnt=100):
         elem_num = gridcnt
     else:
         elem_num = gridcnt - degree + 1
-    print(total)
+    
     assert np.array_equal(sorted(total), [i for i in range(elem_num)])
 
 if __name__ == '__main__':

--- a/psydac/fem/tests/test_grid_decomposition.py
+++ b/psydac/fem/tests/test_grid_decomposition.py
@@ -32,7 +32,9 @@ def test_grid_decomposition(periodic, degree, pad, localsizes, gridcnt=100):
         assert len(grid.indices) == size + offset
         assert np.array_equal(grid.indices, [(i+n)%n for i in range(realstart, end+1)])
 
+        # some more assertions
         assert np.array_equal(grid.indices, (grid.spans - degree + n) % n)
+        assert grid.num_elements == end+1 - realstart
 
         total += [grid.indices[i] for i in range(grid.local_element_start, grid.local_element_end+1)]
 
@@ -43,7 +45,7 @@ def test_grid_decomposition(periodic, degree, pad, localsizes, gridcnt=100):
         elem_num = gridcnt
     else:
         elem_num = gridcnt - degree + 1
-    
+    print(total)
     assert np.array_equal(sorted(total), [i for i in range(elem_num)])
 
 if __name__ == '__main__':

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -580,11 +580,11 @@ class StencilMatrix( Matrix ):
         self._ndim     = len( dims )
 
         # Parallel attributes
-        if V.parallel:
+        if W.parallel:
             # Create data exchanger for ghost regions
             self._synchronizer = CartDataExchanger(
-                cart        = V.cart,
-                dtype       = V.dtype,
+                cart        = W.cart,
+                dtype       = W.dtype,
                 coeff_shape = diags
             )
 


### PR DESCRIPTION
This PR fixes a bug in relation to the `FemAssemblyGrid` when `pad` does not equal `degree`. Previously, there seemed to be some discrepancies on multiple processes (except for the first one) at least on a periodic grid which caused a segmentation fault or an out of bounds error in the kernel, depending on if pyccel was used or not. Now, the spans are elevated on all processes, if `pad==degree+1`. (i.e. the padding parameter is used instead of the degree parameter) Henceforth, this PR does:

* Make DeRham work in parallel;
* Take the pad parameter directly from the `SplineSpace`;
* (sort of) fix `local_element_start` and `local_element_end` in the corner cases, where `end < degree`;
* Include small tests;
* Add parallel unit tests to files `test_api_feec_1d.py` and `test_api_feec_2d.py`, with check on L2 error norm.