### PR TITLE
Pycellisation of the functions in `bsplines.py`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -63,6 +63,8 @@ jobs:
     - name: Install project
       run: |
         python -m pip install .
+        pyccel psydac/core/kernels.py --language fortran
+        pyccel psydac/core/bsplines_pyccel.py --language fortran
         python -m pip freeze
 
     - name: Initialize test directory

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ python3 /path/to/psydac/mpi_tester.py --pyargs psydac -m "parallel"
 
 ## Speeding up **Psydac**'s core
 -----
-Some of the low-level functions in psydac are written in python in a way that can be accelerated by pyccel. Currently, all of those are in `psydac/core/kernels.py`.
+Some of the low-level functions in psydac are written in python in a way that can be accelerated by pyccel. Currently, all of those are in `psydac/core/kernels.py` and `psydac/core/bsplines_pyccel.py`.
 ```bash
 cd path/to/psydac/core
 pyccel kernels.py --language fortran
+pyccel bsplines_pyccel.py --language fortran
 ```
 
 ## Mesh Generation

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -669,10 +669,11 @@ def quadrature_grid(breaks, quad_rule_x, quad_rule_w):
     quad_rule_x = np.asarray( quad_rule_x )
     quad_rule_w = np.asarray( quad_rule_w )
 
-    out = np.zeros((len(breaks) - 1, len(quad_rule_x), 2))
-    quadrature_grid_p(breaks, quad_rule_x, quad_rule_w, out)
+    out1 = np.zeros((len(breaks) - 1, len(quad_rule_x)))
+    out2 = np.zeros_like(out1)
+    quadrature_grid_p(breaks, quad_rule_x, quad_rule_w, out1, out2,)
 
-    return out[..., 0], out[..., 1]
+    return out1, out2
 
 #==============================================================================
 def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization, out=None):

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -319,7 +319,6 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
     bool_normalization = normalization == "M"
 
     collocation_matrix_p(knots, degree, periodic, bool_normalization, xgrid, out)
-
     return out
 
 #==============================================================================
@@ -396,7 +395,6 @@ def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_bo
             out = np.zeros((len(xgrid) - 1, len(elevated_knots) - (degree + 1) - 1 - 1))
 
     histopolation_matrix_p(knots, degree, periodic, normalization, xgrid, check_boundary, elevated_knots, out)
-
     return out
 
 #==============================================================================
@@ -460,7 +458,6 @@ def greville(knots, degree, periodic, out=None):
         n = len(knots) - 2 * degree - 1 if periodic else len(knots) - degree - 1
         out = np.zeros(n)
     greville_p(knots, degree, periodic, out)
-
     return out
 
 #===============================================================================
@@ -508,7 +505,8 @@ def elements_spans(knots, degree, out=None):
 
     """
     if out is None:
-        out=np.zeros(len(knots), dtype=int)
+        out = np.zeros(len(knots), dtype=int)
+
     i_final = elements_spans_p(knots, degree, out)
     return out[:i_final]
 
@@ -615,7 +613,6 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
                 shape += multiplicity * (1 + uniques[0].shape[0])
             out = np.zeros(shape)
     elevate_knots_p(knots, degree, periodic, out, multiplicity, tol)
-
     return out
 
 #==============================================================================
@@ -730,6 +727,7 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization, out=
             [[0. , 0.03125, 0.125, 0.28125]]]])
     """
     ne, nq = quad_grid.shape
+    quad_grid = np.ascontiguousarray(quad_grid)
     if out is None:
         out = np.zeros((ne, degree + 1, nders + 1, nq))
     basis_ders_on_quad_grid_p(knots, degree, quad_grid, nders, normalization == 'M', out)

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -9,10 +9,10 @@ generation with Pyccel, no object-oriented features are employed.
 
 References
 ----------
-[1] L. Piegl and W. Tiller. The NURBS Book, 2nd ed.,
+.. [1] L. Piegl and W. Tiller. The NURBS Book, 2nd ed.,
     Springer-Verlag Berlin Heidelberg GmbH, 1997.
 
-[2] SELALIB, Semi-Lagrangian Library. http://selalib.gforge.inria.fr
+.. [2] SELALIB, Semi-Lagrangian Library. http://selalib.gforge.inria.fr
 
 """
 import numpy as np
@@ -24,7 +24,14 @@ from psydac.core.bsplines_pyccel import (find_span_p,
                                          basis_funs_1st_der_p,
                                          basis_funs_all_ders_p,
                                          collocation_matrix_p,
+                                         histopolation_matrix_p,
+                                         greville_p,
+                                         breakpoints_p,
+                                         elements_spans_p,
+                                         make_knots_p,
                                          elevate_knots_p,
+                                         quadrature_grid_p,
+                                         basis_ders_on_quad_grid_p,
                                          basis_integrals_p)
 
 __all__ = ['find_span',
@@ -46,7 +53,7 @@ __all__ = ['find_span',
 
 
 #==============================================================================
-def find_span(knots: 'float[:]', degree: int, x: float):
+def find_span(knots, degree, x):
     """
     Determine the knot span index at location x, given the B-Splines' knot
     sequence and polynomial degree. See Algorithm A2.1 in [1].
@@ -66,16 +73,16 @@ def find_span(knots: 'float[:]', degree: int, x: float):
         Location of interest.
 
     Returns
-    -------
+     -------
     span : int
         Knot span index.
-
     """
     return find_span_p(knots, degree, x)
 
 #==============================================================================
-def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out=None):
-    """Determine the knot span index at locations in x, given the B-Splines' knot
+def find_spans(knots, degree, x, out=None):
+    """
+    Determine the knot span index at a set of locations x, given the B-Splines' knot
     sequence and polynomial degree. See Algorithm A2.1 in [1].
 
     For a degree p, the knot span index i identifies the indices [i-p:i] of all
@@ -83,21 +90,23 @@ def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out=None):
 
     Parameters
     ----------
-    knots: array_like of floats
-        Knot sequence.
+    knots : array_like
+        Knots sequence.
 
-    degree: int
-        Polynomial degree of the BSplines.
+    degree : int
+        Polynomial degree of B-splines.
 
-    x: array_like of floats
-        Locations of interest
+    x : float
+        Location of interest.
 
-    out: array_like of ints or None
-        Knot span index for each location in x.
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
-    See Also
-    --------
-    psydac.core.bsplines.find_span : Determines the knot span at a location.
+    Returns
+    -------
+    spans : array of ints
+        Knots span indexes.
     """
     if out is None:
         out = np.zeros_like(x)
@@ -105,10 +114,9 @@ def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out=None):
     return out
 
 #==============================================================================
-def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out=None):
+def basis_funs(knots, degree, x, span, out=None):
     """
-    Compute the non-vanishing B-splines at location x, given the knot sequence,
-    polynomial degree and knot span. See Algorithm A2.2 in [1].
+    Compute the non-vanishing B-splines at a unique location.
 
     Parameters
     ----------
@@ -124,25 +132,25 @@ def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out=None):
     span : int
         Knot span index.
 
-    out : array_like of floats
-        Values of p+1 non-vanishing B-Splines at location x.
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
-    Notes
-    -----
-    The original Algorithm A2.2 in The NURBS Book [1] is here slightly improved
-    by using 'left' and 'right' temporary arrays that are one element shorter.
-
+    Returns
+    -------
+    array
+        1D array containing the values of ``degree + 1`` non-zero
+        Bsplines at location ``x``.
     """
+
     if out is None:
         out = np.zeros(degree + 1)
     basis_funs_p(knots, degree, x, span, out)
     return out
 
 #==============================================================================
-def basis_funs_array(knots: 'float[:]', degree: int, span: 'int[:]', x: 'float[:]', out=None):
-    """
-    Compute the non-vanishing B-splines at locations in x, given the knot sequence,
-    polynomial degree and knot span. See Algorithm A2.2 in [1].
+def basis_funs_array(knots, degree, span, x, out=None):
+    """Compute the non-vanishing B-splines at several locations.
 
     Parameters
     ----------
@@ -158,27 +166,26 @@ def basis_funs_array(knots: 'float[:]', degree: int, span: 'int[:]', x: 'float[:
     span : array_like of int
         Knot span indexes.
 
-    out : array_like of floats
-        Values of p+1 non-vanishing B-Splines at all locations in x.
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
     Returns
     -------
-    out : array_like of floats
-        Values of p+1 non-vanishing B-Splines at all locations in x.
+    array
+        2D array of shape ``(len(x), degree + 1)`` containing the values of ``degree + 1`` non-zero
+        Bsplines at each location in ``x``.
     """
+
     if out is None:
         out = np.zeros((x.shape, degree + 1))
     basis_funs_array_p(knots, degree, x, span,  out)
     return out
 
 #==============================================================================
-def basis_funs_1st_der( knots, degree, x, span, out=None):
+def basis_funs_1st_der(knots, degree, x, span, out=None):
     """
-    Compute the first derivative of the non-vanishing B-splines at location x,
-    given the knot sequence, polynomial degree and knot span.
-
-    See function 's_bsplines_non_uniform__eval_deriv' in Selalib's source file
-    'src/splines/sll_m_bsplines_non_uniform.F90'.
+    Compute the first derivative of the non-vanishing B-splines at a location.
 
     Parameters
     ----------
@@ -194,16 +201,28 @@ def basis_funs_1st_der( knots, degree, x, span, out=None):
     span : int
         Knot span index.
 
-    out : numpy.ndarray or None
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
     Returns
     -------
-    out : numpy.ndarray
-        Derivatives of p+1 non-vanishing B-Splines at location x.
+    array
+        1D array of size ``degree + 1`` containing the derivatives of the
+        ``degree + 1`` non-vanishing B-Splines at location x.
 
+    Notes
+    -----
+    See function 's_bsplines_non_uniform__eval_deriv' in Selalib's ([2]) source file
+    'src/splines/sll_m_bsplines_non_uniform.F90'.
+
+    References
+    ----------
+    .. [2] SELALIB, Semi-Lagrangian Library. http://selalib.gforge.inria.fr
     """
+
     if out is None:
-        out = np.empty(degree + 1)
+        out = np.zeros(degree + 1)
     basis_funs_1st_der_p(knots, degree, x, span, out)
     return out
 
@@ -211,12 +230,9 @@ def basis_funs_1st_der( knots, degree, x, span, out=None):
 def basis_funs_all_ders(knots, degree, x, span, n, normalization='B', out=None):
     """
     Evaluate value and n derivatives at x of all basis functions with
-    support in interval [x_{span-1}, x_{span}].
+    support in interval :math:`[x_{span-1}, x_{span}]`.
 
     If called with normalization='M', this uses M-splines instead of B-splines.
-
-    ders[i,j] = (d/dx)^i B_k(x) with k=(span-degree+j),
-                for 0 <= i <= n and 0 <= j <= degree+1.
 
     Parameters
     ----------
@@ -238,20 +254,19 @@ def basis_funs_all_ders(knots, degree, x, span, n, normalization='B', out=None):
     normalization: str
         Set to 'B' to get B-Splines and 'M' to get M-Splines
 
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
     Returns
     -------
-    out : numpy.ndarray (n+1,degree+1)
+    ders : array
         2D array of n+1 (from 0-th to n-th) derivatives at x of all (degree+1)
         non-vanishing basis functions in given span.
-
-    Notes
-    -----
-    The original Algorithm A2.3 in The NURBS Book [1] is here improved:
-        - 'left' and 'right' arrays are 1 element shorter;
-        - inverse of knot differences are saved to avoid unnecessary divisions;
-        - innermost loops are replaced with vector operations on slices.
-
+        ders[i,j] = (d/dx)^i B_k(x) with k=(span-degree+j),
+        for 0 <= i <= n and 0 <= j <= degree+1.
     """
+
     if out is None:
         out = np.zeros((n + 1, degree + 1))
     basis_funs_all_ders_p(knots, degree, x, span, n, normalization == 'M', out)
@@ -259,15 +274,13 @@ def basis_funs_all_ders(knots, degree, x, span, n, normalization='B', out=None):
 
 #==============================================================================
 def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
-    """
-    Compute the collocation matrix $C_ij = B_j(x_i)$, which contains the
-    values of each B-spline basis function $B_j$ at all locations $x_i$.
+    """Computes the collocation matrix
 
     If called with normalization='M', this uses M-splines instead of B-splines.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
@@ -279,12 +292,22 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
     normalization : str
         Set to 'B' for B-splines, and 'M' for M-splines.
 
-    xgrid : 1D array_like
+    xgrid : array_like
         Evaluation points.
 
-    out : 2D numpy.ndarray or None
-        Collocation matrix: values of all basis functions on each point in xgrid.
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
+    Returns
+    -------
+    colloc_matrix : ndarray of floats
+        Array containing the collocation matrix.
+
+    Notes
+    -----
+    The collocation matrix :math:`C_ij = B_j(x_i)`, contains the
+    values of each B-spline basis function :math:`B_j` at all locations :math:`x_i`.
     """
     if out is None:
         nb = len(knots) - degree - 1
@@ -300,17 +323,14 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
     return out
 
 #==============================================================================
-def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_boundary=True, out=None):
-    r"""
-    Compute the histopolation matrix $H_{ij} = \int_{x_i}^{x_{i+1}} B_j(x) dx$,
-    which contains the integrals of each B-spline basis function $B_j$ between
-    two successive grid points.
+def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_boundary, out=None):
+    """Computes the histopolation matrix.
 
     If called with normalization='M', this uses M-splines instead of B-splines.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
@@ -322,9 +342,26 @@ def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_bo
     normalization : str
         Set to 'B' for B-splines, and 'M' for M-splines.
 
-    xgrid : 1D array_like
+    xgrid : array_like
         Grid points.
 
+    check_boundary : bool, default=True
+        If true and ``periodic``, will check the boundaries of ``xgrid``.
+
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Returns
+    -------
+    array
+        Histopolation matrix
+
+    Notes
+    -----
+    The histopolation matrix :math:`H_{ij} = \\int_{x_i}^{x_{i+1}}B_j(x)\\,dx`
+    contains the integrals of each B-spline basis function :math:`B_j` between
+    two successive grid points.
     """
     # Check that knots are ordered (but allow repeated knots)
     if not np.all(np.diff(knots) >= 0):
@@ -354,22 +391,22 @@ def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_bo
 
     if out is None:
         if periodic:
-            out = np.zeros((len(xgrid), len(knots) - 2 * degree -1))
+            out = np.zeros((len(xgrid), len(knots) - 2 * degree - 1))
         else:
             out = np.zeros((len(xgrid) - 1, len(elevated_knots) - (degree + 1) - 1 - 1))
 
-    #histopolation_matrix_p(knots, degree, periodic, normalization, xgrid, check_boundary, elevated_knots, out)
+    histopolation_matrix_p(knots, degree, periodic, normalization, xgrid, check_boundary, elevated_knots, out)
 
     return out
 
 #==============================================================================
-def breakpoints( knots, degree ,tol=1e-15):
+def breakpoints(knots, degree, tol, out=None):
     """
     Determine breakpoints' coordinates.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
@@ -379,24 +416,28 @@ def breakpoints( knots, degree ,tol=1e-15):
         If the distance between two knots is less than tol, we assume 
         that they are repeated knots which correspond to the same break point.
 
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
     Returns
     -------
     breaks : numpy.ndarray (1D)
         Abscissas of all breakpoints.
-
     """
-    knots = np.array(knots)
-    diff  = np.append(True, abs(np.diff(knots[degree:-degree]))>tol)
-    return knots[degree:-degree][diff]
+    if out is None:
+        out = np.zeros(len(knots))
+    i_final = breakpoints_p(knots, degree, out, tol)
+    return out[:i_final]
 
 #==============================================================================
-def greville( knots, degree, periodic ):
+def greville(knots, degree, periodic, out=None):
     """
     Compute coordinates of all Greville points.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
@@ -405,47 +446,40 @@ def greville( knots, degree, periodic ):
     periodic : bool
         True if domain is periodic, False otherwise.
 
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
     Returns
     -------
-    xg : numpy.ndarray (1D)
+    greville : numpy.ndarray (1D)
         Abscissas of all Greville points.
 
     """
-    T = knots
-    p = degree
-    n = len(T)-2*p-1 if periodic else len(T)-p-1
+    if out is None:
+        n = len(knots) - 2 * degree - 1 if periodic else len(knots) - degree - 1
+        out = np.zeros(n)
+    greville_p(knots, degree, periodic, out)
 
-    # Compute greville abscissas as average of p consecutive knot values
-    xg = np.array([sum(T[i:i+p])/p for i in range(1,1+n)])
-
-    # Domain boundaries
-    a = T[p]
-    b = T[-1-p]
-
-    # If needed apply periodic boundary conditions, then sort array
-    if periodic:
-        xg = (xg-a) % (b-a) + a
-        xg = xg[np.argsort(xg)]
-
-    # Make sure roundoff errors don't push Greville points outside domain
-    xg[ 0] = max(xg[ 0], a)
-    xg[-1] = min(xg[-1], b)
-
-    return xg
+    return out
 
 #===============================================================================
-def elements_spans( knots, degree ):
+def elements_spans(knots, degree, out=None):
     """
     Compute the index of the last non-vanishing spline on each grid element
     (cell). The length of the returned array is the number of cells.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
         Polynomial degree of B-splines.
+
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
     Returns
     -------
@@ -473,23 +507,13 @@ def elements_spans( knots, degree ):
        spans  = np.searchsorted( knots, breaks[:-1], side='right' ) - 1
 
     """
-    breaks = breakpoints( knots, degree )
-    nk     = len(knots)
-    ne     = len(breaks)-1
-    spans  = np.zeros( ne, dtype=int )
-
-    ie = 0
-    for ik in range( degree, nk-degree ):
-        if knots[ik+1]-knots[ik]>=1e-15:
-            spans[ie] = ik
-            ie += 1
-        if ie == ne:
-            break
-
-    return spans
+    if out is None:
+        out=np.zeros(len(knots), dtype=int)
+    i_final = elements_spans_p(knots, degree, out)
+    return out[:i_final]
 
 #===============================================================================
-def make_knots( breaks, degree, periodic, multiplicity=1 ):
+def make_knots(breaks, degree, periodic, multiplicity, out=None):
     """
     Create spline knots from breakpoints, with appropriate boundary conditions.
     Let p be spline degree. If domain is periodic, knot sequence is extended
@@ -512,7 +536,11 @@ def make_knots( breaks, degree, periodic, multiplicity=1 ):
         Multiplicity of the knots in the knot sequence, we assume that the same 
         multiplicity applies to each interior knot.
 
-    Result
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Returns
     ------
     T : numpy.ndarray (1D)
         Coordinates of spline knots.
@@ -532,21 +560,10 @@ def make_knots( breaks, degree, periodic, multiplicity=1 ):
         assert len(breaks) > degree
 
     p = degree
-    T = np.zeros( multiplicity*len(breaks[1:-1])+2+2*p )
-
-    T[p+1:-p-1] = np.repeat(breaks[1:-1], multiplicity)
-    T[p]        = breaks[ 0]
-    T[-p-1]     = breaks[-1]
-
-    if periodic:
-        period = breaks[-1]-breaks[0]
-        T[0:p] = [xi-period for xi in breaks[-p-1:-1 ]]
-        T[-p:] = [xi+period for xi in breaks[   1:p+1]]
-    else:
-        T[0:p+1] = breaks[ 0]
-        T[-p-1:] = breaks[-1]
-
-    return T
+    if out is None:
+        out = np.zeros(multiplicity * len(breaks[1:-1]) + 2 + 2 * degree)
+    make_knots_p(breaks, degree, periodic, out, multiplicity)
+    return out
 
 #==============================================================================
 def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
@@ -578,11 +595,14 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
         If the distance between two knots is less than tol, we assume 
         that they are repeated knots which correspond to the same break point.
 
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
     Returns
     -------
-    new_knots : 1D numpy.ndarray
+    new_knots : ndarray
         Knots sequence of spline space of degree p+1.
-
     """
 
     if out is None:
@@ -598,30 +618,29 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
 
     return out
 
-
 #==============================================================================
-def quadrature_grid( breaks, quad_rule_x, quad_rule_w ):
-    r"""
+def quadrature_grid(breaks, quad_rule_x, quad_rule_w):
+    """
     Compute the quadrature points and weights for performing integrals over
     each element (interval) of the 1D domain, given a certain Gaussian
     quadrature rule.
 
-    An n-point Gaussian quadrature rule for the canonical interval $[-1,+1]$
-    and trivial weighting function $\omega(x)=1$ is defined by the n abscissas
-    $x_i$ and n weights $w_i$ that satisfy the following identity for
-    polynomial functions $f(x)$ of degree $2n-1$ or less:
+    An n-point Gaussian quadrature rule for the canonical interval :math:`[-1,+1]`
+    and trivial weighting function :math:`\\omega(x)=1` is defined by the n abscissas
+    :math:`x_i` and n weights :math:`w_i` that satisfy the following identity for
+    polynomial functions :math:`f(x)` of degree :math:`2n-1` or less:
 
-    $\int_{-1}^{+1} f(x) dx = \sum_{i=0}^{n-1} w_i f(x_i)$.
+    .. math :: \\int_{-1}^{+1} f(x) dx = \\sum_{i=0}^{n-1} w_i f(x_i)
 
     Parameters
     ----------
-    breaks : 1D array_like
+    breaks : array_like of floats
         Coordinates of spline breakpoints.
 
-    quad_rule_x : 1D array_like
+    quad_rule_x : array_like of ints
         Coordinates of quadrature points on canonical interval [-1,1].
 
-    quad_rule_w : 1D array_like
+    quad_rule_w : array_like of ints
         Weights assigned to quadrature points on canonical interval [-1,1].
 
     Returns
@@ -653,22 +672,13 @@ def quadrature_grid( breaks, quad_rule_x, quad_rule_w ):
     quad_rule_x = np.asarray( quad_rule_x )
     quad_rule_w = np.asarray( quad_rule_w )
 
-    ne     = len(breaks)-1
-    nq     = len(quad_rule_x)
-    quad_x = np.zeros( (ne,nq) )
-    quad_w = np.zeros( (ne,nq) )
+    out = np.zeros((len(breaks) - 1, len(quad_rule_x), 2))
+    quadrature_grid_p(breaks, quad_rule_x, quad_rule_w, out)
 
-    # Compute location and weight of quadrature points from basic rule
-    for ie,(a,b) in enumerate(zip(breaks[:-1],breaks[1:])):
-        c0 = 0.5*(a+b)
-        c1 = 0.5*(b-a)
-        quad_x[ie,:] = c1*quad_rule_x[:] + c0
-        quad_w[ie,:] = c1*quad_rule_w[:]
-
-    return quad_x, quad_w
+    return out[..., 0], out[..., 1]
 
 #==============================================================================
-def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization):
+def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization, out=None):
     """
     Evaluate B-Splines and their derivatives on the quadrature grid.
 
@@ -684,14 +694,16 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization):
 
     quad_grid: ndarray
         2D array of shape (ne, nq). Coordinates of quadrature points of
-        each element in 1D domain, which can be given by quadrature_grid()
-        or chosen arbitrarily.
-
+        each element in 1D domain.
     nders : int
         Maximum derivative of interest.
 
     normalization : str
         Set to 'B' for B-splines, and 'M' for M-splines.
+
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
     Returns
     -------
@@ -708,10 +720,7 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization):
     >>> knots = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1., 1.])
     >>> degree = 2
     >>> bk = breakpoints(knots, degree)
-    >>> # Valid grid
     >>> grid = np.array([np.linspace(bk[i], bk[i+1], 4, endpoint=False) for i in range(len(bk) - 1)])
-    >>> # Also a valid grid (doesn't start on the left boundary of the domain)
-    >>> grid_2 = grid[2:, :]
     >>> basis_ders_on_quad_grid(knots, degree, grid, 0, "B")
     array([[[[0.5, 0.28125, 0.125, 0.03125]],
             [[0.5, 0.6875 , 0.75 , 0.6875 ]],
@@ -719,42 +728,20 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization):
            [[[0.5, 0.28125, 0.125, 0.03125]],
             [[0.5, 0.6875 , 0.75 , 0.6875 ]],
             [[0. , 0.03125, 0.125, 0.28125]]]])
-    >>> basis_ders_on_quad_grid(knots, degree, grid_2, 0, "B")
-    array([[[[0.5, 0.28125, 0.125, 0.03125]],
-            [[0.5, 0.6875 , 0.75 , 0.6875 ]],
-            [[0. , 0.03125, 0.125, 0.28125]]]])
-
     """
     ne, nq = quad_grid.shape
-    basis = np.zeros((ne, degree+1, nders+1, nq))
+    if out is None:
+        out = np.zeros((ne, degree + 1, nders + 1, nq))
+    basis_ders_on_quad_grid_p(knots, degree, quad_grid, nders, normalization == 'M', out)
+    return out
 
-    if normalization == 'M':
-        scaling = 1. / basis_integrals(knots, degree)
-    spans = elements_spans(knots, degree)
-
-    assert ne <= len(spans)
-    # Test to see if the grid doesn't start at 0
-    offset = 0
-    span_exact = find_span(knots, degree, quad_grid[0, 0])
-    if span_exact != spans[0]:
-        offset = span_exact - spans[0]
-
-    for ie in range(ne):
-        xx = quad_grid[ie, :]
-        span = spans[offset + ie]
-        for iq, xq in enumerate(xx):
-            ders = basis_funs_all_ders(knots, degree, xq, span, nders)
-            if normalization == 'M':
-                ders *= scaling[span - degree:span + 1]
-            basis[ie, :, :, iq] = ders.transpose()
-    return basis
 
 #==============================================================================
 def basis_integrals(knots, degree, out=None):
-    r"""
+    """
     Return the integral of each B-spline basis function over the real line:
 
-    K[i] := \int_{-\infty}^{+\infty} B[i](x) dx = (T[i+p+1]-T[i]) / (p+1).
+    .. math:: K[i] = \\int_{-\\infty}^{+\\infty} B_i(x) dx = (T[i+p+1]-T[i]) / (p+1).
 
     This array can be used to convert B-splines to M-splines, which have unit
     integral over the real line but no partition-of-unity property.
@@ -767,9 +754,13 @@ def basis_integrals(knots, degree, out=None):
     degree : int
         Polynomial degree of B-splines.
 
+    out : array, optional
+        If provided, the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
     Returns
     -------
-    K : 1D numpy.ndarray
+    K : numpy.ndarray
         Array with the integrals of each B-spline basis function.
 
     Notes
@@ -778,8 +769,8 @@ def basis_integrals(knots, degree, out=None):
     non-periodic spaces, hence the length of the output array is always equal
     to (len(knots)-degree-1). In the periodic case the last (degree) values in
     the array are redundant, as they are a copy of the first (degree) values.
-
     """
     if out is None:
         out = np.zeros(len(knots) - degree - 1)
-    return basis_integrals_p(knots, degree, out)
+    basis_integrals_p(knots, degree, out)
+    return out

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -17,6 +17,14 @@ References
 """
 import numpy as np
 
+from psydac.core.bspline_pyccel import (find_span_p,
+                                        find_spans_p,
+                                        basis_funs_p,
+                                        basis_funs_array_p,
+                                        basis_funs_1st_der_p,
+                                        basis_funs_all_ders_p,
+                                        collocation_matrix_p)
+
 __all__ = ['find_span',
            'find_spans',
            'basis_funs',
@@ -33,6 +41,7 @@ __all__ = ['find_span',
            'quadrature_grid',
            'basis_integrals',
            'basis_ders_on_quad_grid']
+
 
 #==============================================================================
 def find_span(knots: 'float[:]', degree: int, x: float):
@@ -60,27 +69,10 @@ def find_span(knots: 'float[:]', degree: int, x: float):
         Knot span index.
 
     """
-    # Knot index at left/right boundary
-    low  = degree
-    high = len(knots)-1-degree
-
-    # Check if point is exactly on left/right boundary, or outside domain
-    if x <= knots[low ]: return low
-    if x >= knots[high]: return high-1
-
-    # Perform binary search
-    span = (low+high)//2
-    while x < knots[span] or x >= knots[span+1]:
-        if x < knots[span]:
-           high = span
-        else:
-           low  = span
-        span = (low+high)//2
-
-    return span
+    return find_span_p(knots, degree, x)
 
 #==============================================================================
-def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
+def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out=None):
     """Determine the knot span index at locations in x, given the B-Splines' knot
     sequence and polynomial degree. See Algorithm A2.1 in [1].
 
@@ -98,20 +90,20 @@ def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
     x: array_like of floats
         Locations of interest
 
-    out: array_like of ints
+    out: array_like of ints or None
         Knot span index for each location in x.
 
     See Also
     --------
     psydac.core.bsplines.find_span : Determines the knot span at a location.
     """
-    n = x.size
-
-    for i in range(n):
-        out[i] = find_span(knots, degree, x[i])
+    if out is None:
+        out = np.empty_like(x)
+    find_spans_p(knots, degree, x, out)
+    return out
 
 #==============================================================================
-def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
+def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out=None):
     """
     Compute the non-vanishing B-splines at location x, given the knot sequence,
     polynomial degree and knot span. See Algorithm A2.2 in [1].
@@ -139,22 +131,13 @@ def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[
     by using 'left' and 'right' temporary arrays that are one element shorter.
 
     """
-    left = np.empty(degree, dtype=float)
-    right = np.empty(degree, dtype=float)
+    if out is None:
+        out = np.empty(degree + 1)
+    basis_funs_p(knots, degree, x, span, out)
+    return out
 
-    out[0] = 1.0
-    for j in range(0, degree):
-        left[j]  = x - knots[span - j]
-        right[j] = knots[span + 1 + j] - x
-        saved    = 0.0
-        for r in range(0, j + 1):
-            temp   = out[r] / (right[r] + left[j - r])
-            out[r] = saved + right[r] * temp
-            saved  = left[j - r] * temp
-        out[j + 1] = saved
-
-# ==============================================================================
-def basis_funs_array(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int[:]', out: 'float[:,:]'):
+#==============================================================================
+def basis_funs_array(knots: 'float[:]', degree: int, span: 'int[:]', x: 'float[:]', out=None):
     """
     Compute the non-vanishing B-splines at locations in x, given the knot sequence,
     polynomial degree and knot span. See Algorithm A2.2 in [1].
@@ -176,14 +159,18 @@ def basis_funs_array(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int[:
     out : array_like of floats
         Values of p+1 non-vanishing B-Splines at all locations in x.
 
+    Returns
+    -------
+    out : array_like of floats
+        Values of p+1 non-vanishing B-Splines at all locations in x.
     """
-
-    n = x.shape[0]
-    for i in range(n):
-        basis_funs(knots, degree, x[i], span[i], out[i, :])
+    if out is None:
+        out = np.empty((x.shape, degree + 1))
+    basis_funs_array_p(knots, degree, x, span,  out)
+    return out
 
 #==============================================================================
-def basis_funs_1st_der( knots, degree, x, span ):
+def basis_funs_1st_der( knots, degree, x, span, out=None):
     """
     Compute the first derivative of the non-vanishing B-splines at location x,
     given the knot sequence, polynomial degree and knot span.
@@ -205,36 +192,21 @@ def basis_funs_1st_der( knots, degree, x, span ):
     span : int
         Knot span index.
 
-    Results
+    out : numpy.ndarray or None
+
+    Returns
     -------
-    ders : numpy.ndarray
+    out : numpy.ndarray
         Derivatives of p+1 non-vanishing B-Splines at location x.
 
     """
-    # Compute nonzero basis functions and knot differences for splines
-    # up to degree deg-1
-    values = np.zeros(degree)
-    basis_funs( knots, degree-1, x, span, values)
-
-    # Compute derivatives at x using formula based on difference of splines of
-    # degree deg-1
-    # -------
-    # j = 0
-    ders  = np.empty( degree+1, dtype=float )
-    saved = degree * values[0] / (knots[span+1]-knots[span+1-degree])
-    ders[0] = -saved
-    # j = 1,...,degree-1
-    for j in range(1,degree):
-        temp    = saved
-        saved   = degree * values[j] / (knots[span+j+1]-knots[span+j+1-degree])
-        ders[j] = temp - saved
-    # j = degree
-    ders[degree] = saved
-
-    return ders
+    if out is None:
+        out = np.empty(degree + 1)
+    basis_funs_1st_der_p(knots, degree, x, span, out)
+    return out
 
 #==============================================================================
-def basis_funs_all_ders( knots, degree, x, span, n ):
+def basis_funs_all_ders(knots, degree, x, span, n, out=None):
     """
     Evaluate value and n derivatives at x of all basis functions with
     support in interval [x_{span-1}, x_{span}].
@@ -259,9 +231,11 @@ def basis_funs_all_ders( knots, degree, x, span, n ):
     n : int
         Max derivative of interest.
 
-    Results
+    out : numpy.ndarray (n+1,degree+1)
+
+    Returns
     -------
-    ders : numpy.ndarray (n+1,degree+1)
+    out : numpy.ndarray (n+1,degree+1)
         2D array of n+1 (from 0-th to n-th) derivatives at x of all (degree+1)
         non-vanishing basis functions in given span.
 
@@ -273,68 +247,13 @@ def basis_funs_all_ders( knots, degree, x, span, n ):
         - innermost loops are replaced with vector operations on slices.
 
     """
-    left  = np.empty( degree )
-    right = np.empty( degree )
-    ndu   = np.empty( (degree+1, degree+1) )
-    a     = np.empty( (       2, degree+1) )
-    ders  = np.zeros( (     n+1, degree+1) ) # output array
-
-    # Number of derivatives that need to be effectively computed
-    # Derivatives higher than degree are = 0.
-    ne = min( n, degree )
-
-    # Compute nonzero basis functions and knot differences for splines
-    # up to degree, which are needed to compute derivatives.
-    # Store values in 2D temporary array 'ndu' (square matrix).
-    ndu[0,0] = 1.0
-    for j in range(0,degree):
-        left [j] = x - knots[span-j]
-        right[j] = knots[span+1+j] - x
-        saved    = 0.0
-        for r in range(0,j+1):
-            # compute inverse of knot differences and save them into lower triangular part of ndu
-            ndu[j+1,r] = 1.0 / (right[r] + left[j-r])
-            # compute basis functions and save them into upper triangular part of ndu
-            temp       = ndu[r,j] * ndu[j+1,r]
-            ndu[r,j+1] = saved + right[r] * temp
-            saved      = left[j-r] * temp
-        ndu[j+1,j+1] = saved
-
-    # Compute derivatives in 2D output array 'ders'
-    ders[0,:] = ndu[:,degree]
-    for r in range(0,degree+1):
-        s1 = 0
-        s2 = 1
-        a[0,0] = 1.0
-        for k in range(1,ne+1):
-            d  = 0.0
-            rk = r-k
-            pk = degree-k
-            if r >= k:
-               a[s2,0] = a[s1,0] * ndu[pk+1,rk]
-               d = a[s2,0] * ndu[rk,pk]
-            j1 = 1   if (rk  > -1 ) else -rk
-            j2 = k-1 if (r-1 <= pk) else degree-r
-            a[s2,j1:j2+1] = (a[s1,j1:j2+1] - a[s1,j1-1:j2]) * ndu[pk+1,rk+j1:rk+j2+1]
-            d += np.dot( a[s2,j1:j2+1], ndu[rk+j1:rk+j2+1,pk] )
-            if r <= pk:
-               a[s2,k] = - a[s1,k-1] * ndu[pk+1,r]
-               d += a[s2,k] * ndu[r,pk]
-            ders[k,r] = d
-            j  = s1
-            s1 = s2
-            s2 = j
-
-    # Multiply derivatives by correct factors
-    r = degree
-    for k in range(1,ne+1):
-        ders[k,:] = ders[k,:] * r
-        r = r * (degree-k)
-
-    return ders
+    if out is None:
+        out = np.empty((n + 1, degree + 1))
+    basis_funs_all_ders_p(knots, degree, x, span, n, out)
+    return out
 
 #==============================================================================
-def collocation_matrix(knots, degree, periodic, normalization, xgrid):
+def collocation_matrix_true(knots, degree, periodic, normalization, xgrid):
     """
     Compute the collocation matrix $C_ij = B_j(x_i)$, which contains the
     values of each B-spline basis function $B_j$ at all locations $x_i$.
@@ -399,6 +318,47 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid):
     mat[abs(mat) < 1e-14] = 0.0
 
     return mat
+
+def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
+    """
+    Compute the collocation matrix $C_ij = B_j(x_i)$, which contains the
+    values of each B-spline basis function $B_j$ at all locations $x_i$.
+
+    If called with normalization='M', this uses M-splines instead of B-splines.
+
+    Parameters
+    ----------
+    knots : 1D array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of spline space.
+
+    periodic : bool
+        True if domain is periodic, False otherwise.
+
+    normalization : str
+        Set to 'B' for B-splines, and 'M' for M-splines.
+
+    xgrid : 1D array_like
+        Evaluation points.
+
+    out : 2D numpy.ndarray or None
+        Collocation matrix: values of all basis functions on each point in xgrid.
+
+    """
+    if out is None:
+        nb = len(knots) - degree - 1
+        if periodic:
+            nb -= degree
+
+        out = np.zeros((xgrid.shape[0], nb))
+
+    bool_normalization = normalization == "M"
+
+    collocation_matrix_p(knots, degree, periodic, bool_normalization, xgrid, out)
+
+    return out
 
 #==============================================================================
 def histopolation_matrix(knots, degree, periodic, normalization, xgrid):
@@ -869,9 +829,10 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization):
         . iq: local quadrature point (0 <= iq <  nq    )
 
     """
+
     # TODO: add example to docstring
 
-    ne,nq = quad_grid.shape
+    ne, nq = quad_grid.shape
     basis = np.zeros((ne, degree+1, nders+1, nq))
 
     if normalization == 'M':

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -513,7 +513,7 @@ def elements_spans(knots, degree, out=None):
     return out[:i_final]
 
 #===============================================================================
-def make_knots(breaks, degree, periodic, multiplicity, out=None):
+def make_knots(breaks, degree, periodic, multiplicity=1, out=None):
     """
     Create spline knots from breakpoints, with appropriate boundary conditions.
     Let p be spline degree. If domain is periodic, knot sequence is extended

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -18,7 +18,9 @@ References
 import numpy as np
 
 __all__ = ['find_span',
+           'find_spans',
            'basis_funs',
+           'basis_funs_array',
            'basis_funs_1st_der',
            'basis_funs_all_ders',
            'collocation_matrix',
@@ -33,7 +35,7 @@ __all__ = ['find_span',
            'basis_ders_on_quad_grid']
 
 #==============================================================================
-def find_span( knots, degree, x ):
+def find_span(knots: 'float[:]', degree: int, x: float):
     """
     Determine the knot span index at location x, given the B-Splines' knot
     sequence and polynomial degree. See Algorithm A2.1 in [1].
@@ -78,14 +80,45 @@ def find_span( knots, degree, x ):
     return span
 
 #==============================================================================
-def basis_funs( knots, degree, x, span ):
+def find_spans(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
+    """Determine the knot span index at locations in x, given the B-Splines' knot
+    sequence and polynomial degree. See Algorithm A2.1 in [1].
+
+    For a degree p, the knot span index i identifies the indices [i-p:i] of all
+    p+1 non-zero basis functions at a given location x.
+
+    Parameters
+    ----------
+    knots: array_like of floats
+        Knot sequence.
+
+    degree: int
+        Polynomial degree of the BSplines.
+
+    x: array_like of floats
+        Locations of interest
+
+    out: array_like of ints
+        Knot span index for each location in x.
+
+    See Also
+    --------
+    psydac.core.bsplines.find_span : Determines the knot span at a location.
+    """
+    n = x.size
+
+    for i in range(n):
+        out[i] = find_span(knots, degree, x[i])
+
+#==============================================================================
+def basis_funs(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
     """
     Compute the non-vanishing B-splines at location x, given the knot sequence,
     polynomial degree and knot span. See Algorithm A2.2 in [1].
 
     Parameters
     ----------
-    knots : array_like
+    knots : array_like of floats
         Knots sequence.
 
     degree : int
@@ -97,9 +130,7 @@ def basis_funs( knots, degree, x, span ):
     span : int
         Knot span index.
 
-    Results
-    -------
-    values : numpy.ndarray
+    out : array_like of floats
         Values of p+1 non-vanishing B-Splines at location x.
 
     Notes
@@ -108,22 +139,48 @@ def basis_funs( knots, degree, x, span ):
     by using 'left' and 'right' temporary arrays that are one element shorter.
 
     """
-    left   = np.empty( degree  , dtype=float )
-    right  = np.empty( degree  , dtype=float )
-    values = np.empty( degree+1, dtype=float )
+    left = np.empty(degree, dtype=float)
+    right = np.empty(degree, dtype=float)
 
-    values[0] = 1.0
-    for j in range(0,degree):
-        left [j] = x - knots[span-j]
-        right[j] = knots[span+1+j] - x
+    out[0] = 1.0
+    for j in range(0, degree):
+        left[j]  = x - knots[span - j]
+        right[j] = knots[span + 1 + j] - x
         saved    = 0.0
-        for r in range(0,j+1):
-            temp      = values[r] / (right[r] + left[j-r])
-            values[r] = saved + right[r] * temp
-            saved     = left[j-r] * temp
-        values[j+1] = saved
+        for r in range(0, j + 1):
+            temp   = out[r] / (right[r] + left[j - r])
+            out[r] = saved + right[r] * temp
+            saved  = left[j - r] * temp
+        out[j + 1] = saved
 
-    return values
+# ==============================================================================
+def basis_funs_array(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int[:]', out: 'float[:,:]'):
+    """
+    Compute the non-vanishing B-splines at locations in x, given the knot sequence,
+    polynomial degree and knot span. See Algorithm A2.2 in [1].
+
+    Parameters
+    ----------
+    knots : array_like of floats
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : array_like of floats
+        Evaluation points.
+
+    span : array_like of int
+        Knot span indexes.
+
+    out : array_like of floats
+        Values of p+1 non-vanishing B-Splines at all locations in x.
+
+    """
+
+    n = x.shape[0]
+    for i in range(n):
+        basis_funs(knots, degree, x[i], span[i], out[i, :])
 
 #==============================================================================
 def basis_funs_1st_der( knots, degree, x, span ):
@@ -156,7 +213,8 @@ def basis_funs_1st_der( knots, degree, x, span ):
     """
     # Compute nonzero basis functions and knot differences for splines
     # up to degree deg-1
-    values = basis_funs( knots, degree-1, x, span )
+    values = np.zeros(degree)
+    basis_funs( knots, degree-1, x, span, values)
 
     # Compute derivatives at x using formula based on difference of splines of
     # degree deg-1
@@ -331,9 +389,10 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid):
         normalize = lambda basis, span: basis * scaling[span-degree: span+1]
 
     # Fill in non-zero matrix values
+    basis = np.zeros(degree + 1)
     for i,x in enumerate( xgrid ):
         span  =  find_span( knots, degree, x )
-        basis = basis_funs( knots, degree, x, span )
+        basis_funs( knots, degree, x, span, basis)
         mat[i,js(span)] = normalize(basis, span)
 
     # Mitigate round-off errors

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -323,7 +323,7 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
     return out
 
 #==============================================================================
-def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_boundary, out=None):
+def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_boundary=True, out=None):
     """Computes the histopolation matrix.
 
     If called with normalization='M', this uses M-splines instead of B-splines.
@@ -400,7 +400,7 @@ def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_bo
     return out
 
 #==============================================================================
-def breakpoints(knots, degree, tol, out=None):
+def breakpoints(knots, degree, tol=1e-15, out=None):
     """
     Determine breakpoints' coordinates.
 

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -112,11 +112,11 @@ def basis_funs_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'floa
     right = np.zeros(degree, dtype=float)
 
     out[0] = 1.0
-    for j in range(0, degree):
+    for j in range(degree):
         left[j]  = x - knots[span - j]
         right[j] = knots[span + 1 + j] - x
         saved    = 0.0
-        for r in range(0, j + 1):
+        for r in range(j + 1):
             temp   = out[r] / (right[r] + left[j - r])
             out[r] = saved + right[r] * temp
             saved  = left[j - r] * temp
@@ -265,11 +265,11 @@ def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n
     # Store values in 2D temporary array 'ndu' (square matrix).
 
     ndu[0, 0] = 1.0
-    for j in range(0, degree):
+    for j in range(degree):
         left[j]  = x - knots[span-j]
         right[j] = knots[span+1+j] - x
         saved    = 0.0
-        for r in range(0, j+1):
+        for r in range(j+1):
             # compute inverse of knot differences and save them into lower triangular part of ndu
             ndu[j + 1, r] = 1.0 / (right[r] + left[j - r])
             # compute basis functions and save them into upper triangular part of ndu
@@ -281,7 +281,7 @@ def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n
     # Compute derivatives in 2D output array 'out'
     out[0, :] = ndu[:, degree]
 
-    for r in range(0, degree+1):
+    for r in range(degree+1):
 
         s1 = 0
         s2 = 1
@@ -406,12 +406,12 @@ def collocation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normali
     # Rescaling of B-splines, to get M-splines if needed
     if not normalization:
         if periodic:
-            for i in range(0, nx):
-                for j in range(0, degree + 1):
+            for i in range(nx):
+                for j in range(degree + 1):
                     actual_j = (spans[i] - degree + j) % nb
                     out[i, actual_j] = basis[i, j]
         else:
-            for i in range(0, nx):
+            for i in range(nx):
                 out[i, spans[i] - degree:spans[i] + 1] = basis[i, :]
     else:
         integrals = np.zeros(knots.shape[0] - degree - 1)

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -955,6 +955,7 @@ def quadrature_grid_p(breaks: 'float[:]', quad_rule_x: 'float[:]', quad_rule_w: 
     out2 : array
         Half of the result will be inserted into this array.
         It should be of the appropriate shape and dtype.
+
     Notes
     -----
     Contents of 2D output arrays 'quad_x' and 'quad_w' are accessed with two
@@ -963,11 +964,10 @@ def quadrature_grid_p(breaks: 'float[:]', quad_rule_x: 'float[:]', quad_rule_w: 
       . iq is the local index of a quadrature point within the element.
 
     """
-    ne = len(breaks) - 1
-    nq = len(quad_rule_x)
+    ncells = len(breaks) - 1
 
     # Compute location and weight of quadrature points from basic rule
-    for ie in range(len(breaks) - 1):
+    for ie in range(ncells):
         a = breaks[ie]
         b = breaks[ie + 1]
 

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -1,0 +1,523 @@
+# This file holds the pyccelisable versions of the functions in bsplines.py
+# This will be changed once pyccel can return arrays and can get out=None arguments
+# like Numpy functions.
+
+import numpy as np
+
+def find_span_p(knots: 'float[:]', degree: int, x: float):
+    """
+    Determine the knot span index at location x, given the B-Splines' knot
+    sequence and polynomial degree. See Algorithm A2.1 in [1].
+
+    For a degree p, the knot span index i identifies the indices [i-p:i] of all
+    p+1 non-zero basis functions at a given location x.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : float
+        Location of interest.
+
+    Returns
+    -------
+    span : int
+        Knot span index.
+
+    """
+    # Knot index at left/right boundary
+    low  = degree
+    high = len(knots)-1-degree
+
+    # Check if point is exactly on left/right boundary, or outside domain
+    if x <= knots[low ]: return low
+    if x >= knots[high]: return high-1
+
+    # Perform binary search
+    span = (low+high)//2
+    while x < knots[span] or x >= knots[span+1]:
+        if x < knots[span]:
+           high = span
+        else:
+           low  = span
+        span = (low+high)//2
+
+    return span
+
+#==============================================================================
+def find_spans_p(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
+    """Determine the knot span index at locations in x, given the B-Splines' knot
+    sequence and polynomial degree. See Algorithm A2.1 in [1].
+
+    For a degree p, the knot span index i identifies the indices [i-p:i] of all
+    p+1 non-zero basis functions at a given location x.
+
+    Parameters
+    ----------
+    knots: array_like of floats
+        Knot sequence.
+
+    degree: int
+        Polynomial degree of the BSplines.
+
+    x: array_like of floats
+        Locations of interest
+
+    out: array_like of ints
+        Knot span index for each location in x.
+
+    See Also
+    --------
+    psydac.core.bsplines.find_span : Determines the knot span at a location.
+    """
+    n = x.shape[0]
+
+    for i in range(n):
+        out[i] = find_span_p(knots, degree, x[i])
+
+#==============================================================================
+def basis_funs_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
+    """
+    Compute the non-vanishing B-splines at location x, given the knot sequence,
+    polynomial degree and knot span. See Algorithm A2.2 in [1].
+
+    Parameters
+    ----------
+    knots : array_like of floats
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : float
+        Evaluation point.
+
+    span : int
+        Knot span index.
+
+    out : array_like of floats
+        Values of p+1 non-vanishing B-Splines at location x.
+
+    Notes
+    -----
+    The original Algorithm A2.2 in The NURBS Book [1] is here slightly improved
+    by using 'left' and 'right' temporary arrays that are one element shorter.
+
+    """
+    left = np.empty(degree, dtype=float)
+    right = np.empty(degree, dtype=float)
+
+    out[0] = 1.0
+    for j in range(0, degree):
+        left[j]  = x - knots[span - j]
+        right[j] = knots[span + 1 + j] - x
+        saved    = 0.0
+        for r in range(0, j + 1):
+            temp   = out[r] / (right[r] + left[j - r])
+            out[r] = saved + right[r] * temp
+            saved  = left[j - r] * temp
+        out[j + 1] = saved
+
+# ==============================================================================
+def basis_funs_array_p(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int[:]', out: 'float[:,:]'):
+    """
+    Compute the non-vanishing B-splines at locations in x, given the knot sequence,
+    polynomial degree and knot span. See Algorithm A2.2 in [1].
+
+    Parameters
+    ----------
+    knots : array_like of floats
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : array_like of floats
+        Evaluation points.
+
+    span : array_like of int
+        Knot span indexes.
+
+    out : array_like of floats
+        Values of p+1 non-vanishing B-Splines at all locations in x.
+
+    """
+
+    n = x.shape[0]
+    for i in range(n):
+        basis_funs_p(knots, degree, x[i], span[i], out[i, :])
+
+
+def basis_funs_1st_der_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
+    """
+    Compute the first derivative of the non-vanishing B-splines at location x,
+    given the knot sequence, polynomial degree and knot span.
+
+    See function 's_bsplines_non_uniform__eval_deriv' in Selalib's source file
+    'src/splines/sll_m_bsplines_non_uniform.F90'.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : float
+        Evaluation point.
+
+    span : int
+        Knot span index.
+
+    out : numpy.ndarray
+        Derivatives of p+1 non-vanishing B-Splines at location x.
+
+    """
+    # Compute nonzero basis functions and knot differences for splines
+    # up to degree deg-1
+    values = np.zeros(degree)
+    basis_funs_p(knots, degree-1, x, span, values)
+
+    # Compute derivatives at x using formula based on difference of splines of
+    # degree deg-1
+    # -------
+    # j = 0
+    saved = degree * values[0] / (knots[span+1]-knots[span+1-degree])
+    out[0] = -saved
+    # j = 1,...,degree-1
+    for j in range(1,degree):
+        temp    = saved
+        saved   = degree * values[j] / (knots[span+j+1]-knots[span+j+1-degree])
+        out[j] = temp - saved
+    # j = degree
+    out[degree] = saved
+
+
+def dot_2d(a: 'float[:, :]', b: 'float[:, :]', out: 'float[:, :]'):
+    for i in range(a.shape[0]):
+        for k in range(b.shape[1]):
+            out[i, k] = np.sum(a[i, :] * b[:, k])
+
+
+def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n: int, out: 'float[:,:]'):
+    """
+    Evaluate value and n derivatives at x of all basis functions with
+    support in interval [x_{span-1}, x_{span}].
+
+    ders[i,j] = (d/dx)^i B_k(x) with k=(span-degree+j),
+                for 0 <= i <= n and 0 <= j <= degree+1.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    x : float
+        Evaluation point.
+
+    span : int
+        Knot span index.
+
+    n : int
+        Max derivative of interest.
+
+
+    -------
+    ders : numpy.ndarray (n+1,degree+1)
+        2D array of n+1 (from 0-th to n-th) derivatives at x of all (degree+1)
+        non-vanishing basis functions in given span.
+
+    Notes
+    -----
+    The original Algorithm A2.3 in The NURBS Book [1] is here improved:
+        - 'left' and 'right' arrays are 1 element shorter;
+        - inverse of knot differences are saved to avoid unnecessary divisions;
+        - innermost loops are replaced with vector operations on slices.
+    """
+    left  = np.empty(degree)
+    right = np.empty(degree)
+    ndu   = np.empty((degree+1, degree+1))
+    a     = np.empty((2, degree+1))
+    temp_dot_array = np.zeros((1, 1))
+    # Number of derivatives that need to be effectively computed
+    # Derivatives higher than degree are = 0.
+    ne = min(n, degree)
+
+    # Compute nonzero basis functions and knot differences for splines
+    # up to degree, which are needed to compute derivatives.
+    # Store values in 2D temporary array 'ndu' (square matrix).
+
+    ndu[0, 0] = 1.0
+    for j in range(0, degree):
+
+        left[j]  = x - knots[span-j]
+        right[j] = knots[span+1+j] - x
+        saved    = 0.0
+        for r in range(0, j+1):
+            # compute inverse of knot differences and save them into lower triangular part of ndu
+            ndu[j + 1, r] = 1.0 / (right[r] + left[j - r])
+            # compute basis functions and save them into upper triangular part of ndu
+            temp          = ndu[r, j] * ndu[j + 1, r]
+            ndu[r, j + 1] = saved + right[r] * temp
+            saved         = left[j - r] * temp
+        ndu[j + 1, j + 1] = saved
+
+    # Compute derivatives in 2D output array 'out'
+    out[0, :] = ndu[:, degree]
+    for r in range(0, degree+1):
+        s1 = 0
+        s2 = 1
+        a[0,0] = 1.0
+        for k in range(1, ne + 1):
+            d  = 0.0
+            rk = r-k
+            pk = degree-k
+            if r >= k:
+               a[s2, 0] = a[s1, 0] * ndu[pk + 1, rk]
+               d = a[s2, 0] * ndu[rk, pk]
+
+            j1 = 1   if (rk  > -1 ) else -rk
+            j2 = k-1 if (r-1 <= pk) else degree-r
+
+            a[s2, j1:j2 + 1] = (a[s1, j1:j2 + 1] - a[s1, j1 - 1:j2]) * ndu[pk + 1, rk + j1:rk + j2 + 1]
+            dot_2d(a[s2:s2 + 1, j1:j2 + 1], ndu[rk + j1:rk + j2 + 1, pk: pk + 1], temp_dot_array)
+            d += temp_dot_array[0, 0]
+
+            if r <= pk:
+               a[s2, k] = - a[s1, k - 1] * ndu[pk + 1, r]
+               d += a[s2, k] * ndu[r, pk]
+
+            out[k, r] = d
+            j  = s1
+            s1 = s2
+            s2 = j
+
+    # Multiply derivatives by correct factors
+    r = degree
+    for k in range(1,ne+1):
+        out[k, :] = out[k, :] * r
+        r = r * (degree-k)
+
+
+def basis_integrals_p(knots: 'float[:]', degree: int, out: 'float[:]'):
+    r"""
+    Return the integral of each B-spline basis function over the real line:
+
+    K[i] := \int_{-\infty}^{+\infty} B[i](x) dx = (T[i+p+1]-T[i]) / (p+1).
+
+    This array can be used to convert B-splines to M-splines, which have unit
+    integral over the real line but no partition-of-unity property.
+
+    Parameters
+    ----------
+    knots : 1D array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    Returns
+    -------
+    K : 1D numpy.ndarray
+        Array with the integrals of each B-spline basis function.
+
+    Notes
+    -----
+    For convenience, this function does not distinguish between periodic and
+    non-periodic spaces, hence the length of the output array is always equal
+    to (len(knots)-degree-1). In the periodic case the last (degree) values in
+    the array are redundant, as they are a copy of the first (degree) values.
+
+    """
+    T = knots
+    p = degree
+    n = len(T)-p-1
+    for i in range(n):
+        out[i] = (T[i + p + 1] - T[i])/ (p + 1)
+
+
+def collocation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normalization: bool, xgrid: 'float[:]',
+                         out: 'float[:,:]'):
+    """
+    Compute the collocation matrix $C_ij = B_j(x_i)$, which contains the
+    values of each B-spline basis function $B_j$ at all locations $x_i$.
+
+    If called with normalization='M', this uses M-splines instead of B-splines.
+
+    Parameters
+    ----------
+    knots : 1D array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of spline space.
+
+    periodic : bool
+        True if domain is periodic, False otherwise.
+
+    normalization : bool
+        Set to False for B-splines, and True for M-splines.
+
+    xgrid : 1D array_like
+        Evaluation points.
+
+    out : 2D numpy.ndarray
+        Collocation matrix: values of all basis functions on each point in xgrid.
+
+    """
+
+    # Number of basis functions (in periodic case remove degree repeated elements)
+    nb = len(knots)-degree-1
+    if periodic:
+        nb -= degree
+
+    # Number of evaluation points
+    nx = len(xgrid)
+
+    basis = np.zeros((nx, degree + 1))
+    spans = np.zeros(nx, dtype=int)
+    find_spans_p(knots, degree, xgrid, spans)
+    basis_funs_array_p(knots, degree, xgrid, spans, basis)
+
+    # Fill in non-zero matrix values
+
+    # Rescaling of B-splines, to get M-splines if needed
+    if not normalization:
+        if periodic:
+            for i in range(0, nx):
+                for j in range(0, degree + 1):
+                    actual_j = (spans[i] - degree + j) % nb
+                    out[i, actual_j] = basis[i, j]
+        else:
+            for i in range(0, nx):
+                out[i, spans[i] - degree:spans[i] + 1] = basis[i, :]
+    else:
+        integrals = np.zeros(knots.shape[0] - degree - 1)
+        basis_integrals_p(knots, degree, integrals)
+        if periodic:
+            for i in range(0, nx):
+                for j in range(0, degree + 1):
+                    actual_j = (spans[i] - degree + j) % nb
+                    out[i, actual_j] = basis[i, j] / integrals[spans[i] - degree + j]
+
+        else:
+            scaling = np.ones_like(integrals) / integrals
+            for i in range(0, nx):
+                local_scaling = scaling[spans[i] - degree:spans[i] + 1]
+                out[i, spans[i] - degree:spans[i] + 1] = basis[i, :] * local_scaling[:]
+
+    # Mitigate round-off errors
+    for x in range(nx):
+        for y in range(nb):
+            if abs(out[x, y]) < 1e-14:
+                out[x, y] = 0.0
+
+
+# def histopolation_matrix(knots: 'float[:]', degree: int, periodic: bool, normalization: bool, xgrid: 'float[:]',
+#                          check_boundary: bool, out: 'float[:,:]'):
+#
+#     nb = len(knots) - degree - 1
+#     if periodic:
+#         nb -= degree
+#
+#     # Number of evaluation points
+#     nx = len(xgrid)
+#
+#     # In periodic case, make sure that evaluation points include domain boundaries
+#     if periodic:
+#         xmin = knots[degree]
+#         xmax = knots[-1 - degree]
+#         if xgrid[0] > xmin:
+#             xgrid = [xmin, *xgrid]
+#         if xgrid[-1] < xmax:
+#             xgrid = [*xgrid, xmax]
+#
+#     # New knots
+#
+#     # B-splines of degree p+1: basis[i,j] := Bj(xi)
+#     #
+#     # NOTES:
+#     #  . cannot use M-splines in analytical formula for histopolation matrix
+#     #  . always use non-periodic splines to avoid circulant matrix structure
+#     colloc = np.zeros((nx, nb))
+#     collocation_matrix_p(knots,
+#                          degree + 1,
+#                          False,
+#                          False,
+#                          xgrid,
+#                          colloc)
+
+
+def elevate_knots(knots: 'float[:]', degree: int, periodic: bool, out: 'float[:]',
+                  multiplicity: int = 1,
+                  tol: float = 1e-15):
+    """
+    Given the knot sequence of a spline space S of degree p, compute the knot
+    sequence of a spline space S_0 of degree p+1 such that u' is in S for all
+    u in S_0.
+
+    Specifically, on bounded domains the first and last knots are repeated in
+    the sequence, and in the periodic case the knot sequence is extended by
+    periodicity.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence of spline space of degree p.
+    degree : int
+        Spline degree (= polynomial degree within each interval).
+    periodic : bool
+        True if domain is periodic, False otherwise.
+    multiplicity : int
+        Multiplicity of the knots in the knot sequence, we assume that the same
+        multiplicity applies to each interior knot.
+    tol: float
+        If the distance between two knots is less than tol, we assume
+        that they are repeated knots which correspond to the same break point.
+
+    Returns
+    -------
+    new_knots : 1D numpy.ndarray
+        Knots sequence of spline space of degree p+1.
+    """
+
+    if periodic:
+        T, p = knots, degree
+        period = T[len(knots) -1 - p] - T[p]
+        left   = T[len(knots) -2 - 2 * p] - period
+        right  = T[2 * p + 1] + period
+
+        out[0] = left
+        out[-1] = right
+        out[1: - 1] = knots
+
+    else:
+        out[0] = knots[0]
+        out[1:degree + 2] = knots[:degree+1]
+
+        n_out = out.shape[0]
+        n_knots = len(knots)
+        out[n_out - degree - 2] = knots[n_knots - 1]
+        out[n_out - degree - 1:n_out] = knots[n_knots - degree - 1:]
+
+        if len(knots[degree + 1:n_knots - degree - 1]) > 0:
+            out[degree + 2: degree + 2 + multiplicity] = knots[degree + 1]
+
+            unique_index = 0
+
+            for i in range(degree + 1, len(knots) - degree - 2, 1):
+                if knots[i + 1] - knots[i] > tol:
+                    out[degree + 2 + multiplicity * (unique_index + 1):
+                        degree + 2 + multiplicity * (unique_index + 2)] = knots[i + 1]
+                    unique_index += 1
+
+        else:
+            out[degree + 2: n_out - degree - 2] = knots[degree + 1:n_knots - degree - 1]

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -900,16 +900,16 @@ def quadrature_grid_p(breaks: 'float[:]', quad_rule_x: 'float[:]', quad_rule_w: 
         Weights assigned to quadrature points on canonical interval [-1,1].
 
     out1 : array
-        Half of the result will be inserted into this array.
+        2D output array where the quadrature points will be inserted.
         It should be of the appropriate shape and dtype.
 
     out2 : array
-        Half of the result will be inserted into this array.
+        2D output array where the quadrature weights will be inserted.
         It should be of the appropriate shape and dtype.
 
     Notes
     -----
-    Contents of 2D output arrays 'quad_x' and 'quad_w' are accessed with two
+    Contents of 2D output arrays 'out1' and 'out2' are accessed with two
     indices (ie,iq) where:
       . ie is the global element index;
       . iq is the local index of a quadrature point within the element.
@@ -961,8 +961,8 @@ def basis_ders_on_quad_grid_p(knots: 'float[:]', degree: int, quad_grid: 'float[
 
     Notes
     -----
-        Values of B-Splines and their derivatives at quadrature points in
-        each element of 1D domain. Indices are
+        4D output array 'out' contains values of B-Splines and their derivatives
+        at quadrature points in each element of 1D domain. Indices are
         . ie: global element         (0 <= ie <  ne    )
         . il: local basis function   (0 <= il <= degree)
         . id: derivative             (0 <= id <= nders )

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -667,7 +667,7 @@ def merge_sort(a: 'float[:]') -> 'float[:]':
 
 
 # =============================================================================
-def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float = 1e-15):
+def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float):
     """
     Determine breakpoints' coordinates.
 

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -988,5 +988,5 @@ def basis_ders_on_quad_grid_p(knots: 'float[:]', degree: int, quad_grid: 'float[
             basis_funs_all_ders_p(knots, degree, xq, span, nders, False, ders)
             if normalization:
                 ders *= scaling[span - degree:span + 1]
-            for id in range(degree + 1):
-                out[ie, id, :, iq] = ders[:, id]
+            for k in range(degree + 1):
+                out[ie, k, :, iq] = ders[:, k]

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -948,10 +948,13 @@ def quadrature_grid_p(breaks: 'float[:]', quad_rule_x: 'float[:]', quad_rule_w: 
     quad_rule_w : array_like of ints
         Weights assigned to quadrature points on canonical interval [-1,1].
 
-    out : array
-        The result will be inserted into this array.
+    out1 : array
+        Half of the result will be inserted into this array.
         It should be of the appropriate shape and dtype.
 
+    out2 : array
+        Half of the result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     Notes
     -----
     Contents of 2D output arrays 'quad_x' and 'quad_w' are accessed with two

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -4,32 +4,32 @@
 
 import numpy as np
 
-#==============================================================================
+
+# =============================================================================
 def find_span_p(knots: 'float[:]', degree: int, x: float):
     """
-    Determine the knot span index at location x, given the B-Splines' knot
-    sequence and polynomial degree. See Algorithm A2.1 in [1].
+        Determine the knot span index at location x, given the B-Splines' knot
+        sequence and polynomial degree. See Algorithm A2.1 in [1].
 
-    For a degree p, the knot span index i identifies the indices [i-p:i] of all
-    p+1 non-zero basis functions at a given location x.
+        For a degree p, the knot span index i identifies the indices [i-p:i] of all
+        p+1 non-zero basis functions at a given location x.
 
-    Parameters
-    ----------
-    knots : array_like
-        Knots sequence.
+        Parameters
+        ----------
+        knots : array_like
+            Knots sequence.
 
-    degree : int
-        Polynomial degree of B-splines.
+        degree : int
+            Polynomial degree of B-splines.
 
-    x : float
-        Location of interest.
+        x : float
+            Location of interest.
 
-    Returns
-    -------
-    span : int
-        Knot span index.
-
-    """
+        Returns
+         -------
+        span : int
+            Knot span index.
+        """
     # Knot index at left/right boundary
     low  = degree
     high = len(knots)-1-degree
@@ -49,9 +49,11 @@ def find_span_p(knots: 'float[:]', degree: int, x: float):
 
     return span
 
-#==============================================================================
+
+# =============================================================================
 def find_spans_p(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
-    """Determine the knot span index at locations in x, given the B-Splines' knot
+    """
+    Determine the knot span index at a set of locations x, given the B-Splines' knot
     sequence and polynomial degree. See Algorithm A2.1 in [1].
 
     For a degree p, the knot span index i identifies the indices [i-p:i] of all
@@ -59,32 +61,29 @@ def find_spans_p(knots: 'float[:]', degree: int, x: 'float[:]', out: 'int[:]'):
 
     Parameters
     ----------
-    knots: array_like of floats
-        Knot sequence.
+    knots : array_like
+        Knots sequence.
 
-    degree: int
-        Polynomial degree of the BSplines.
+    degree : int
+        Polynomial degree of B-splines.
 
-    x: array_like of floats
-        Locations of interest
+    x : array
+        Location of interest.
 
-    out: array_like of ints
-        Knot span index for each location in x.
-
-    See Also
-    --------
-    psydac.core.bsplines.find_span : Determines the knot span at a location.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     """
     n = x.shape[0]
 
     for i in range(n):
         out[i] = find_span_p(knots, degree, x[i])
 
-#==============================================================================
+
+# =============================================================================
 def basis_funs_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
     """
-    Compute the non-vanishing B-splines at location x, given the knot sequence,
-    polynomial degree and knot span. See Algorithm A2.2 in [1].
+    Compute the non-vanishing B-splines at a unique location.
 
     Parameters
     ----------
@@ -100,14 +99,9 @@ def basis_funs_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'floa
     span : int
         Knot span index.
 
-    out : array_like of floats
-        Values of p+1 non-vanishing B-Splines at location x.
-
-    Notes
-    -----
-    The original Algorithm A2.2 in The NURBS Book [1] is here slightly improved
-    by using 'left' and 'right' temporary arrays that are one element shorter.
-
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     """
     left = np.zeros(degree, dtype=float)
     right = np.zeros(degree, dtype=float)
@@ -123,7 +117,8 @@ def basis_funs_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'floa
             saved  = left[j - r] * temp
         out[j + 1] = saved
 
-#==============================================================================
+
+# =============================================================================
 def basis_funs_array_p(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int[:]', out: 'float[:,:]'):
     """
     Compute the non-vanishing B-splines at locations in x, given the knot sequence,
@@ -143,23 +138,20 @@ def basis_funs_array_p(knots: 'float[:]', degree: int, x: 'float[:]', span: 'int
     span : array_like of int
         Knot span indexes.
 
-    out : array_like of floats
-        Values of p+1 non-vanishing B-Splines at all locations in x.
-
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     """
 
     n = x.shape[0]
     for i in range(n):
         basis_funs_p(knots, degree, x[i], span[i], out[i, :])
 
-#==============================================================================
+
+# =============================================================================
 def basis_funs_1st_der_p(knots: 'float[:]', degree: int, x: float, span: int, out: 'float[:]'):
     """
-    Compute the first derivative of the non-vanishing B-splines at location x,
-    given the knot sequence, polynomial degree and knot span.
-
-    See function 's_bsplines_non_uniform__eval_deriv' in Selalib's source file
-    'src/splines/sll_m_bsplines_non_uniform.F90'.
+    Compute the first derivative of the non-vanishing B-splines at a location.
 
     Parameters
     ----------
@@ -175,9 +167,18 @@ def basis_funs_1st_der_p(knots: 'float[:]', degree: int, x: float, span: int, ou
     span : int
         Knot span index.
 
-    out : numpy.ndarray
-        Derivatives of p+1 non-vanishing B-Splines at location x.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
+    Notes
+    -----
+    See function 's_bsplines_non_uniform__eval_deriv' in Selalib's ([2]) source file
+    'src/splines/sll_m_bsplines_non_uniform.F90'.
+
+    References
+    ----------
+    .. [2] SELALIB, Semi-Lagrangian Library. http://selalib.gforge.inria.fr
     """
     # Compute nonzero basis functions and knot differences for splines
     # up to degree deg-1
@@ -199,20 +200,28 @@ def basis_funs_1st_der_p(knots: 'float[:]', degree: int, x: float, span: int, ou
     out[degree] = saved
 
 
+# =============================================================================
 def dot_2d(a: 'float[:, :]', b: 'float[:, :]', out: 'float[:, :]'):
     for i in range(a.shape[0]):
         for k in range(b.shape[1]):
             out[i, k] = np.sum(a[i, :] * b[:, k])
 
 
+# =============================================================================
 def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n: int, normalization: bool,
                           out: 'float[:,:]'):
     """
     Evaluate value and n derivatives at x of all basis functions with
-    support in interval [x_{span-1}, x_{span}].
+    support in interval :math:`[x_{span-1}, x_{span}]`.
 
-    ders[i,j] = (d/dx)^i B_k(x) with k=(span-degree+j),
-                for 0 <= i <= n and 0 <= j <= degree+1.
+    If called with normalization='M', this uses M-splines instead of B-splines.
+
+    Fills a  2D array with n+1 (from 0-th to n-th) derivatives at x
+    of all (degree+1) non-vanishing basis functions in given span.
+
+    .. math::
+        ders[i,j] = \\frac{d^i}{dx^i} B_k(x) \\, \\text{with} k=(span-degree+j),
+        \\forall (i,j),  0 \\leq i \\leq n \\, 0 \\leq j \\leq \\text{degree}+1.
 
     Parameters
     ----------
@@ -231,18 +240,12 @@ def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n
     n : int
         Max derivative of interest.
 
+    normalization: str
+        Set to 'B' to get B-Splines and 'M' to get M-Splines
 
-    -------
-    ders : numpy.ndarray (n+1,degree+1)
-        2D array of n+1 (from 0-th to n-th) derivatives at x of all (degree+1)
-        non-vanishing basis functions in given span.
-
-    Notes
-    -----
-    The original Algorithm A2.3 in The NURBS Book [1] is here improved:
-        - 'left' and 'right' arrays are 1 element shorter;
-        - inverse of knot differences are saved to avoid unnecessary divisions;
-        - innermost loops are replaced with vector operations on slices.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     """
     left  = np.empty(degree)
     right = np.empty(degree)
@@ -311,33 +314,30 @@ def basis_funs_all_ders_p(knots: 'float[:]', degree: int, x: float, span: int, n
 
     if normalization:
         for i in range(degree + 1):
-            out[i, :] *= (degree + 1) / (knots[i + span + 1] - knots[i + span - degree])
+            out[:, i] *= (degree + 1) / (knots[i + span + 1] - knots[i + span - degree])
 
-    # if normalization == 'M':
-    #     ders *= [(degree + 1) / (knots[i + degree + 1] - knots[i]) \
-    #              for i in range(span - degree, span + 1)]
 
+# =============================================================================
 def basis_integrals_p(knots: 'float[:]', degree: int, out: 'float[:]'):
-    r"""
+    """
     Return the integral of each B-spline basis function over the real line:
 
-    K[i] := \int_{-\infty}^{+\infty} B[i](x) dx = (T[i+p+1]-T[i]) / (p+1).
+    :math: K[i] := \\int_{-\\infty}^{+\\infty} B[i](x) dx = (T[i+p+1]-T[i]) / (p+1).
 
     This array can be used to convert B-splines to M-splines, which have unit
     integral over the real line but no partition-of-unity property.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
         Polynomial degree of B-splines.
 
-    Returns
-    -------
-    K : 1D numpy.ndarray
-        Array with the integrals of each B-spline basis function.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
     Notes
     -----
@@ -354,17 +354,16 @@ def basis_integrals_p(knots: 'float[:]', degree: int, out: 'float[:]'):
         out[i] = (T[i + p + 1] - T[i])/ (p + 1)
 
 
+# =============================================================================
 def collocation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normalization: bool, xgrid: 'float[:]',
                          out: 'float[:,:]'):
-    """
-    Compute the collocation matrix $C_ij = B_j(x_i)$, which contains the
-    values of each B-spline basis function $B_j$ at all locations $x_i$.
+    """Computes the collocation matrix
 
     If called with normalization='M', this uses M-splines instead of B-splines.
 
     Parameters
     ----------
-    knots : 1D array_like
+    knots : array_like
         Knots sequence.
 
     degree : int
@@ -373,15 +372,20 @@ def collocation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normali
     periodic : bool
         True if domain is periodic, False otherwise.
 
-    normalization : bool
-        Set to False for B-splines, and True for M-splines.
+    normalization : str
+        Set to 'B' for B-splines, and 'M' for M-splines.
 
-    xgrid : 1D array_like
+    xgrid : array_like
         Evaluation points.
 
-    out : 2D numpy.ndarray
-        Collocation matrix: values of all basis functions on each point in xgrid.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
 
+    Notes
+    -----
+    The collocation matrix :math:`C_ij = B_j(x_i)`, contains the
+    values of each B-spline basis function :math:`B_j` at all locations :math:`x_i`.
     """
 
     # Number of basis functions (in periodic case remove degree repeated elements)
@@ -431,157 +435,403 @@ def collocation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normali
                 out[x, y] = 0.0
 
 
-# def histopolation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normalization: bool, xgrid: 'float[:]',
-#                            check_boundary: bool, elevated_knots: 'float[:]', out: 'float[:,:]'):
-#
-#     nb = len(knots) - degree - 1
-#     if periodic:
-#         nb -= degree
-#
-#     # Number of evaluation points
-#     nx = len(xgrid)
-#
-#     # In periodic case, make sure that evaluation points include domain boundaries
-#
-#     if periodic:
-#         xgrid_new = np.zeros(shape=xgrid.shape[0])
-#         if check_boundary:
-#             xmin = knots[degree]
-#             xmax = knots[-1 - degree]
-#             if xgrid[0] > xmin:
-#                 xgrid_new[0] = xmin
-#                 xgrid_new[1:] = xgrid[:-1]
-#                 np.append(xgrid_new, xgrid[-1])
-#             elif xgrid[-1] < xmax:
-#                 np.append(xgrid_new, xmax)
-#                 xgrid_new[:-1] = xgrid
-#             else:
-#                 xgrid_new[:] = xgrid
-#         else:
-#             xgrid_new[:] = xgrid
-#
-#         B-splines of degree p+1: basis[i,j] := Bj(xi)
-#
-#         NOTES:
-#          . cannot use M-splines in analytical formula for histopolation matrix
-#          . always use non-periodic splines to avoid circulant matrix structure
-#
-#         colloc = np.zeros((nx + 1, nb))
-#         collocation_matrix_p(elevated_knots,
-#                              degree + 1,
-#                              False,
-#                              False,
-#                              xgrid_new,
-#                              colloc)
-#
-#         m = colloc.shape[0] - 1
-#         n = colloc.shape[1] - 1
-#
-#         spans = np.zeros(colloc.shape[0], dtype=int)
-#         for i in range(colloc.shape[0]):
-#             local_span = 0
-#             for j in range(colloc.shape[0] - 1, 0, -1):
-#                 if abs(colloc[i, j]) > 1e-15:
-#                     local_span = j
-#                     break
-#             spans[i] = local_span + degree + 1
-#
-#         # Compute histopolation matrix from collocation matrix of higher degree
-#         H = np.zeros((m, n))
-#         if normalization:
-#             for i in range(m):
-#                 # Indices of first/last non-zero elements in row of collocation matrix
-#                 jstart = spans[i] - (degree + 1)
-#                 jend = min(spans[i + 1], n)
-#                 # Compute non-zero values of histopolation matrix
-#                 for j in range(1 + jstart, jend + 1):
-#                     s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
-#                     H[i, j - 1] = s
-#
-#         else:
-#             integrals = np.zeros(knots.shape[0] - degree - 1)
-#             basis_integrals_p(knots, degree, integrals)
-#             for i in range(m):
-#                 # Indices of first/last non-zero elements in row of collocation matrix
-#                 jstart = spans[i] - (degree + 1)
-#                 jend = min(spans[i + 1], n)
-#                 # Compute non-zero values of histopolation matrix
-#                 for j in range(1 + jstart, jend + 1):
-#                     s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
-#                     H[i, j - 1] = s * integrals[j - 1]
-#
-#         # Mitigate round-off errors
-#         for i in range(m):
-#             for j in range(n):
-#                 if abs(out[i, j]) < 1e-14:
-#                     H[i, j] = 0.0
-#
-#         # Periodic case: wrap around histopolation matrix
-#         #  1. identify repeated basis functions (sum columns)
-#         #  2. identify split interval (sum rows)
-#         for i in range(m):
-#             for j in range(n):
-#                 out[i%nx, j%nb] += H[i, j]
-#
-#     else:
-#
-#         # B-splines of degree p+1: basis[i,j] := Bj(xi)
-#         #
-#         # NOTES:
-#         #  . cannot use M-splines in analytical formula for histopolation matrix
-#         #  . always use non-periodic splines to avoid circulant matrix structure
-#
-#         colloc = np.zeros((nx, nb))
-#         collocation_matrix_p(elevated_knots,
-#                              degree + 1,
-#                              False,
-#                              False,
-#                              xgrid,
-#                              colloc)
-#
-#         spans = np.zeros(colloc.shape[0], dtype=int)
-#         for i in range(colloc.shape[0]):
-#             local_span = 0
-#             for j in range(colloc.shape[0] - 1, 0, -1):
-#                 if abs(colloc[i, j]) > 1e-15:
-#                     local_span = j
-#                     break
-#             spans[i] = local_span + degree + 1
-#
-#         m = colloc.shape[0] - 1
-#         n = colloc.shape[1] - 1
-#         # Compute histopolation matrix from collocation matrix of higher degree
-#         if normalization:
-#             for i in range(m):
-#                 # Indices of first/last non-zero elements in row of collocation matrix
-#                 jstart = spans[i] - (degree + 1)
-#                 jend = min(spans[i + 1], n)
-#                 # Compute non-zero values of histopolation matrix
-#                 for j in range(1 + jstart, jend + 1):
-#                     s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
-#                     out[i, j - 1] = s
-#
-#         else:
-#             integrals = np.zeros(knots.shape[0] - degree - 1)
-#             basis_integrals_p(knots, degree, integrals)
-#             for i in range(m):
-#                 # Indices of first/last non-zero elements in row of collocation matrix
-#                 jstart = spans[i] - (degree + 1)
-#                 jend = min(spans[i + 1], n)
-#                 # Compute non-zero values of histopolation matrix
-#                 for j in range(1 + jstart, jend + 1):
-#                     s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
-#                     out[i, j - 1] = s * integrals[j - 1]
-#
-#         # Mitigate round-off errors
-#         for i in range(m):
-#             for j in range(n):
-#                 if abs(out[i, j]) < 1e-14:
-#                     out[i, j] = 0.0
-#
-#         # Non periodic case: stop here
+# =============================================================================
+def histopolation_matrix_p(knots: 'float[:]', degree: int, periodic: bool, normalization: bool, xgrid: 'float[:]',
+                           check_boundary: bool, elevated_knots: 'float[:]', out: 'float[:,:]'):
+    """Computes the histopolation matrix.
+
+    If called with normalization='M', this uses M-splines instead of B-splines.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of spline space.
+
+    periodic : bool
+        True if domain is periodic, False otherwise.
+
+    normalization : str
+        Set to 'B' for B-splines, and 'M' for M-splines.
+
+    xgrid : array_like
+        Grid points.
+
+    check_boundary : bool, default=True
+        If true and ``periodic``, will check the boundaries of ``xgrid``.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Notes
+    -----
+    The histopolation matrix :math:`H_{ij} = \\int_{x_i}^{x_{i+1}}B_j(x)\\,dx`
+    contains the integrals of each B-spline basis function :math:`B_j` between
+    two successive grid points.
+    """
+    nb = len(knots) - degree - 1
+    if periodic:
+        nb -= degree
+
+    # Number of evaluation points
+    nx = len(xgrid)
+
+    # In periodic case, make sure that evaluation points include domain boundaries
+
+    if periodic:
+        xgrid_new = np.zeros(len(xgrid) + 2)
+        actual_len = len(xgrid)
+        if check_boundary:
+            xmin = knots[degree]
+            xmax = knots[len(knots) - 1 - degree]
+
+            if xgrid[0] > xmin and xgrid[-1] < xmax:
+                xgrid_new[0] = xmin
+                xgrid_new[1:-1] = xgrid[:]
+                xgrid_new[-1] = xmax
+                actual_len += 2
+
+            elif xgrid[0] > xmin:
+                xgrid_new[0] = xmin
+                xgrid_new[1:-1] = xgrid[:]
+                actual_len += 1
+
+            elif xgrid[-1] < xmax:
+                xgrid_new[-2] = xmax
+                xgrid_new[:-2] = xgrid
+                actual_len += 1
+            else:
+                xgrid_new[:-2] = xgrid
+
+        else:
+            xgrid_new[:-2] = xgrid
+
+        # B-splines of degree p+1: basis[i,j] := Bj(xi)
+
+        # NOTES:
+        #  . cannot use M-splines in analytical formula for histopolation matrix
+        #  . always use non-periodic splines to avoid circulant matrix structure
+        nb_elevated = len(elevated_knots) - (degree + 1) - 1
+        colloc = np.zeros((actual_len, nb_elevated))
+        collocation_matrix_p(elevated_knots,
+                             degree + 1,
+                             False,
+                             False,
+                             xgrid_new[:actual_len],
+                             colloc)
+
+        m = colloc.shape[0] - 1
+        n = colloc.shape[1] - 1
+
+        spans = np.zeros(colloc.shape[0], dtype=int)
+        for i in range(colloc.shape[0]):
+            local_span = 0
+            for j in range(colloc.shape[1]):
+                if abs(colloc[i, j]) != 0:
+                    local_span = j
+                    break
+            spans[i] = local_span + degree + 1
+
+        # Compute histopolation matrix from collocation matrix of higher degree
+        H = np.zeros((m, n))
+        if normalization:
+            for i in range(m):
+                # Indices of first/last non-zero elements in row of collocation matrix
+                jstart = spans[i] - (degree + 1)
+                jend = min(spans[i + 1], n)
+                # Compute non-zero values of histopolation matrix
+                for j in range(1 + jstart, jend + 1):
+                    s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
+                    H[i, j - 1] = s
+
+        else:
+            integrals = np.zeros(knots.shape[0] - degree - 1)
+            basis_integrals_p(knots, degree, integrals)
+            for i in range(m):
+                # Indices of first/last non-zero elements in row of collocation matrix
+                jstart = spans[i] - (degree + 1)
+                jend = min(spans[i + 1], n)
+                # Compute non-zero values of histopolation matrix
+                for j in range(1 + jstart, jend + 1):
+                    s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
+                    H[i, j - 1] = s * integrals[j - 1]
+
+        # Mitigate round-off errors
+        for i in range(m):
+            for j in range(n):
+                if abs(H[i, j]) < 1e-14:
+                    H[i, j] = 0.0
+
+        # Periodic case: wrap around histopolation matrix
+        #  1. identify repeated basis functions (sum columns)
+        #  2. identify split interval (sum rows)
+        for i in range(m):
+            for j in range(n):
+                out[i % nx, j % nb] += H[i, j]
+
+    else:
+
+        # B-splines of degree p+1: basis[i,j] := Bj(xi)
+
+        # NOTES:
+        #  . cannot use M-splines in analytical formula for histopolation matrix
+        #  . always use non-periodic splines to avoid circulant matrix structure
+        nb_elevated = len(elevated_knots) - (degree + 1) - 1
+        colloc = np.zeros((nx, nb_elevated))
+        collocation_matrix_p(elevated_knots,
+                             degree + 1,
+                             False,
+                             False,
+                             xgrid,
+                             colloc)
+
+        spans = np.zeros(colloc.shape[0], dtype=int)
+        for i in range(colloc.shape[0]):
+            local_span = 0
+            for j in range(colloc.shape[1]):
+                if abs(colloc[i, j]) != 0:
+                    local_span = j
+                    break
+            spans[i] = local_span + degree + 1
+
+        m = colloc.shape[0] - 1
+        n = colloc.shape[1] - 1
+        # Compute histopolation matrix from collocation matrix of higher degree
+        if normalization:
+            for i in range(m):
+                # Indices of first/last non-zero elements in row of collocation matrix
+                jstart = spans[i] - (degree + 1)
+                jend = min(spans[i + 1], n)
+                # Compute non-zero values of histopolation matrix
+                for j in range(1 + jstart, jend + 1):
+                    s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
+                    out[i, j - 1] = s
+
+        else:
+            integrals = np.zeros(knots.shape[0] - degree - 1)
+            basis_integrals_p(knots, degree, integrals)
+            for i in range(m):
+                # Indices of first/last non-zero elements in row of collocation matrix
+                jstart = spans[i] - (degree + 1)
+                jend = min(spans[i + 1], n)
+                # Compute non-zero values of histopolation matrix
+                for j in range(1 + jstart, jend + 1):
+                    s = np.sum(colloc[i, 0:j]) - np.sum(colloc[i + 1, 0:j])
+                    out[i, j - 1] = s * integrals[j - 1]
+
+        # Mitigate round-off errors
+        for i in range(m):
+            for j in range(n):
+                if abs(out[i, j]) < 1e-14:
+                    out[i, j] = 0.0
+
+            # Non periodic case: stop here
 
 
+# =============================================================================
+def merge_sort(a: 'float[:]') -> 'float[:]':
+    if len(a) != 1 and len(a) != 0:
+        n = len(a)
+
+        a1 = np.zeros(n // 2)
+        a1[:] = a[:n // 2]
+        a2 = np.zeros(n - n // 2)
+        a2[:] = a[n // 2:]
+
+        merge_sort(a1)
+        merge_sort(a2)
+
+        i_a1 = 0
+        i_a2 = 0
+        for i in range(n):
+            a1_i = a1[i_a1]
+            a2_i = a2[i_a2]
+            if a1_i < a2_i:
+                a[i] = a1_i
+                i_a1 += 1
+            else:
+                a[i] = a2_i
+                i_a2 += 1
+            if i_a1 == len(a1) or i_a2 == len(a2):
+                last_i = i
+                break
+
+        for i_1 in range(n // 2 - i_a1):
+            a[last_i + 1 + i_1] = a1[i_a1 + i_1]
+
+        for i_2 in range(n - n // 2 - i_a2):
+            a[last_i + 1 + i_2] = a2[i_a2 + i_2]
+
+
+# =============================================================================
+def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float = 1e-15):
+    """
+    Determine breakpoints' coordinates.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    tol: float
+        If the distance between two knots is less than tol, we assume
+        that they are repeated knots which correspond to the same break point.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Returns
+    -------
+    breaks : numpy.ndarray (1D)
+        Abscissas of all breakpoints.
+    """
+    out[0] = knots[degree]
+    i_out = 1
+    for i in range(degree + 1, len(knots) - degree):
+        if abs(knots[i] - knots[i + 1]) > tol:
+            out[i_out] = knots[i]
+            i_out += 1
+    return i_out
+
+# =============================================================================
+def greville_p(knots: 'float[:]', degree: int, periodic: bool, out:'float[:]'):
+    """
+    Compute coordinates of all Greville points.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    periodic : bool
+        True if domain is periodic, False otherwise.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+    """
+    T = knots
+    p = degree
+    n = len(T)-2*p-1 if periodic else len(T)-p-1
+
+    # Compute greville abscissas as average of p consecutive knot values
+    for i in range(1, 1+n):
+        out[i - 1] = sum(T[i:i + p]) / p
+
+    # Domain boundaries
+    a = T[p]
+    b = T[len(T) - 1 - p]
+
+    # If needed apply periodic boundary conditions, then sort array
+    if periodic:
+        out[:] = (out[:] - a) % (b-a) + a
+        merge_sort(out)
+
+    # Make sure roundoff errors don't push Greville points outside domain
+    out[0] = max(out[0], a)
+    out[-1] = min(out[-1], b)
+
+
+# =============================================================================
+def elements_spans_p(knots: 'float[:]', degree: int, out: 'int[:]'):
+    """
+    Compute the index of the last non-vanishing spline on each grid element
+    (cell). The length of the returned array is the number of cells.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Notes
+    -----
+    1) Numbering of basis functions starts from 0, not 1;
+    2) This function could be written in two lines:
+
+       breaks = breakpoints( knots, degree )
+       spans  = np.searchsorted( knots, breaks[:-1], side='right' ) - 1
+    """
+    temp_array = np.zeros(len(knots))
+
+    actual_len = breakpoints_p( knots, degree, temp_array)
+
+    nk     = len(knots)
+    ne     = actual_len - 1
+
+    ie = 0
+    for ik in range(degree, nk-degree):
+        if knots[ik + 1] - knots[ik] >= 1e-15:
+            out[ie] = ik
+            ie += 1
+        if ie == ne:
+            break
+
+    return ne
+
+
+# =============================================================================
+def make_knots_p(breaks: 'float[:]', degree: int, periodic: bool, out: 'float[:]', multiplicity: int = 1):
+    """
+    Create spline knots from breakpoints, with appropriate boundary conditions.
+    Let p be spline degree. If domain is periodic, knot sequence is extended
+    by periodicity so that first p basis functions are identical to last p.
+    Otherwise, knot sequence is clamped (i.e. endpoints are repeated p times).
+
+    Parameters
+    ----------
+    breaks : array_like
+        Coordinates of breakpoints (= cell edges); given in increasing order and
+        with no duplicates.
+
+    degree : int
+        Spline degree (= polynomial degree within each interval).
+
+    periodic : bool
+        True if domain is periodic, False otherwise.
+
+    multiplicity: int
+        Multiplicity of the knots in the knot sequence, we assume that the same
+        multiplicity applies to each interior knot.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+.
+    """
+    for i in range(1, len(breaks) - 1):
+        out[degree + 1  + (i - 1) * multiplicity:degree + 1 + i * multiplicity] = breaks[i]
+
+    out[degree] = breaks[0]
+    out[len(out) - degree - 1] = breaks[-1]
+
+    if periodic:
+        period = breaks[-1]-breaks[0]
+        for i in range(degree):
+            out[i] = breaks[len(breaks) - degree - 1 + i] - period
+            out[len(out) - 1 - i] = breaks[degree - i] + period
+    else:
+        out[0:degree + 1] = breaks[0]
+        out[len(out) - degree - 1:] = breaks[-1]
+
+
+# =============================================================================
 def elevate_knots_p(knots: 'float[:]', degree: int, periodic: bool, out: 'float[:]',
                     multiplicity: int = 1,
                     tol: float = 1e-15):
@@ -598,21 +848,24 @@ def elevate_knots_p(knots: 'float[:]', degree: int, periodic: bool, out: 'float[
     ----------
     knots : array_like
         Knots sequence of spline space of degree p.
+
     degree : int
         Spline degree (= polynomial degree within each interval).
+
     periodic : bool
         True if domain is periodic, False otherwise.
+
     multiplicity : int
         Multiplicity of the knots in the knot sequence, we assume that the same
         multiplicity applies to each interior knot.
+
     tol: float
         If the distance between two knots is less than tol, we assume
         that they are repeated knots which correspond to the same break point.
 
-    Returns
-    -------
-    new_knots : 1D numpy.ndarray
-        Knots sequence of spline space of degree p+1.
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
     """
 
     if periodic:
@@ -647,3 +900,118 @@ def elevate_knots_p(knots: 'float[:]', degree: int, periodic: bool, out: 'float[
 
         else:
             out[degree + 2: n_out - degree - 2] = knots[degree + 1:n_knots - degree - 1]
+
+
+# =============================================================================
+def quadrature_grid_p(breaks: 'float[:]', quad_rule_x: 'float[:]', quad_rule_w: 'float[:]', out: 'float[:,:,:]'):
+    """
+    Compute the quadrature points and weights for performing integrals over
+    each element (interval) of the 1D domain, given a certain Gaussian
+    quadrature rule.
+
+    An n-point Gaussian quadrature rule for the canonical interval :math:`[-1,+1]`
+    and trivial weighting function :math:`\\omega(x)=1` is defined by the n abscissas
+    :math:`x_i` and n weights :math:`w_i` that satisfy the following identity for
+    polynomial functions :math:`f(x)` of degree :math:`2n-1` or less:
+
+    .. math :: \\int_{-1}^{+1} f(x) dx = \\sum_{i=0}^{n-1} w_i f(x_i)
+
+    Parameters
+    ----------
+    breaks : array_like of floats
+        Coordinates of spline breakpoints.
+
+    quad_rule_x : array_like of ints
+        Coordinates of quadrature points on canonical interval [-1,1].
+
+    quad_rule_w : array_like of ints
+        Weights assigned to quadrature points on canonical interval [-1,1].
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Notes
+    -----
+    Contents of 2D output arrays 'quad_x' and 'quad_w' are accessed with two
+    indices (ie,iq) where:
+      . ie is the global element index;
+      . iq is the local index of a quadrature point within the element.
+
+    """
+    ne = len(breaks) - 1
+    nq = len(quad_rule_x)
+
+    # Compute location and weight of quadrature points from basic rule
+    for ie in range(len(breaks) - 1):
+        a = breaks[ie]
+        b = breaks[ie + 1]
+
+        c0 = 0.5 * (a + b)
+        c1 = 0.5 * (b - a)
+        out[ie, :, 0] = c1 * quad_rule_x[:] + c0
+        out[ie, :, 1] = c1 * quad_rule_w[:]
+
+
+# =============================================================================
+def basis_ders_on_quad_grid_p(knots: 'float[:]', degree: int, quad_grid: 'float[:,:]', nders: int, normalization: bool,
+                            out: 'float[:,:,:,:]'):
+    """
+    Evaluate B-Splines and their derivatives on the quadrature grid.
+
+    If called with normalization='M', this uses M-splines instead of B-splines.
+
+    Parameters
+    ----------
+    knots : array_like
+        Knots sequence.
+
+    degree : int
+        Polynomial degree of B-splines.
+
+    quad_grid: ndarray
+        2D array of shape (ne, nq). Coordinates of quadrature points of
+        each element in 1D domain, which can be given by quadrature_grid()
+        or chosen arbitrarily.
+
+    nders : int
+        Maximum derivative of interest.
+
+    normalization : str
+        Set to 'B' for B-splines, and 'M' for M-splines.
+
+    out : array
+        The result will be inserted into this array.
+        It should be of the appropriate shape and dtype.
+
+    Notes
+    -----
+        Values of B-Splines and their derivatives at quadrature points in
+        each element of 1D domain. Indices are
+        . ie: global element         (0 <= ie <  ne    )
+        . il: local basis function   (0 <= il <= degree)
+        . id: derivative             (0 <= id <= nders )
+        . iq: local quadrature point (0 <= iq <  nq    )
+    """
+
+    ne, nq = quad_grid.shape
+    if normalization:
+        integrals = np.zeros(knots.shape[0] - degree - 1)
+        basis_integrals_p(knots, degree, integrals)
+
+    temp_spans = np.zeros(len(knots), dtype=int)
+    actual_index = elements_spans_p(knots, degree, temp_spans)
+    spans = temp_spans[:actual_index]
+
+    ders = np.zeros((nders + 1, degree + 1))
+
+    for ie in range(ne):
+        xx = quad_grid[ie, :]
+        span = spans[ie]
+        for iq, xq in enumerate(xx):
+            basis_funs_all_ders_p(knots, degree, xq, span, nders, False, ders)
+            if normalization:
+                ders /= integrals[span - degree:span + 1]
+            for i_der in range(nders + 1):
+                for i_basis in range(degree + 1):
+                    out[ie, i_basis, i_der, iq] = ders[i_der, i_basis]

--- a/psydac/core/bsplines_pyccel.py
+++ b/psydac/core/bsplines_pyccel.py
@@ -667,7 +667,7 @@ def merge_sort(a: 'float[:]') -> 'float[:]':
 
 
 # =============================================================================
-def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float):
+def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float = 1e-15):
     """
     Determine breakpoints' coordinates.
 
@@ -694,11 +694,12 @@ def breakpoints_p(knots: 'float[:]', degree: int, out: 'float[:]', tol: float):
     """
     out[0] = knots[degree]
     i_out = 1
-    for i in range(degree + 1, len(knots) - degree):
+    for i in range(degree, len(knots) - degree - 1):
         if abs(knots[i] - knots[i + 1]) > tol:
-            out[i_out] = knots[i]
+            out[i_out] = knots[i + 1]
             i_out += 1
     return i_out
+
 
 # =============================================================================
 def greville_p(knots: 'float[:]', degree: int, periodic: bool, out:'float[:]'):
@@ -770,14 +771,14 @@ def elements_spans_p(knots: 'float[:]', degree: int, out: 'int[:]'):
     """
     temp_array = np.zeros(len(knots))
 
-    actual_len = breakpoints_p( knots, degree, temp_array)
+    actual_len = breakpoints_p(knots, degree, temp_array)
 
     nk     = len(knots)
     ne     = actual_len - 1
 
     ie = 0
     for ik in range(degree, nk-degree):
-        if knots[ik + 1] - knots[ik] >= 1e-15:
+        if abs(knots[ik + 1] - knots[ik]) >= 1e-15:
             out[ie] = ik
             ie += 1
         if ie == ne:

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -474,10 +474,17 @@ def basis_integrals_true(knots, degree):
 ###############################################################################
 # Tests
 ###############################################################################
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
 def test_find_span(knots, degree, x):
     expected = find_span_true(knots, degree, x)
@@ -486,10 +493,17 @@ def test_find_span(knots, degree, x):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
 def test_basis_funs(knots, degree, x):
     span = find_span(knots, degree, x)
@@ -499,10 +513,17 @@ def test_basis_funs(knots, degree, x):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
 def test_basis_funs_1st_der(knots, degree, x):
     span = find_span(knots, degree, x)
@@ -512,10 +533,17 @@ def test_basis_funs_1st_der(knots, degree, x):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
 @pytest.mark.parametrize('n', (2, 3, 4, 5))
 @pytest.mark.parametrize('normalization', ('B', 'M'))
@@ -527,10 +555,17 @@ def test_basis_funs_all_ders(knots, degree, x, n, normalization):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('periodic', (True, False))
 @pytest.mark.parametrize('normalization', ('B', 'M'))
 @pytest.mark.parametrize('xgrid', (np.random.random(10), np.random.random(15)))
@@ -541,10 +576,17 @@ def test_collocation_matrix(knots, degree, periodic, normalization, xgrid):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('periodic', [True, False])
 @pytest.mark.parametrize('normalization', ('B', 'M'))
 @pytest.mark.parametrize('xgrid', (np.random.random(10), np.random.random(15)))
@@ -555,20 +597,34 @@ def test_histopolation_matrix(knots, degree, periodic, normalization, xgrid):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 def test_breakpoints(knots, degree):
     expected = breakpoints_true(knots, degree)
     out = breakpoints(knots, degree)
 
     assert np.allclose(expected, out)
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('periodic', [True, False])
 def test_greville(knots, degree, periodic):
     expected = greville_true(knots, degree, periodic)
@@ -577,10 +633,17 @@ def test_greville(knots, degree, periodic):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 def test_elements_spans(knots, degree):
     expected = elements_spans_true(knots, degree)
     out = elements_spans(knots, degree)
@@ -601,10 +664,17 @@ def test_make_knots(breaks, degree, periodic, multiplicity):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('periodic', (True, False))
 @pytest.mark.parametrize('multiplicity', (1, 2, 3))
 def test_elevate_knots(knots, degree, periodic, multiplicity):
@@ -625,10 +695,17 @@ def test_quadrature_grid(breaks, quad_order):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 @pytest.mark.parametrize('n', (2, 3, 4, 5))
 @pytest.mark.parametrize('normalization', ('B', 'M'))
 @pytest.mark.parametrize('quad_order', (2, 3, 4, 5))
@@ -643,10 +720,17 @@ def test_basis_ders_on_quad_grid(knots, degree, n, normalization, quad_order):
     assert np.allclose(expected, out)
 
 
-@pytest.mark.parametrize('knots',
-                         (np.sort(np.random.random(15)),
-                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
-@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize(('knots', 'degree'),
+                         [(np.sort(np.random.random(15)), 2),
+                          (np.sort(np.random.random(15)), 3),
+                          (np.sort(np.random.random(15)), 4),
+                          (np.sort(np.random.random(15)), 5),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 3),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 4),
+                          (np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0]), 5),
+                          (np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), 2),
+                          (np.array([0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]), 3)])
 def test_basis_integrals(knots, degree):
     expected = basis_integrals_true(knots, degree)
     out = basis_integrals(knots, degree)

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -1,0 +1,547 @@
+import numpy as np
+import pytest
+
+from psydac.core.bsplines import (find_span,
+                                  basis_funs,
+                                  basis_funs_1st_der,
+                                  basis_funs_all_ders,
+                                  collocation_matrix,
+                                  histopolation_matrix,
+                                  breakpoints,
+                                  greville,
+                                  elements_spans,
+                                  make_knots,
+                                  elevate_knots,
+                                  quadrature_grid,
+                                  basis_integrals,
+                                  basis_ders_on_quad_grid)
+
+###############################################################################
+# "True" Functions
+###############################################################################
+
+def find_span_true( knots, degree, x ):
+    # Knot index at left/right boundary
+    low  = degree
+    high = len(knots)-1-degree
+
+    # Check if point is exactly on left/right boundary, or outside domain
+    if x <= knots[low ]: return low
+    if x >= knots[high]: return high-1
+
+    # Perform binary search
+    span = (low+high)//2
+    while x < knots[span] or x >= knots[span+1]:
+        if x < knots[span]:
+           high = span
+        else:
+           low  = span
+        span = (low+high)//2
+
+    return span
+
+#==============================================================================
+def basis_funs_true( knots, degree, x, span ):
+    left   = np.empty( degree  , dtype=float )
+    right  = np.empty( degree  , dtype=float )
+    values = np.empty( degree+1, dtype=float )
+
+    values[0] = 1.0
+    for j in range(0,degree):
+        left [j] = x - knots[span-j]
+        right[j] = knots[span+1+j] - x
+        saved    = 0.0
+        for r in range(0,j+1):
+            temp      = values[r] / (right[r] + left[j-r])
+            values[r] = saved + right[r] * temp
+            saved     = left[j-r] * temp
+        values[j+1] = saved
+
+    return values
+
+#==============================================================================
+def basis_funs_1st_der_true( knots, degree, x, span ):
+    # Compute nonzero basis functions and knot differences for splines
+    # up to degree deg-1
+    values = basis_funs_true( knots, degree-1, x, span )
+
+    # Compute derivatives at x using formula based on difference of splines of
+    # degree deg-1
+    # -------
+    # j = 0
+    ders  = np.empty( degree+1, dtype=float )
+    saved = degree * values[0] / (knots[span+1]-knots[span+1-degree])
+    ders[0] = -saved
+    # j = 1,...,degree-1
+    for j in range(1,degree):
+        temp    = saved
+        saved   = degree * values[j] / (knots[span+j+1]-knots[span+j+1-degree])
+        ders[j] = temp - saved
+    # j = degree
+    ders[degree] = saved
+
+    return ders
+
+#==============================================================================
+def basis_funs_all_ders_true( knots, degree, x, span, n ):
+    left  = np.empty( degree )
+    right = np.empty( degree )
+    ndu   = np.empty( (degree+1, degree+1) )
+    a     = np.empty( (       2, degree+1) )
+    ders  = np.zeros( (     n+1, degree+1) ) # output array
+
+    # Number of derivatives that need to be effectively computed
+    # Derivatives higher than degree are = 0.
+    ne = min( n, degree )
+
+    # Compute nonzero basis functions and knot differences for splines
+    # up to degree, which are needed to compute derivatives.
+    # Store values in 2D temporary array 'ndu' (square matrix).
+    ndu[0,0] = 1.0
+    for j in range(0,degree):
+        left [j] = x - knots[span-j]
+        right[j] = knots[span+1+j] - x
+        saved    = 0.0
+        for r in range(0,j+1):
+            # compute inverse of knot differences and save them into lower triangular part of ndu
+            ndu[j+1,r] = 1.0 / (right[r] + left[j-r])
+            # compute basis functions and save them into upper triangular part of ndu
+            temp       = ndu[r,j] * ndu[j+1,r]
+            ndu[r,j+1] = saved + right[r] * temp
+            saved      = left[j-r] * temp
+        ndu[j+1,j+1] = saved
+
+    # Compute derivatives in 2D output array 'ders'
+    ders[0,:] = ndu[:,degree]
+    for r in range(0,degree+1):
+        s1 = 0
+        s2 = 1
+        a[0,0] = 1.0
+        for k in range(1,ne+1):
+            d  = 0.0
+            rk = r-k
+            pk = degree-k
+            if r >= k:
+               a[s2,0] = a[s1,0] * ndu[pk+1,rk]
+               d = a[s2,0] * ndu[rk,pk]
+            j1 = 1   if (rk  > -1 ) else -rk
+            j2 = k-1 if (r-1 <= pk) else degree-r
+            a[s2,j1:j2+1] = (a[s1,j1:j2+1] - a[s1,j1-1:j2]) * ndu[pk+1,rk+j1:rk+j2+1]
+            d += np.dot( a[s2,j1:j2+1], ndu[rk+j1:rk+j2+1,pk] )
+            if r <= pk:
+               a[s2,k] = - a[s1,k-1] * ndu[pk+1,r]
+               d += a[s2,k] * ndu[r,pk]
+            ders[k,r] = d
+            j  = s1
+            s1 = s2
+            s2 = j
+
+    # Multiply derivatives by correct factors
+    r = degree
+    for k in range(1,ne+1):
+        ders[k,:] = ders[k,:] * r
+        r = r * (degree-k)
+
+    return ders
+
+#==============================================================================
+def collocation_matrix_true(knots, degree, periodic, normalization, xgrid):
+    # Number of basis functions (in periodic case remove degree repeated elements)
+    nb = len(knots)-degree-1
+    if periodic:
+        nb -= degree
+
+    # Number of evaluation points
+    nx = len(xgrid)
+
+    # Collocation matrix as 2D Numpy array (dense storage)
+    mat = np.zeros( (nx,nb) )
+
+    # Indexing of basis functions (periodic or not) for a given span
+    if periodic:
+        js = lambda span: [(span-degree+s) % nb for s in range( degree+1 )]
+    else:
+        js = lambda span: slice( span-degree, span+1 )
+
+    # Rescaling of B-splines, to get M-splines if needed
+    if normalization == 'B':
+        normalize = lambda basis, span: basis
+    elif normalization == 'M':
+        scaling = 1 / basis_integrals_true(knots, degree)
+        normalize = lambda basis, span: basis * scaling[span-degree: span+1]
+
+    # Fill in non-zero matrix values
+    for i,x in enumerate( xgrid ):
+        span  =  find_span_true( knots, degree, x )
+        basis = basis_funs_true( knots, degree, x, span )
+        mat[i,js(span)] = normalize(basis, span)
+
+    # Mitigate round-off errors
+    mat[abs(mat) < 1e-14] = 0.0
+
+    return mat
+
+#==============================================================================
+def histopolation_matrix(knots, degree, periodic, normalization, xgrid):
+    # Check that knots are ordered (but allow repeated knots)
+    if not np.all(np.diff(knots) >= 0):
+        raise ValueError("Cannot accept knot sequence: {}".format(knots))
+
+    # Check that spline degree is non-negative integer
+    if not isinstance(degree, (int, np.integer)):
+        raise TypeError("Degree {} must be integer, got type {} instead".format(degree, type(degree)))
+    if degree < 0:
+        raise ValueError("Cannot accept negative degree: {}".format(degree))
+
+    # Check 'periodic' flag
+    if not isinstance(periodic, bool):
+        raise TypeError("Cannot accept non-boolean 'periodic' parameter: {}".format(periodic))
+
+    # Check 'normalization' option
+    if normalization not in ['B', 'M']:
+        raise ValueError("Cannot accept 'normalization' parameter: {}".format(normalization))
+
+    # Check that grid points are ordered, and do not allow repetitions
+    if not np.all(np.diff(xgrid) > 0):
+        raise ValueError("Grid points must be ordered, with no repetitions: {}".format(xgrid))
+
+    # Number of basis functions (in periodic case remove degree repeated elements)
+    nb = len(knots)-degree-1
+    if periodic:
+        nb -= degree
+
+    # Number of evaluation points
+    nx = len(xgrid)
+
+    # In periodic case, make sure that evaluation points include domain boundaries
+    # TODO: only do this if the user asks for it!
+    if periodic:
+        xmin  = knots[degree]
+        xmax  = knots[-1-degree]
+        if xgrid[0] > xmin:
+            xgrid = [xmin, *xgrid]
+        if xgrid[-1] < xmax:
+            xgrid = [*xgrid, xmax]
+
+    # B-splines of degree p+1: basis[i,j] := Bj(xi)
+    #
+    # NOTES:
+    #  . cannot use M-splines in analytical formula for histopolation matrix
+    #  . always use non-periodic splines to avoid circulant matrix structure
+    C = collocation_matrix_true(
+        knots    = elevate_knots_true(knots, degree, periodic),
+        degree   = degree + 1,
+        periodic = False,
+        normalization = 'B',
+        xgrid = xgrid
+    )
+
+    # Rescaling of M-splines, to get B-splines if needed
+    if normalization == 'M':
+        normalize = lambda bi, j: bi
+    elif normalization == 'B':
+        scaling = basis_integrals_true(knots, degree)
+        normalize = lambda bi, j: bi * scaling[j]
+
+    # Compute span for each row (index of last non-zero basis function)
+    # TODO: would be better to have this ready beforehand
+    # TODO: use tolerance instead of comparing against zero
+    spans = [(row != 0).argmax() + (degree+1) for row in C]
+
+    # Compute histopolation matrix from collocation matrix of higher degree
+    m = C.shape[0] - 1
+    n = C.shape[1] - 1
+    H = np.zeros((m, n))
+    for i in range(m):
+        # Indices of first/last non-zero elements in row of collocation matrix
+        jstart = spans[i] - (degree+1)
+        jend   = min(spans[i+1], n)
+        # Compute non-zero values of histopolation matrix
+        for j in range(1+jstart, jend+1):
+            s = C[i, 0:j].sum() - C[i+1, 0:j].sum()
+            H[i, j-1] = normalize(s, j-1)
+
+    # Mitigate round-off errors
+    H[abs(H) < 1e-14] = 0.0
+
+    # Non periodic case: stop here
+    if not periodic:
+        return H
+
+    # Periodic case: wrap around histopolation matrix
+    #  1. identify repeated basis functions (sum columns)
+    #  2. identify split interval (sum rows)
+    Hp = np.zeros((nx, nb))
+    for i in range(m):
+        for j in range(n):
+            Hp[i%nx, j%nb] += H[i, j]
+
+    return Hp
+
+#==============================================================================
+def breakpoints_true( knots, degree ,tol=1e-15):
+    knots = np.array(knots)
+    diff  = np.append(True, abs(np.diff(knots[degree:-degree]))>tol)
+    return knots[degree:-degree][diff]
+
+#==============================================================================
+def greville_true( knots, degree, periodic ):
+    T = knots
+    p = degree
+    n = len(T)-2*p-1 if periodic else len(T)-p-1
+
+    # Compute greville abscissas as average of p consecutive knot values
+    xg = np.array([sum(T[i:i+p])/p for i in range(1,1+n)])
+
+    # Domain boundaries
+    a = T[p]
+    b = T[-1-p]
+
+    # If needed apply periodic boundary conditions, then sort array
+    if periodic:
+        xg = (xg-a) % (b-a) + a
+        xg = xg[np.argsort(xg)]
+
+    # Make sure roundoff errors don't push Greville points outside domain
+    xg[ 0] = max(xg[ 0], a)
+    xg[-1] = min(xg[-1], b)
+
+    return xg
+
+#===============================================================================
+def elements_spans_true( knots, degree ):
+    breaks = breakpoints_true( knots, degree )
+    nk     = len(knots)
+    ne     = len(breaks)-1
+    spans  = np.zeros( ne, dtype=int )
+
+    ie = 0
+    for ik in range( degree, nk-degree ):
+        if knots[ik+1]-knots[ik]>=1e-15:
+            spans[ie] = ik
+            ie += 1
+        if ie == ne:
+            break
+
+    return spans
+
+#===============================================================================
+def make_knots_true( breaks, degree, periodic, multiplicity=1 ):
+    # Type checking
+    assert isinstance( degree  , int  )
+    assert isinstance( periodic, bool )
+
+    # Consistency checks
+    assert len(breaks) > 1
+    assert all( np.diff(breaks) > 0 )
+    assert degree > 0
+    assert 1 <= multiplicity and multiplicity <= degree + 1
+
+    if periodic:
+        assert len(breaks) > degree
+
+    p = degree
+    T = np.zeros( multiplicity*len(breaks[1:-1])+2+2*p )
+
+    T[p+1:-p-1] = np.repeat(breaks[1:-1], multiplicity)
+    T[p]        = breaks[ 0]
+    T[-p-1]     = breaks[-1]
+
+    if periodic:
+        period = breaks[-1]-breaks[0]
+        T[0:p] = [xi-period for xi in breaks[-p-1:-1 ]]
+        T[-p:] = [xi+period for xi in breaks[   1:p+1]]
+    else:
+        T[0:p+1] = breaks[ 0]
+        T[-p-1:] = breaks[-1]
+
+    return T
+
+#==============================================================================
+def elevate_knots_true(knots, degree, periodic, multiplicity=1, tol=1e-15):
+    knots = np.array(knots)
+
+    if periodic:
+        [T, p] = knots, degree
+        period = T[-1-p] - T[p]
+        left   = [T[-1-p-(p+1)] - period]
+        right  = [T[   p+(p+1)] + period]
+    else:
+        left  = [knots[0],*knots[:degree+1]]
+        right = [knots[-1],*knots[-degree-1:]]
+
+        diff   = np.append(True, np.diff(knots[degree+1:-degree-1])>tol)
+        if len(knots[degree+1:-degree-1])>0:
+            unique = knots[degree+1:-degree-1][diff]
+            knots  = np.repeat(unique, multiplicity)
+        else:
+            knots = knots[degree+1:-degree-1]
+
+    return np.array([*left, *knots, *right])
+
+#==============================================================================
+def quadrature_grid_true( breaks, quad_rule_x, quad_rule_w ):
+    # Check that input arrays have correct size
+    assert len(breaks)      >= 2
+    assert len(quad_rule_x) == len(quad_rule_w)
+
+    # Check that provided quadrature rule is defined on interval [-1,1]
+    assert min(quad_rule_x) >= -1
+    assert max(quad_rule_x) <= +1
+
+    quad_rule_x = np.asarray( quad_rule_x )
+    quad_rule_w = np.asarray( quad_rule_w )
+
+    ne     = len(breaks)-1
+    nq     = len(quad_rule_x)
+    quad_x = np.zeros( (ne,nq) )
+    quad_w = np.zeros( (ne,nq) )
+
+    # Compute location and weight of quadrature points from basic rule
+    for ie,(a,b) in enumerate(zip(breaks[:-1],breaks[1:])):
+        c0 = 0.5*(a+b)
+        c1 = 0.5*(b-a)
+        quad_x[ie,:] = c1*quad_rule_x[:] + c0
+        quad_w[ie,:] = c1*quad_rule_w[:]
+
+    return quad_x, quad_w
+
+#==============================================================================
+def basis_ders_on_quad_grid_true(knots, degree, quad_grid, nders, normalization):
+    ne,nq = quad_grid.shape
+    basis = np.zeros((ne, degree+1, nders+1, nq))
+
+    if normalization == 'M':
+        scaling = 1. / basis_integrals_true(knots, degree)
+
+    for ie in range(ne):
+        xx = quad_grid[ie, :]
+        for iq, xq in enumerate(xx):
+            span = find_span_true(knots, degree, xq)
+            ders = basis_funs_all_ders_true(knots, degree, xq, span, nders)
+            if normalization == 'M':
+                ders *= scaling[None, span-degree:span+1]
+            basis[ie, :, :, iq] = ders.transpose()
+
+    return basis
+
+#==============================================================================
+def basis_integrals_true(knots, degree):
+    T = knots
+    p = degree
+    n = len(T)-p-1
+    K = np.array([(T[i+p+1] - T[i]) / (p + 1) for i in range(n)])
+
+    return K
+
+
+###############################################################################
+# Tests
+###############################################################################
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
+def test_find_span(knots, degree, x):
+    expected = find_span_true(knots, degree, x)
+    out = find_span(knots, degree, x)
+
+    assert np.allclose(expected, out)
+
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
+def test_basis_funs(knots, degree, x):
+    span = find_span(knots, degree, x)
+    expected = basis_funs_true(knots, degree, x, span)
+    out = basis_funs(knots, degree, x, span)
+
+    assert np.allclose(expected, out)
+
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
+def test_basis_funs_1st_der(knots, degree, x):
+    span = find_span(knots, degree, x)
+    expected = basis_funs_1st_der_true(knots, degree, x, span)
+    out = basis_funs_1st_der(knots, degree, x, span)
+
+    assert np.allclose(expected, out)
+
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('x', (np.random.random(), np.random.random(), np.random.random()))
+@pytest.mark.parametrize('n', (2, 3, 4, 5))
+def test_basis_funs_all_ders(knots, degree, x, n):
+    span = find_span(knots, degree, x)
+    expected = basis_funs_all_ders_true(knots, degree, x, span, n)
+    out = basis_funs_all_ders(knots, degree, x, span, n)
+
+    assert np.allclose(expected, out)
+
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('periodic', (True, False))
+@pytest.mark.parametrize('normalization', ('B', 'M'))
+@pytest.mark.parametrize('xgrid', (np.random.random(10), np.random.random(15)))
+def test_collocation_matrix(knots, degree, periodic, normalization, xgrid):
+    expected = collocation_matrix_true(knots, degree, periodic, normalization, xgrid)
+    out = collocation_matrix(knots, degree, periodic, normalization, xgrid)
+
+    assert np.allclose(expected, out)
+
+def test_histopolation_matrix():
+    pass
+
+def test_breakpoints():
+    pass
+
+def test_greville():
+    pass
+
+def test_elements_spans():
+    pass
+
+def test_make_knots():
+    pass
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('periodic', (True, False))
+@pytest.mark.parametrize('multiplicity', (1, 2, 3))
+def test_elevate_knots(knots, degree, periodic, multiplicity):
+    expected = elevate_knots_true(knots, degree, periodic, multiplicity)
+    out = elevate_knots(knots, degree, periodic, multiplicity)
+
+    assert np.allclose(expected, out)
+
+def test_quadrature_grid():
+    pass
+
+def test_basis_ders_on_quad_grid():
+    pass
+
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+def test_basis_integrals(knots, degree):
+    expected = basis_integrals_true(knots, degree)
+    out = basis_integrals(knots, degree)
+
+    assert np.allclose(expected, out)

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -182,7 +182,7 @@ def collocation_matrix_true(knots, degree, periodic, normalization, xgrid):
     return mat
 
 #==============================================================================
-def histopolation_matrix(knots, degree, periodic, normalization, xgrid):
+def histopolation_matrix_true(knots, degree, periodic, normalization, xgrid):
     # Check that knots are ordered (but allow repeated knots)
     if not np.all(np.diff(knots) >= 0):
         raise ValueError("Cannot accept knot sequence: {}".format(knots))
@@ -503,8 +503,20 @@ def test_collocation_matrix(knots, degree, periodic, normalization, xgrid):
 
     assert np.allclose(expected, out)
 
-def test_histopolation_matrix():
-    pass
+@pytest.mark.parametrize('knots',
+                         (np.sort(np.random.random(15)),
+                          np.array([0.0, 0.0, 0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.0, 1.0])))
+@pytest.mark.parametrize('degree', (2, 3, 4, 5))
+@pytest.mark.parametrize('periodic', (True, False))
+@pytest.mark.parametrize('normalization', ('B', 'M'))
+@pytest.mark.parametrize('xgrid', (np.random.random(10), np.random.random(15)))
+def test_histopolation_matrix(knots, degree, periodic, normalization, xgrid):
+    xgrid = np.sort(np.unique(xgrid))
+    expected = histopolation_matrix_true(knots, degree, periodic, normalization, xgrid)
+    out = histopolation_matrix(knots, degree, periodic, normalization, xgrid)
+
+    assert np.allclose(expected, out)
+
 
 def test_breakpoints():
     pass


### PR DESCRIPTION
This PR aims at providing pyccelisable versions of the core functions in `bspline.py`. This consists of the file  `bsplines_pyccel.py` that is a transcription in pyccel-friendly python of `bsplines.py`. There is also a new test file that I used to make sure that those "new" functions yielded the correct results. This test file ought to be removed once the PR is ready. 