### PR TITLE
Correct names of pushforward functions in `VectorFemField`

### DIFF
--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -227,8 +227,8 @@ class VectorFemSpace( FemSpace ):
             pushed_fields = self.pushforward_fields_regular_tensor_grid(grid, *fields, mapping=mapping)
             # return a list of list of C-contiguous arrays, one list for each field
             # with one array for each dimension.
-            return [[np.ascontiguousarray(pushed_fields[..., i, j]) for i in range(self._ldim)]
-                    for j in range(len(fields))]
+            return [[np.ascontiguousarray(pushed_fields[..., j, i]) for j in range(self._ldim)]
+                    for i in range(len(fields))]
 
         # Case 4. (self.ldim)D arrays of coordinates and no npts_per_cell
         # -> unstructured grid
@@ -272,7 +272,7 @@ class VectorFemSpace( FemSpace ):
 
         mapping: psydac.mapping.SplineMapping
             Mapping on which to push-forward
-        
+
         parent_kind : sympde.topology.datatype
 
         Returns
@@ -292,7 +292,7 @@ class VectorFemSpace( FemSpace ):
                                                                                 mapping=mapping,
                                                                                 parent_kind=kind)
                                  for i in range(self._ldim)]
-            return [[pushed_fields_int[i][j] for i in range(self._ldim)] for j in range(len(fields))]
+            return [[pushed_fields_int[j][i] for j in range(self._ldim)] for i in range(len(fields))]
 
         # out_fields is a list self._ldim of arrays of shape grid.shape + (len(fields),)
         out_fields = np.asarray([self.spaces[i].eval_fields_regular_tensor_grid(grid, *[f.fields[i] for f in fields])
@@ -587,8 +587,8 @@ class ProductFemSpace( FemSpace ):
             pushed_fields = self.pushforward_fields_regular_tensor_grid(grid, *fields, mapping=mapping)
             # return a list of list of C-contiguous arrays, one list for each field
             # with one array for each dimension.
-            return [[np.ascontiguousarray(pushed_fields[..., i, j]) for i in range(self._ldim)]
-                    for j in range(len(fields))]
+            return [[np.ascontiguousarray(pushed_fields[..., j, i]) for j in range(self._ldim)]
+                    for i in range(len(fields))]
 
         # Case 4. (self.ldim)D arrays of coordinates and no npts_per_cell
         # -> unstructured grid
@@ -647,7 +647,7 @@ class ProductFemSpace( FemSpace ):
                                                                                 mapping=mapping,
                                                                                 parent_kind=kind)
                                  for i in range(self._ldim)]
-            return [[pushed_fields_int[i][j] for i in range(self._ldim)] for j in range(len(fields))]
+            return [[pushed_fields_int[j][i] for j in range(self._ldim)] for i in range(len(fields))]
 
         # out_fields is a list self._ldim of arrays of shape grid.shape + (len(fields),)
         out_fields = np.asarray([self.spaces[i].eval_fields_regular_tensor_grid(grid, *[f.fields[i] for f in fields])

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -163,7 +163,7 @@ class VectorFemSpace( FemSpace ):
         raise NotImplementedError( "VectorFemSpace not yet operational" )
 
     # ...
-    def pushforward_fields(self, grid, *fields, mapping=None, npts_per_cell=None):
+    def pushforward_fields(self, grid, *fields, mapping, npts_per_cell=None):
         """ Push forward fields on a given grid and a given mapping
 
         Parameters
@@ -186,10 +186,6 @@ class VectorFemSpace( FemSpace ):
         List of ndarray
             push-forwarded fields
         """
-
-        # Check that a mapping is given
-        if mapping is None:
-            raise TypeError("pushforward_fields() missing 1 required keyword-only argument: 'mapping'")
 
         # Check that the fields belong to our space
         assert all(f.space is self for f in fields)
@@ -244,7 +240,7 @@ class VectorFemSpace( FemSpace ):
                              "Case 4. {0}D arrays of coordinates and no npts_per_cell".format(self.ldim))
 
     # ...
-    def pushforward_field(self, field, *eta, mapping=None, parent_kind=None):
+    def pushforward_field(self, field, *eta, mapping, parent_kind=None):
         assert field.space is self
         assert len(eta) == self._ldim
 
@@ -256,7 +252,7 @@ class VectorFemSpace( FemSpace ):
         raise NotImplementedError("VectorFemSpace not yet operational")
 
     # ...
-    def pushforward_fields_regular_tensor_grid(self, grid, *fields, mapping=None, parent_kind=None):
+    def pushforward_fields_regular_tensor_grid(self, grid, *fields, mapping, parent_kind=None):
         """Push-forwards fields on a regular tensor grid using a given a mapping.
 
         Parameters
@@ -523,7 +519,7 @@ class ProductFemSpace( FemSpace ):
         raise NotImplementedError( "ProductFemSpace not yet operational" )
 
     # ...
-    def pushforward_fields(self, grid, *fields, mapping=None, npts_per_cell=None):
+    def pushforward_fields(self, grid, *fields, mapping, npts_per_cell=None):
         """ Push forward fields on a given grid and a given mapping
 
         Parameters
@@ -546,10 +542,6 @@ class ProductFemSpace( FemSpace ):
         List of ndarray
             push-forwarded fields
         """
-
-        # Check that a mapping is given
-        if mapping is None:
-            raise TypeError("pushforward_fields() missing 1 required keyword-only argument: 'mapping'")
 
         # Check that the fields belong to our space
         assert all(f.space is self for f in fields)
@@ -604,14 +596,14 @@ class ProductFemSpace( FemSpace ):
                              "Case 4. {0}D arrays of coordinates and no npts_per_cell".format(self.ldim))
 
     # ...
-    def pushforward_field(self, field, *eta, mapping=None, parent_kind=None):
+    def pushforward_field(self, field, *eta, mapping, parent_kind=None):
         assert field.space is self
         assert len(eta) == self._ldim
 
         raise NotImplementedError("ProductFemSpace not yet operational")
 
     # ...
-    def pushforward_fields_regular_tensor_grid(self, grid, *fields, mapping=None, parent_kind=None):
+    def pushforward_fields_regular_tensor_grid(self, grid, *fields, mapping, parent_kind=None):
         """Push-forwards fields on a regular tensor grid using a given a mapping.
 
         Parameters

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -248,6 +248,11 @@ class VectorFemSpace( FemSpace ):
         assert field.space is self
         assert len(eta) == self._ldim
 
+        if parent_kind is None:
+            kind = self._symbolic_space.kind
+        else:
+            kind = parent_kind
+
         raise NotImplementedError("VectorFemSpace not yet operational")
 
     # ...
@@ -267,6 +272,8 @@ class VectorFemSpace( FemSpace ):
 
         mapping: psydac.mapping.SplineMapping
             Mapping on which to push-forward
+        
+        parent_kind : sympde.topology.datatype
 
         Returns
         -------
@@ -620,6 +627,8 @@ class ProductFemSpace( FemSpace ):
 
         mapping: psydac.mapping.SplineMapping
             Mapping on which to push-forward
+        
+        parent_kind : sympde.topology.datatype
 
         Returns
         -------


### PR DESCRIPTION
Rename methods of `VectorFemField` class:

- `pushforward` -> `pushforward_field`
- `pushforward_grid`-> `pushforward_fields`
- `pushforward_regular_tensor_grid` -> `pushforward_fields_regular_tensor_grid`

Also apply some small corrections to the docstrings. 