### PR TITLE
Fix installation process

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,13 +67,11 @@ jobs:
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
         python -m pip install wheel
-        python -m pip install numpy>=1.16
         python -m pip install -r requirements.txt
       
     - name: Install project
       run: |
         python -m pip install .
-        python -m pip install numba
         python -m pip freeze
 
     - name: Initialize test directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@
 #
 numpy>=1.16
 Cython>=0.25
+numba
 mpi4py
 h5py
 --no-binary h5py
-
-# Igakit (TODO: remove library dependency)
-https://bitbucket.org/dalcinl/igakit/get/master.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@ install_requires = [
     'pyccel>=0.10.1',
     'gelato==0.11',
 
+    # Alternative backend to Pyccel is Numba
+    'numba',
+
     # In addition, we depend on mpi4py and h5py (MPI version).
     # Since h5py must be built from source, we run the commands
     #
@@ -71,6 +74,9 @@ install_requires = [
     # When pyccel is run in parallel with MPI, it uses tblib to pickle
     # tracebacks, which allows mpi4py to broadcast exceptions
     'tblib',
+
+    # IGAKIT - not on PyPI
+    'igakit @ https://bitbucket.org/dalcinl/igakit/get/master.tar.gz',
 ]
 
 dependency_links = []


### PR DESCRIPTION
Avoid runtime errors when loading pyccelized modules, caused by version mismatch between Numpy header used by Pyccel and installed Numpy library:

- Add Numba to requirements.txt in order to make sure that Pyccel and its dependencies are built against the same Numpy version (numba 0.55.0 requires numpy<1.22)

- Add Numba and Igakit to dependencies in setup.py
