### PR TITLE
Update igakit's URL. Build it w/ same Numpy version as Numba. Add pyproject.toml

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,16 +52,17 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
-    - name: Install Python dependencies
-#      if: steps.pip-cache.outputs.cache-hit != 'true'
-      run: |
-        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel --verbose
-        python -m pip install -r requirements.txt --verbose
-        python -m pip list
-      
+#    - name: Install Python dependencies
+##      if: steps.pip-cache.outputs.cache-hit != 'true'
+#      run: |
+#        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#        python -m pip install wheel --verbose
+#        python -m pip install -r requirements.txt --verbose
+#        python -m pip list
+
     - name: Install project
       run: |
+        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
         python -m pip install . --verbose
         pyccel psydac/core/kernels.py --language fortran
         pyccel psydac/core/bsplines_pyccel.py --language fortran

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,17 +52,16 @@ jobs:
         restore-keys: |
           ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
-#    - name: Install Python dependencies
-##      if: steps.pip-cache.outputs.cache-hit != 'true'
-#      run: |
-#        export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-#        python -m pip install wheel --verbose
-#        python -m pip install -r requirements.txt --verbose
-#        python -m pip list
-
-    - name: Install project
+    - name: Install Python dependencies
+#      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+        python -m pip install wheel --verbose
+        python -m pip install -r requirements.txt --verbose
+        python -m pip list
+      
+    - name: Install project
+      run: |
         python -m pip install . --verbose
         pyccel psydac/core/kernels.py --language fortran
         pyccel psydac/core/bsplines_pyccel.py --language fortran

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,9 +56,8 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel setuptools
         python -m pip install -r requirements.txt --verbose
-        python -m pip install --no-build-isolation 'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
+        python -m pip install -r requirements_extra.txt --no-build-isolation --verbose
         python -m pip list
       
     - name: Install project

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel setuptools
+        python -m pip install wheel setuptools 'numpy<1.22'
         python -m pip install --no-build-isolation -r requirements.txt --verbose
         python -m pip list
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel setuptools 'numpy<1.22'
+        python -m pip install wheel setuptools
         python -m pip install --no-build-isolation -r requirements.txt --verbose
         python -m pip list
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,13 +56,13 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install -r requirements.txt --verbose
-        python -m pip install -r requirements_extra.txt --no-build-isolation --verbose
+        python -m pip install -r requirements.txt
+        python -m pip install -r requirements_extra.txt --no-build-isolation
         python -m pip list
       
     - name: Install project
       run: |
-        python -m pip install . --verbose
+        python -m pip install .
         pyccel psydac/core/kernels.py --language fortran
         pyccel psydac/core/bsplines_pyccel.py --language fortran
         python -m pip freeze

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,8 +56,8 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel --verbose
-        python -m pip install -r requirements.txt --verbose
+        python -m pip install wheel setuptools
+        python -m pip install --no-build-isolation -r requirements.txt --verbose
         python -m pip list
       
     - name: Install project

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel setuptools 'numpy>=1.16,<1.22' 'Cython>=0.25'
+        python -m pip install wheel setuptools 'numpy<1.22'
         python -m pip install --no-build-isolation -r requirements.txt --verbose
         python -m pip list
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,8 +76,9 @@ jobs:
       working-directory: ./pytest
       run: |
         export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-        python -m pytest --pyargs psydac -m "not parallel"
-        python mpi_tester.py --pyargs psydac -m "parallel"
+        python -m pytest --pyargs psydac -m "not parallel" -k "geometry"
+#        python -m pytest --pyargs psydac -m "not parallel"
+#        python mpi_tester.py --pyargs psydac -m "parallel"
 
     - name: Remove test directory
       if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,7 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel setuptools 'numpy<1.22'
+        python -m pip install wheel setuptools 'numpy>=1.16,<1.22' 'Cython>=0.25'
         python -m pip install --no-build-isolation -r requirements.txt --verbose
         python -m pip list
       

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,8 @@ jobs:
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
         python -m pip install wheel setuptools
-        python -m pip install --no-build-isolation -r requirements.txt --verbose
+        python -m pip install -r requirements.txt --verbose
+        python -m pip install --no-build-isolation 'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
         python -m pip list
       
     - name: Install project

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -76,9 +76,8 @@ jobs:
       working-directory: ./pytest
       run: |
         export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-        python -m pytest --pyargs psydac -m "not parallel" -k "geometry"
-#        python -m pytest --pyargs psydac -m "not parallel"
-#        python mpi_tester.py --pyargs psydac -m "parallel"
+        python -m pytest --pyargs psydac -m "not parallel"
+        python mpi_tester.py --pyargs psydac -m "parallel"
 
     - name: Remove test directory
       if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,13 +56,13 @@ jobs:
 #      if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |
         export CC="mpicc" HDF5_MPI="ON" HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-        python -m pip install wheel
-        python -m pip install -r requirements.txt
+        python -m pip install wheel --verbose
+        python -m pip install -r requirements.txt --verbose
         python -m pip list
       
     - name: Install project
       run: |
-        python -m pip install .
+        python -m pip install . --verbose
         pyccel psydac/core/kernels.py --language fortran
         pyccel psydac/core/bsplines_pyccel.py --language fortran
         python -m pip freeze

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
     export HDF5_MPI="ON"
     export HDF5_DIR=/path/to/hdf5/openmpi
     python3 -m pip install -r requirements.txt
+    python3 -m pip install -r requirements_extra.txt --no-build-isolation
      ```
 
 ## Installing the library

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy"]
+requires = ["setuptools>=40.8.0", "wheel", "numpy<1.22"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # HDF5_MPI="ON"
 # HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
 #
-numpy>=1.16
+numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # HDF5_MPI="ON"
 # HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
 #
-numpy >=1.16,<1.22
+numpy>=1.16
 Cython>=0.25
 numba
 mpi4py

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,6 @@ numba
 mpi4py
 h5py
 --no-binary h5py
+
+# IGAKIT - not on PyPI
+https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,11 @@
 # HDF5_MPI="ON"
 # HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
 #
+setuptools
+wheel
 numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py
 h5py
 --no-binary h5py
-
-# IGAKIT - not on PyPI
-#https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ h5py
 --no-binary h5py
 
 # IGAKIT - not on PyPI
-https://github.com/dalcinl/igakit/archive/refs/heads/master.zip
+#https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,0 +1,2 @@
+# IGAKIT - not on PyPI
+https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/setup.py
+++ b/setup.py
@@ -63,17 +63,25 @@ install_requires = [
     # Alternative backend to Pyccel is Numba
     'numba',
 
-    # In addition, we depend on mpi4py and h5py (MPI version).
-    # Since h5py must be built from source, we run the commands
-    #
-    # python3 -m pip install requirements.txt
-    # python3 -m pip install .
+    # In addition, we depend on mpi4py and h5py (parallel version)
     'mpi4py',
-    'h5py',
 
     # When pyccel is run in parallel with MPI, it uses tblib to pickle
     # tracebacks, which allows mpi4py to broadcast exceptions
     'tblib',
+
+    # Since h5py must be built from source using the MPI compiler and linked
+    # to a parallel HDF5 library, the following environment variables must be
+    # defined upon calling pip install:
+    #
+    # CC="mpicc"
+    # HDF5_MPI="ON"
+    # HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+    #
+    # Since we cannot pass the flag `--no-binary h5py' to setuptools, we have
+    # to download the binaries from GitHub. Using a separate requirements.txt
+    # may cause dependency conflicts which pip is not able to resolve.
+    'h5py @ https://github.com/h5py/h5py/archive/refs/heads/master.zip',
 
     # IGAKIT - not on PyPI
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     'tblib',
 
     # IGAKIT - not on PyPI
-    'igakit @ https://bitbucket.org/dalcinl/igakit/get/master.tar.gz',
+    'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip',
 ]
 
 dependency_links = []

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ install_requires = [
     'tblib',
 
     # IGAKIT - not on PyPI
-    'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip',
+    'igakit',
 ]
 
 dependency_links = []

--- a/setup.py
+++ b/setup.py
@@ -63,25 +63,17 @@ install_requires = [
     # Alternative backend to Pyccel is Numba
     'numba',
 
-    # In addition, we depend on mpi4py and h5py (parallel version)
+    # In addition, we depend on mpi4py and h5py (MPI version).
+    # Since h5py must be built from source, we run the commands
+    #
+    # python3 -m pip install requirements.txt
+    # python3 -m pip install .
     'mpi4py',
+    'h5py',
 
     # When pyccel is run in parallel with MPI, it uses tblib to pickle
     # tracebacks, which allows mpi4py to broadcast exceptions
     'tblib',
-
-    # Since h5py must be built from source using the MPI compiler and linked
-    # to a parallel HDF5 library, the following environment variables must be
-    # defined upon calling pip install:
-    #
-    # CC="mpicc"
-    # HDF5_MPI="ON"
-    # HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-    #
-    # Since we cannot pass the flag `--no-binary h5py' to setuptools, we have
-    # to download the binaries from GitHub. Using a separate requirements.txt
-    # may cause dependency conflicts which pip is not able to resolve.
-    'h5py @ https://github.com/h5py/h5py/archive/refs/heads/master.zip',
 
     # IGAKIT - not on PyPI
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip',


### PR DESCRIPTION
Igakit (not on PyPI) was just moved to GitHub, hence we are updating its URL in our `setup.py` file. This solves #206.

Because of the incompatibility between the Numpy build versions for Numba and Igakit, we now install Igakit without a pip isolated environment in order to use the same Numpy version that was previously installed by Numba. To this end we now list Igakit in a new file, `requirements_extra.txt`, which is dedicated to non-isolated builds.

In addition, we add the new file `pyproject.toml` in accordance to PEP 518.
