### PR TITLE
Make assembly algorithm and dot product faster

### DIFF
--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -633,12 +633,13 @@ def _create_ast_bilinear_form(terminal_expr, atomic_expr_field,
                 stmts = Block(body)
                 g_stmts += [stmts]
 
-                ln = Tuple(*[d-1 for d in tests_degree[sub_tests[0]]])
-                start_expr =  TensorMax(TensorMul(TensorAdd(TensorMul(ind_element, Tuple(*[-1]*dim)), ln), Tuple(*b0s)),Tuple(*[S.Zero]*dim))
-                start_expr = TensorAssignExpr(Tuple(*bs[sub_tests[0]]), start_expr)
-                end_expr = TensorMax(TensorMul(TensorAdd(TensorMul(Tuple(*[-1]*dim), ind_element.length), TensorAdd(ind_element, Tuple(*tests_degree[sub_tests[0]]))), Tuple(*e0s)), Tuple(*[S.Zero]*dim))
-                end_expr = TensorAssignExpr(Tuple(*es[sub_tests[0]]), end_expr)
-                g_stmts_texpr += [start_expr, end_expr]
+                if is_parallel:
+                    ln = Tuple(*[d-1 for d in tests_degree[sub_tests[0]]])
+                    start_expr =  TensorMax(TensorMul(TensorAdd(TensorMul(ind_element, Tuple(*[-1]*dim)), ln), Tuple(*b0s)),Tuple(*[S.Zero]*dim))
+                    start_expr = TensorAssignExpr(Tuple(*bs[sub_tests[0]]), start_expr)
+                    end_expr = TensorMax(TensorMul(TensorAdd(TensorMul(Tuple(*[-1]*dim), ind_element.length), TensorAdd(ind_element, Tuple(*tests_degree[sub_tests[0]]))), Tuple(*e0s)), Tuple(*[S.Zero]*dim))
+                    end_expr = TensorAssignExpr(Tuple(*es[sub_tests[0]]), end_expr)
+                    g_stmts_texpr += [start_expr, end_expr]
 
             else:
                 l_stmts = []

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -536,8 +536,8 @@ def _create_ast_bilinear_form(terminal_expr, atomic_expr_field,
     pads      = variables(('pad1, pad2, pad3'), dtype='int')[:dim]
     b0s       = variables(('b01, b02, b03'), dtype='int')[:dim]
     e0s       = variables(('e01, e02, e03'), dtype='int')[:dim]
-    g_quad     = GlobalTensorQuadrature(False)
-    l_quad     = LocalTensorQuadrature(False)
+    g_quad    = GlobalTensorQuadrature(False)
+    l_quad    = LocalTensorQuadrature(False)
 
     quad_order    = kwargs.pop('quad_order', None)
 

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -377,6 +377,7 @@ class AST(object):
         if mapping_space:
             f         = (tests+trials+fields)[0]
             f         = f.duplicate('mapping_'+f.name)
+            f         = expand([f])[0]
             mapping_degrees      = get_degrees([f], mapping_space)
             multiplicity_mapping = get_multiplicity([f], mapping_space.vector_space)
             d_mapping = {f: {'global': GlobalTensorQuadratureTestBasis (f),

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from mpi4py    import MPI
 
 from sympy import Mul, Tuple
-from sympy import Mod, Abs, Range, Symbol, Max
+from sympy import Mod as sy_Mod, Abs, Range, Symbol, Max
 from sympy import Function, Integer
 
 from psydac.pyccel.ast.core import Variable, IndexedVariable
@@ -52,6 +52,12 @@ def compute_diag_len(p, md, mc, return_padding=False):
         return n.astype('int'), (-ep).astype('int')
     else:
         return n.astype('int')
+
+def Mod(a,b):
+    if b == 1:
+        return Integer(0)
+    else:
+        return sy_Mod(a,b)
 
 @lru_cache(maxsize=32)
 class LinearOperatorDot(SplBasic):

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -157,7 +157,7 @@ class IndexNode(Expr):
     def length(self):
         return self._length
 
-    def set_range(self, start=TensorInteger(1), stop=None, length=None):
+    def set_range(self, start=TensorInteger(0), stop=None, length=None):
         if length is None:
             length = stop
         obj = type(self)(start=start, stop=stop, length=length)

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -1734,7 +1734,7 @@ def construct_itergener(a, index):
 
     elif isinstance(a, LocalTensorQuadrature):
         generator = TensorGenerator(a, index)
-        element   = TensorQuadrature()
+        element   = TensorQuadrature(a.weights)
 
     elif isinstance(a, GlobalTensorQuadratureTrialBasis):
         generator = TensorGenerator(a, index)

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from itertools import product
 
 from sympy import Basic, Expr
-from sympy import AtomicExpr
+from sympy import AtomicExpr, S
 from sympy import Function
 from sympy import Mul
 from sympy.core.singleton     import Singleton
@@ -113,10 +113,13 @@ class TensorAdd(TensorExpression):
 
 class TensorMul(TensorExpression):
     pass
+
+class TensorMax(TensorExpression):
+    pass
 #==============================================================================
 class TensorAssignExpr(Basic):
     def __new__(cls, lhs, rhs):
-        assert isinstance(lhs, Expr)
+        assert isinstance(lhs, (Expr, Tuple))
         assert isinstance(rhs, Expr)
         return Basic.__new__(cls, lhs, rhs)
 
@@ -131,17 +134,29 @@ class TensorAssignExpr(Basic):
 #==============================================================================
 class IndexNode(Expr):
     """Base class representing one index of an iterator"""
-    def __new__(cls, length=None):
+    def __new__(cls, start=0, stop=None, length=None):
         obj = Basic.__new__(cls)
+        obj._start  = start
+        obj._stop   = stop
         obj._length = length
         return obj
+
+    @property
+    def start(self):
+        return self._start
+
+    @property
+    def stop(self):
+        return self._stop
 
     @property
     def length(self):
         return self._length
 
-    def set_length(self, length):
-        obj = type(self)(length)
+    def set_range(self, start=Tuple(*[S.Zero]*3), stop=None, length=None):
+        if length is None:
+            length = stop
+        obj = type(self)(start=start, stop=stop, length=length)
         return obj
 
 class IndexElement(IndexNode):
@@ -1735,8 +1750,8 @@ def construct_itergener(a, index):
         generator = ProductGenerator(a.expr, index)
         element   = a.atom
     elif isinstance(a, TensorAssignExpr):
-        generator = TensorGenerator(a.lhs, index)
-        element   = a.rhs
+        generator = TensorGenerator(a.rhs, index)
+        element   = a.lhs
     else:
         raise TypeError('{} not available'.format(type(a)))
     # ...
@@ -1787,7 +1802,7 @@ def construct_itergener(a, index):
     elif isinstance(element, MatrixLocalBasis):
         iterator = ProductIterator(element)
 
-    elif isinstance(element, Expr):
+    elif isinstance(element, (Expr, Tuple)):
         iterator = TensorIterator(element)
     else:
         raise TypeError('{} not available'.format(type(element)))

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -116,6 +116,10 @@ class TensorMul(TensorExpression):
 
 class TensorMax(TensorExpression):
     pass
+
+class TensorInteger(TensorExpression):
+    pass
+
 #==============================================================================
 class TensorAssignExpr(Basic):
     def __new__(cls, lhs, rhs):
@@ -153,7 +157,7 @@ class IndexNode(Expr):
     def length(self):
         return self._length
 
-    def set_range(self, start=Tuple(*[S.Zero]*3), stop=None, length=None):
+    def set_range(self, start=TensorInteger(1), stop=None, length=None):
         if length is None:
             length = stop
         obj = type(self)(start=start, stop=stop, length=length)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1358,6 +1358,9 @@ class Parser(object):
 
         return tuple(newargs)
 
+    def _visit_TensorInteger(self, expr, **kwargs):
+        args = [expr.args[0]]*self.dim
+        return tuple(args)
     # ....................................................
     def _visit_Expr(self, expr, **kwargs):
         return SymbolicExpr(expr)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1359,8 +1359,7 @@ class Parser(object):
         return tuple(newargs)
 
     def _visit_TensorInteger(self, expr, **kwargs):
-        args = [expr.args[0]]*self.dim
-        return tuple(args)
+        return (expr.args[0],)*self.dim
     # ....................................................
     def _visit_Expr(self, expr, **kwargs):
         return SymbolicExpr(expr)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1569,6 +1569,7 @@ class Parser(object):
 
         indices = list(self._visit(expr.index))
         starts, stops, lengths = list(self._visit(expr.index.start)), list(self._visit(expr.index.stop)), list(self._visit(expr.index.length))
+
         for i,j in zip(flatten(indices), flatten(lengths)):
             self.indices[str(i)] = j
 
@@ -1621,17 +1622,18 @@ class Parser(object):
                     mask_init += list(inits[axis])
                     inits[axis]   = None
             indices = [i for i in indices if i is not None]
-            starts  = [i for i in starts if i is not None]
-            stops   = [i for i in stops if i is not None]
-            inits   = [i for i in inits if i is not None]
+            starts  = [i for i in starts  if i is not None]
+            stops   = [i for i in stops   if i is not None]
+            inits   = [i for i in inits   if i is not None]
 
         elif mask:
             axis      = mask.axis
             index     = indices.pop(axis)
-            starts    = starts.pop(axis)
-            stops     = stops.pop(axis)
+            start     = starts.pop(axis)
+            stop      = stops.pop(axis)
             init      = inits.pop(axis)
             mask_init = [Assign(index, 0), *init]
+
         for index, s, e, init in zip(indices[::-1], starts[::-1], stops[::-1], inits[::-1]):
 
             body = list(init) + body

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -5,11 +5,11 @@ import numpy as np
 from collections import OrderedDict
 
 from sympy import IndexedBase, Indexed
-from sympy import Mul, Matrix
+from sympy import Mul, Matrix, Expr
 from sympy import Add
 from sympy import Abs
 from sympy import Symbol, Idx
-from sympy import Max, Range
+from sympy import Range
 from sympy import Basic, Function
 from sympy.simplify import cse_main
 from sympy.core.containers import Tuple
@@ -93,6 +93,10 @@ class Shape(Basic):
     @property
     def arg(self):
         return self._args[0]
+
+
+class Max(Expr):
+    pass
 
 def is_scalar_array(var):
     indices = var.indices
@@ -382,6 +386,8 @@ class Parser(object):
 
         f_coeffs   = args.pop('f_coeffs',    None)
 
+        starts = args.pop('starts', [])
+        ends   = args.pop('ends', [])
         if f_coeffs:
             f_span     = args.pop('f_span',      [])
             f_basis    = args.pop('field_basis', [])
@@ -414,6 +420,8 @@ class Parser(object):
             f_args     = [self._visit(i, **kwargs) for i in f_args]
             f_args     = [tuple(arg.values())[0] if isinstance(arg, dict) else arg for arg in f_args]
             arguments += flatten(f_args)
+
+        arguments += starts + ends
 
         body = flatten(tuple(self._visit(i, **kwargs) for i in expr.body))
 
@@ -1318,6 +1326,16 @@ class Parser(object):
             
         return tuple(newargs)
 
+    def _visit_TensorMax(self, expr, **kwargs):
+        args = [self._visit(a, **kwargs) for a in expr.args]
+        arg1 = args[0]
+        arg2 = args[1]
+        newargs = []
+        for i,j in zip(arg1, arg2):
+            newargs.append(Max(i,j))
+
+        return tuple(newargs)
+
     # ....................................................
     def _visit_Expr(self, expr, **kwargs):
         return SymbolicExpr(expr)
@@ -1549,7 +1567,8 @@ class Parser(object):
         t_iterations = [TensorIteration(i,j)
                         for i,j in zip(t_iterator, t_generator)]
 
-        indices, lengths = list(self._visit(expr.index)), list(self._visit(expr.index.length))
+        indices = list(self._visit(expr.index))
+        starts, stops, lengths = list(self._visit(expr.index.start)), list(self._visit(expr.index.stop)), list(self._visit(expr.index.length))
         for i,j in zip(flatten(indices), flatten(lengths)):
             self.indices[str(i)] = j
 
@@ -1597,23 +1616,26 @@ class Parser(object):
             for axis,T in enumerate(mask):
                 if T:
                     indices[axis] = None
-                    lengths[axis] = None
+                    starts [axis] = None
+                    stops  [axis] = None
                     mask_init += list(inits[axis])
                     inits[axis]   = None
             indices = [i for i in indices if i is not None]
-            lengths = [i for i in lengths if i is not None]
+            starts  = [i for i in starts if i is not None]
+            stops   = [i for i in stops if i is not None]
             inits   = [i for i in inits if i is not None]
 
         elif mask:
             axis      = mask.axis
             index     = indices.pop(axis)
-            length    = lengths.pop(axis)
+            starts    = starts.pop(axis)
+            stops     = stops.pop(axis)
             init      = inits.pop(axis)
             mask_init = [Assign(index, 0), *init]
-        for index, length, init in zip(indices[::-1], lengths[::-1], inits[::-1]):
+        for index, s, e, init in zip(indices[::-1], starts[::-1], stops[::-1], inits[::-1]):
 
             body = list(init) + body
-            body = [For(index, Range(length), body)]
+            body = [For(index, Range(s, e), body)]
         # ...
         # remove the list and return the For Node only
 

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -551,7 +551,6 @@ class Parser(object):
         names = 'global_x1:%s'%(dim+1)
         points   = variables(names, dtype='real', rank=rank, cls=IndexedVariable)
 
-        weights = []
         if expr.weights:
             names = 'global_w1:%s'%(dim+1)
             weights  = variables(names, dtype='real', rank=rank, cls=IndexedVariable)
@@ -559,6 +558,7 @@ class Parser(object):
             # gather by axis
             targets = tuple(zip(points, weights))
         else:
+            weights = []
             targets = tuple(zip(points))
 
         self.insert_variables(*points, *weights)
@@ -573,7 +573,6 @@ class Parser(object):
         names = 'local_x1:%s'%(dim+1)
         points   = variables(names, dtype='real', rank=rank, cls=IndexedVariable)
 
-        weights = []
         if expr.weights:
             names = 'local_w1:%s'%(dim+1)
             weights  = variables(names, dtype='real', rank=rank, cls=IndexedVariable)
@@ -581,6 +580,7 @@ class Parser(object):
             # gather by axis
             targets = tuple(zip(points, weights))
         else:
+            weights = []
             targets = tuple(zip(points))
 
         self.insert_variables(*points, *weights)
@@ -593,7 +593,6 @@ class Parser(object):
         names   = 'x1:%s'%(dim+1)
         points  = variables(names, dtype='real', cls=Variable)
 
-        weights = []
         if expr.weights:
             names   = 'w1:%s'%(dim+1)
             weights = variables(names, dtype='real', cls=Variable)
@@ -601,7 +600,8 @@ class Parser(object):
             # gather by axis
             targets = tuple(zip(points, weights))
         else:
-            target  = tuple(zip(points))
+            weights  = []
+            targets  = tuple(zip(points))
 
         self.insert_variables(*points, *weights)
 

--- a/psydac/api/basic.py
+++ b/psydac/api/basic.py
@@ -283,6 +283,6 @@ class BasicDiscrete(BasicCodeGen):
         mapping             = kwargs.pop('mapping', None)
         mapping_space       = kwargs.pop('mapping_space', None)
 
-        return AST(expr, kernel_expr, discrete_space, tag, quad_order=quad_order,
-                    mapping=mapping, is_rational_mapping=is_rational_mapping, mapping_space=mapping_space)
+        return AST(expr, kernel_expr, discrete_space, mapping_space=mapping_space, tag=tag, quad_order=quad_order,
+                    mapping=mapping, is_rational_mapping=is_rational_mapping)
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -888,7 +888,8 @@ class DiscreteFunctional(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans[q.local_element_start:q.local_element_end+1] for q in space.quad_grids]
+            map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
+            map_span   = [span[q.local_element_start:q.local_element_end+1] for q,span in zip(space.quad_grids, map_span)]
             map_basis  = [q.basis[q.local_element_start:q.local_element_end+1] for q in space.quad_grids]
 
             if self.is_rational_mapping:

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -317,7 +317,7 @@ class DiscreteBilinearForm(BasicDiscrete):
         else:
             args = self._args
 
-        args = args + [int(i) for i in self._element_loop_starts] + [int(i) for i in self._element_loop_ends]
+        args = args + tuple(int(i) for i in self._element_loop_starts) + tuple(int(i) for i in self._element_loop_ends)
         if reset:
             reset_arrays(*self.global_matrices)
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -888,21 +888,8 @@ class DiscreteFunctional(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
-            map_basis  = [q.basis for q in space.quad_grids]
-            if self.grid.axis is not None:
-                axis   = self.grid.axis
-                nderiv = self.max_nderiv
-                space  = space.spaces[axis]
-                points = self.grid.points[axis]
-                boundary_basis = basis_ders_on_quad_grid(
-                        space.knots, space.degree, points, nderiv, space.basis)
-
-                map_basis[axis] = map_basis[axis].copy()
-                map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
-                if self.grid.ext == 1:
-                    map_span[axis]    = map_span[axis].copy()
-                    map_span[axis][0] = map_span[axis][-1]
+            map_span   = [q.spans[q.local_element_start:q.local_element_end+1] for q in space.quad_grids]
+            map_basis  = [q.basis[q.local_element_start:q.local_element_end+1] for q in space.quad_grids]
 
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -124,17 +124,17 @@ def construct_trial_space_arguments(basis_values):
     return trial_basis, trial_degrees, pads
 
 #==============================================================================
-def construct_quad_grids_arguments(grid, weights=True):
+def construct_quad_grids_arguments(grid, use_weights=True):
     points         = grid.points
-    if weights:
+    if use_weights:
         weights        = grid.weights
         quads          = flatten(list(zip(points, weights)))
     else:
         quads = flatten(list(zip(points)))
 
-    quads_degree   = flatten(grid.quad_order)
-    n_elements     = grid.n_elements
-    return n_elements, quads, quads_degree
+    quads_order   = flatten(grid.quad_order)
+    n_elements    = grid.n_elements
+    return n_elements, quads, quads_order
 
 def reset_arrays(*args):
     for a in args: a[:] = 0.
@@ -348,7 +348,7 @@ class DiscreteBilinearForm(BasicDiscrete):
 
         test_basis, test_degrees, spans, pads  = construct_test_space_arguments(self.test_basis)
         trial_basis, trial_degrees, pads       = construct_trial_space_arguments(self.trial_basis)
-        n_elements, quads, quad_degrees        = construct_quad_grids_arguments(self.grid, weights=False)
+        n_elements, quads, quad_degrees        = construct_quad_grids_arguments(self.grid, use_weights=False)
 
         pads                      = self.test_basis.space.vector_space.pads
         element_mats, global_mats = self.allocate_matrices(backend)
@@ -360,17 +360,19 @@ class DiscreteBilinearForm(BasicDiscrete):
             map_degree = space.degree
             map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
             map_basis  = [q.basis for q in space.quad_grids]
-            if self.grid.axis is not None:
-                axis   = self.grid.axis
+            axis       = self.grid.axis
+            ext        = self.grid.ext
+            points     = self.grid.points
+            if axis is not None:
                 nderiv = self.max_nderiv
                 space  = space.spaces[axis]
-                points = self.grid.points[axis]
+                points = points[axis]
                 boundary_basis = basis_ders_on_quad_grid(
                         space.knots, space.degree, points, nderiv, space.basis)
 
                 map_basis[axis] = map_basis[axis].copy()
                 map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
-                if self.grid.ext == 1:
+                if ext == 1:
                     map_span[axis]    = map_span[axis].copy()
                     map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:
@@ -662,7 +664,7 @@ class DiscreteLinearForm(BasicDiscrete):
     def construct_arguments(self):
 
         tests_basis, tests_degrees, spans, pads = construct_test_space_arguments(self.test_basis)
-        n_elements, quads, quads_degree         = construct_quad_grids_arguments(self.grid, weights=False)
+        n_elements, quads, quads_degree         = construct_quad_grids_arguments(self.grid, use_weights=False)
 
         global_pads   = self.space.vector_space.pads
 
@@ -675,17 +677,19 @@ class DiscreteLinearForm(BasicDiscrete):
             map_degree = space.degree
             map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
             map_basis  = [q.basis for q in space.quad_grids]
-            if self.grid.axis is not None:
-                axis   = self.grid.axis
+            axis       = self.grid.axis
+            ext        = self.grid.ext
+            points     = self.grid.points
+            if axis is not None:
                 nderiv = self.max_nderiv
                 space  = space.spaces[axis]
-                points = self.grid.points[axis]
+                points = points[axis]
                 boundary_basis = basis_ders_on_quad_grid(
                         space.knots, space.degree, points, nderiv, space.basis)
 
                 map_basis[axis] = map_basis[axis].copy()
                 map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
-                if self.grid.ext == 1:
+                if ext == 1:
                     map_span[axis]    = map_span[axis].copy()
                     map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -28,6 +28,7 @@ from psydac.cad.geometry     import Geometry
 from psydac.mapping.discrete import NurbsMapping
 from psydac.fem.vector       import ProductFemSpace
 from psydac.fem.basic        import FemField
+from psydac.core.bsplines    import basis_ders_on_quad_grid
 
 __all__ = (
     'DiscreteBilinearForm',
@@ -359,6 +360,19 @@ class DiscreteBilinearForm(BasicDiscrete):
             map_degree = space.degree
             map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
             map_basis  = [q.basis for q in space.quad_grids]
+            if self.grid.axis is not None:
+                axis   = self.grid.axis
+                nderiv = self.max_nderiv
+                space  = space.spaces[axis]
+                points = self.grid.points[axis]
+                boundary_basis = basis_ders_on_quad_grid(
+                        space.knots, space.degree, points, nderiv, space.basis)
+
+                map_basis[axis] = map_basis[axis].copy()
+                map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
+                if self.grid.ext == 1:
+                    map_span[axis]    = map_span[axis].copy()
+                    map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:
@@ -661,6 +675,19 @@ class DiscreteLinearForm(BasicDiscrete):
             map_degree = space.degree
             map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
             map_basis  = [q.basis for q in space.quad_grids]
+            if self.grid.axis is not None:
+                axis   = self.grid.axis
+                nderiv = self.max_nderiv
+                space  = space.spaces[axis]
+                points = self.grid.points[axis]
+                boundary_basis = basis_ders_on_quad_grid(
+                        space.knots, space.degree, points, nderiv, space.basis)
+
+                map_basis[axis] = map_basis[axis].copy()
+                map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
+                if self.grid.ext == 1:
+                    map_span[axis]    = map_span[axis].copy()
+                    map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:
@@ -863,6 +890,20 @@ class DiscreteFunctional(BasicDiscrete):
             map_degree = space.degree
             map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
             map_basis  = [q.basis for q in space.quad_grids]
+            if self.grid.axis is not None:
+                axis   = self.grid.axis
+                nderiv = self.max_nderiv
+                space  = space.spaces[axis]
+                points = self.grid.points[axis]
+                boundary_basis = basis_ders_on_quad_grid(
+                        space.knots, space.degree, points, nderiv, space.basis)
+
+                map_basis[axis] = map_basis[axis].copy()
+                map_basis[axis][0:1, :, 0:nderiv+1, 0:1] = boundary_basis
+                if self.grid.ext == 1:
+                    map_span[axis]    = map_span[axis].copy()
+                    map_span[axis][0] = map_span[axis][-1]
+
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -235,18 +235,18 @@ class DiscreteBilinearForm(BasicDiscrete):
         ends   = vector_space.ends
         npts   = vector_space.npts
 
-        self._starts = tuple(0 if i==0   else 1 for i in starts)
-        self._ends   = tuple(0 if i+1==n else 1 for i,n in zip(ends, npts))
+        self._element_loop_starts = tuple(i!=0   for i in starts)
+        self._element_loop_ends   = tuple(i+1!=n for i,n in zip(ends, npts))
         #...
         if isinstance(target, (Boundary, Interface)):
             #...
             # If process does not own the boundary or interface, do not assemble anything
             if test_ext == -1:
-                if self._starts[axis] != 0:
+                if self._element_loop_starts[axis]:
                     self._func = do_nothing
 
             elif test_ext == 1:
-                if self._ends[axis] != 0:
+                if self._element_loop_ends[axis]:
                     self._func = do_nothing
 
         self._args = self.construct_arguments(backend=kwargs.pop('backend', None))
@@ -317,7 +317,7 @@ class DiscreteBilinearForm(BasicDiscrete):
         else:
             args = self._args
 
-        args = args + self._starts + self._ends
+        args = args + [int(i) for i in self._element_loop_starts] + [int(i) for i in self._element_loop_ends]
         if reset:
             reset_arrays(*self.global_matrices)
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -123,10 +123,13 @@ def construct_trial_space_arguments(basis_values):
     return trial_basis, trial_degrees, pads
 
 #==============================================================================
-def construct_quad_grids_arguments(grid):
+def construct_quad_grids_arguments(grid, weights=True):
     points         = grid.points
-    weights        = grid.weights
-    quads          = flatten(list(zip(points, weights)))
+    if weights:
+        weights        = grid.weights
+        quads          = flatten(list(zip(points, weights)))
+    else:
+        quads = flatten(list(zip(points)))
 
     quads_degree   = flatten(grid.quad_order)
     n_elements     = grid.n_elements
@@ -215,10 +218,10 @@ class DiscreteBilinearForm(BasicDiscrete):
         assert np.array_equal(quad_order, get_quad_order(self.spaces[1]))
         BasicDiscrete.__init__(self, expr, kernel_expr, quad_order=quad_order, **kwargs)
         #...
-        grid              = QuadratureGrid( test_space, axis, test_ext, trial_space=trial_space)
-        self._grid        = grid
-        self._test_basis  = BasisValues( test_space,  nderiv = self.max_nderiv , trial=False, grid=grid, ext=test_ext)
-        self._trial_basis = BasisValues( trial_space, nderiv = self.max_nderiv , trial=True, grid=grid, ext=trial_ext)
+        grid                = QuadratureGrid( test_space, axis, test_ext, trial_space=trial_space)
+        self._grid          = grid
+        self._test_basis    = BasisValues( test_space,  nderiv = self.max_nderiv , trial=False, grid=grid, ext=test_ext)
+        self._trial_basis   = BasisValues( trial_space, nderiv = self.max_nderiv , trial=True, grid=grid, ext=trial_ext)
 
         if isinstance(test_space.vector_space, BlockVectorSpace):
             vector_space = test_space.vector_space.spaces[0]
@@ -295,7 +298,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                     assert i==j
                     v = v[i]
                 if isinstance(v, FemField):
-                    basis_v  = BasisValues(v.space, nderiv = self.max_nderiv, grid=self.grid)
+                    basis_v  = BasisValues(v.space, nderiv = self.max_nderiv, trial=True, grid=self.grid)
                     bs, d, s, p = construct_test_space_arguments(basis_v)
                     basis   += bs
                     spans   += s
@@ -344,20 +347,27 @@ class DiscreteBilinearForm(BasicDiscrete):
 
         test_basis, test_degrees, spans, pads  = construct_test_space_arguments(self.test_basis)
         trial_basis, trial_degrees, pads       = construct_trial_space_arguments(self.trial_basis)
-        n_elements, quads, quad_degrees        = construct_quad_grids_arguments(self.grid)
+        n_elements, quads, quad_degrees        = construct_quad_grids_arguments(self.grid, weights=False)
 
         pads                      = self.test_basis.space.vector_space.pads
         element_mats, global_mats = self.allocate_matrices(backend)
         self._global_matrices     = [M._data for M in global_mats]
 
         if self.mapping:
-            mapping = [e._coeffs._data for e in self.mapping._fields]
+            mapping    = [e._coeffs._data for e in self.mapping._fields]
+            space      = self.mapping._fields[0].space
+            map_degree = space.degree
+            map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.quad_grids]
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:
-            mapping = []
+            mapping    = []
+            map_degree = []
+            map_span   = []
+            map_basis  = []
 
-        args = (*test_basis, *trial_basis, *spans, *quads, *test_degrees, *trial_degrees, *n_elements, *quad_degrees, *pads, *element_mats, *self._global_matrices, *mapping)
+        args = (*test_basis, *trial_basis, *map_basis, *spans, *map_span, *quads, *test_degrees, *trial_degrees, *map_degree, *n_elements, *quad_degrees, *pads, *mapping, *element_mats, *self._global_matrices)
         return args
 
     def allocate_matrices(self, backend=None):
@@ -596,7 +606,7 @@ class DiscreteLinearForm(BasicDiscrete):
                     i = get_space_indices_from_target(self.domain, self.target)
                     v = v[i]
                 if isinstance(v, FemField):
-                    basis_v  = BasisValues(v.space, nderiv = self.max_nderiv, grid=self.grid)
+                    basis_v  = BasisValues(v.space, nderiv = self.max_nderiv, trial=True, grid=self.grid)
                     bs, d, s, p = construct_test_space_arguments(basis_v)
                     basis   += bs
                     spans   += s
@@ -638,7 +648,7 @@ class DiscreteLinearForm(BasicDiscrete):
     def construct_arguments(self):
 
         tests_basis, tests_degrees, spans, pads = construct_test_space_arguments(self.test_basis)
-        n_elements, quads, quads_degree         = construct_quad_grids_arguments(self.grid)
+        n_elements, quads, quads_degree         = construct_quad_grids_arguments(self.grid, weights=False)
 
         global_pads   = self.space.vector_space.pads
 
@@ -646,12 +656,19 @@ class DiscreteLinearForm(BasicDiscrete):
         self._global_matrices   = [M._data for M in global_mats]
 
         if self.mapping:
-            mapping   = [e._coeffs._data for e in self.mapping._fields]
+            mapping    = [e._coeffs._data for e in self.mapping._fields]
+            space      = self.mapping._fields[0].space
+            map_degree = space.degree
+            map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.quad_grids]
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:
-            mapping   = []
-        args = (*tests_basis, *spans, *quads, *tests_degrees, *n_elements, *quads_degree, *global_pads, *element_mats, *self._global_matrices, *mapping)
+            mapping    = []
+            map_degree = []
+            map_span   = []
+            map_basis  = []
+        args = (*tests_basis, *map_basis, *spans, *map_span, *quads, *tests_degrees, *map_degree, *n_elements, *quads_degree, *global_pads, *mapping, *element_mats, *self._global_matrices)
         return args
 
     def allocate_matrices(self):
@@ -781,7 +798,7 @@ class DiscreteFunctional(BasicDiscrete):
         # ...
         grid             = QuadratureGrid( self.space,  axis=axis, ext=ext)
         self._grid       = grid
-        self._test_basis = BasisValues( self.space, nderiv = self.max_nderiv, grid=grid, ext=ext)
+        self._test_basis = BasisValues( self.space, nderiv = self.max_nderiv, trial=True, grid=grid, ext=ext)
 
         self._args = self.construct_arguments()
 
@@ -841,13 +858,20 @@ class DiscreteFunctional(BasicDiscrete):
             self._vector = vector
 
         if self.mapping:
-            mapping = [e._coeffs._data for e in self.mapping._fields]
+            mapping    = [e._coeffs._data for e in self.mapping._fields]
+            space      = self.mapping._fields[0].space
+            map_degree = space.degree
+            map_span   = [q.spans-s for q,s in zip(space.quad_grids, space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.quad_grids]
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]
         else:
-            mapping = []
+            mapping    = []
+            map_degree = []
+            map_span   = []
+            map_basis  = []
 
-        args = (*tests_basis, *spans, *quads, *tests_degrees, *n_elements, *quads_degree, *global_pads, element_mats, self._vector, *mapping)
+        args = (*tests_basis, *map_basis, *spans, *map_span, *quads, *tests_degrees, *map_degree, *n_elements, *quads_degree, *global_pads, *mapping, element_mats, self._vector)
 
         return args
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -376,7 +376,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                     map_span[axis]    = map_span[axis].copy()
                     map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:
-                mapping = [*mapping, self.mapping._weights_field._coeffs._data]
+                mapping = [*mapping, self.mapping.weights_field.coeffs._data]
         else:
             mapping    = []
             map_degree = []
@@ -693,7 +693,7 @@ class DiscreteLinearForm(BasicDiscrete):
                     map_span[axis]    = map_span[axis].copy()
                     map_span[axis][0] = map_span[axis][-1]
             if self.is_rational_mapping:
-                mapping = [*mapping, self.mapping._weights_field._coeffs._data]
+                mapping = [*mapping, self.mapping.weights_field.coeffs._data]
         else:
             mapping    = []
             map_degree = []

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -161,10 +161,10 @@ class BasisValues():
         The spans of the basis functions.
 
     """
-    def __init__( self, V, nderiv , trial=False, grid=None, ext=None):
+    def __init__( self, V, nderiv , trial=False, grid=None, ext=None, bil=False):
 
         self._space = V
-
+        assert grid is not None
         if isinstance(V, ProductFemSpace):
             starts = V.vector_space.starts
             V      = V.spaces
@@ -179,12 +179,13 @@ class BasisValues():
         else:
             indices = [None]*len(V[0].spaces)
 
+        weights = grid.weights
         for si,Vi in zip(starts,V):
             quad_grids  = Vi.quad_grids
             spans_i     = []
             basis_i     = []
 
-            for sij,g,p,vij,ind in zip(si, quad_grids, Vi.vector_space.pads, Vi.spaces, indices):
+            for sij,g,w,p,vij,ind in zip(si, quad_grids, weights, Vi.vector_space.pads, Vi.spaces, indices):
                 sp = g.spans-sij
                 bs = g.basis
                 if not trial and vij.periodic and vij.degree <= p:
@@ -202,6 +203,11 @@ class BasisValues():
                             sp = np.concatenate((sp,sp[-1:]))
                         else:
                             raise ValueError("Could not contsruct the basis functions")
+
+                if not trial:
+                    wshape = w.shape
+                    bs     = bs.copy()
+                    bs     = bs*w.reshape(wshape[0], 1, 1, wshape[1])
                 spans_i.append(sp)
                 basis_i.append(bs)
 

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -161,7 +161,7 @@ class BasisValues():
         The spans of the basis functions.
 
     """
-    def __init__( self, V, nderiv , trial=False, grid=None, ext=None, bil=False):
+    def __init__( self, V, nderiv , trial=False, grid=None, ext=None):
 
         self._space = V
         assert grid is not None
@@ -205,9 +205,8 @@ class BasisValues():
                             raise ValueError("Could not contsruct the basis functions")
 
                 if not trial:
-                    wshape = w.shape
-                    bs     = bs.copy()
-                    bs     = bs*w.reshape(wshape[0], 1, 1, wshape[1])
+                    bs  = bs.copy()
+                    bs *= w[:, None, None, :]
                 spans_i.append(sp)
                 basis_i.append(bs)
 

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -575,7 +575,7 @@ class CartDataExchanger:
 
         # Shortcuts
         cart = self._cart
-        comm = self._comm_cart
+        comm = cart._comm_cart
 
         # Choose non-negative invertible function tag(disp) >= 0
         # NOTES:

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -85,7 +85,6 @@ class CartDecomposition():
         # ...
         self._ndims = len( npts )
         # ...
-
         # ...
         self._size = comm.Get_size()
         self._rank = comm.Get_rank()
@@ -576,7 +575,7 @@ class CartDataExchanger:
 
         # Shortcuts
         cart = self._cart
-        comm = self._comm
+        comm = self._comm_cart
 
         # Choose non-negative invertible function tag(disp) >= 0
         # NOTES:

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -575,7 +575,7 @@ class CartDataExchanger:
 
         # Shortcuts
         cart = self._cart
-        comm = cart._comm_cart
+        comm = self._comm
 
         # Choose non-negative invertible function tag(disp) >= 0
         # NOTES:

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -606,7 +606,6 @@ class CartDataExchanger:
         # Wait for end of data exchange (MPI_WAITALL)
         MPI.Request.Waitall( requests )
 
-        comm.Barrier()
 
     #---------------------------------------------------------------------------
     # Private methods

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -87,6 +87,10 @@ class BlockVectorSpace( VectorSpace ):
         return self._spaces
 
     @property
+    def parallel( self ):
+        return self._spaces[0].parallel
+
+    @property
     def starts( self ):
         return [s.starts for s in self._spaces]
 

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -88,6 +88,7 @@ class BlockVectorSpace( VectorSpace ):
 
     @property
     def parallel( self ):
+        """ Returns True if the memory is distributed."""
         return self._spaces[0].parallel
 
     @property

--- a/psydac/mapping/discrete.py
+++ b/psydac/mapping/discrete.py
@@ -350,6 +350,10 @@ class NurbsMapping( SplineMapping ):
         return self._control_points
 
     @property
+    def weights_field( self ):
+        return self._weights_field
+
+    @property
     def weights( self ):
         return self._weights
 


### PR DESCRIPTION
- Simplify the generated code of the dot product when shift == 1
- Remove the MPI barrier from the ghost regions update
- Decouple the mapping space from the test space
- Multiply the test basis function by the quadrature weights
- Assemble only the necessary parts without the ghost regions in the parallel case