### PR TITLE
Use Comm.Allreduce instead of Comm.allreduce

### DIFF
--- a/examples/test_cg_perf.py
+++ b/examples/test_cg_perf.py
@@ -1,53 +1,119 @@
+import pytest      
 import time
+import matplotlib.pyplot as plt
 import numpy as np
 
-from mpi4py       import MPI
-from psydac.ddm.cart       import CartDecomposition
-from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
-from psydac.api.settings   import PSYDAC_BACKEND_GPYCCEL
-from psydac.linalg.iterative_solvers import cg
+from sympy.core.containers import Tuple
+from sympy                 import Matrix               
+from sympy                 import Function                                
+from sympy                 import pi, cos, sin, exp                        
+      
+from sympde.core     import Constant
+from sympde.calculus import grad, dot, inner, rot, div
+from sympde.calculus import laplace, bracket, convect
+from sympde.calculus import jump, avg, Dn, minus, plus
 
-n1 = 10000
-p1 = 1
-P1 = False
+from sympde.topology import ScalarFunctionSpace
+from sympde.topology import element_of, elements_of
+from sympde.topology import InteriorDomain, Union
+from sympde.topology import Boundary, NormalVector
+from sympde.topology import Domain
+from sympde.topology import trace_1
+from sympde.topology import Cube
+from sympde.topology import ElementDomain
+from sympde.topology import Area
+from sympde.topology import IdentityMapping, PolarMapping, AffineMapping
+                         
+from sympde.expr.expr          import LinearExpr
+from sympde.expr.expr          import LinearForm, BilinearForm
+from sympde.expr.expr          import integral              
+from sympde.expr.expr          import Functional, Norm                       
+from sympde.expr.expr          import linearize                      
+from sympde.expr.evaluation    import TerminalExpr
+from sympde.expr               import find, EssentialBC
 
-comm = MPI.COMM_WORLD
-cart = CartDecomposition(
-    npts    = [n1],
-    pads    = [p1],
-    periods = [P1],
-    reorder = False,
-    comm    = comm,
-    reverse_axis = False,
-)
+from psydac.api.discretization import discretize
+from psydac.fem.basic          import FemField
+from psydac.utilities.utils    import refine_array_1d
+from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
 
-V = StencilVectorSpace( cart )
-s1, = V.starts
-e1, = V.ends
+from mpi4py import MPI
+#==============================================================================
 
-A = StencilMatrix( V, V , backend=PSYDAC_BACKEND_GPYCCEL)
-x0 = StencilVector( V )
+def run_poisson_3d(solution, f, domain, ncells, degree, comm):
 
-A[:, 0]  = 2
-A[:,-1] = -1
-A[:, 1] = -1
+    #+++++++++++++++++++++++++++++++
+    # 1. Abstract model
+    #+++++++++++++++++++++++++++++++
 
-A.remove_spurious_entries()
+    V   = ScalarFunctionSpace('V', domain, kind='h1')
 
-for i1 in range(s1,e1+1):
-    x0[i1] = 2.0*np.random.random() - 1.0
+    u, v = elements_of(V, names='u, v')
+    nn   = NormalVector('nn')
 
-b = A.dot(x0)
+    kappa  = 10**3
+    error  = u - solution
+    expr   = dot(grad(u),grad(v))
+    expr_b = -v*dot(grad(u),nn) -dot(grad(v), nn)*u + kappa*u*v
 
-t0 = time.time()
-x, info = cg( A, b, tol=1e-13, maxiter=30000 )
-t1 = time.time()
-T  = t1-t0
-T  = comm.reduce(T, op=MPI.MAX)
+    a = BilinearForm((u,v),  integral(domain, expr) + integral(domain.boundary, expr_b))
+    l = LinearForm(v, integral(domain, f*v))
 
-if comm.rank == 0:
-    print(info)
-    print("Elapsed time ::", t1-t0)
+    equation = find(u, forall=v, lhs=a(u,v), rhs=l(v))
 
+    l2norm = Norm(error, domain, kind='l2')
+    h1norm = Norm(error, domain, kind='h1')
+
+    #+++++++++++++++++++++++++++++++
+    # 2. Discretization
+    #+++++++++++++++++++++++++++++++
+    domain_h = discretize(domain, ncells=ncells, comm=comm)
+    Vh       = discretize(V, domain_h, degree=degree)
+
+    equation_h = discretize(equation, domain_h, [Vh, Vh], backend=PSYDAC_BACKEND_GPYCCEL)
+
+    l2norm_h = discretize(l2norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
+    h1norm_h = discretize(h1norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
+
+    equation_h.set_solver('cg', info=True, tol=1e-14, maxiter=2)
+
+    A = equation_h.lhs.assemble()
+    b = equation_h.rhs.assemble()
+
+    timing   = {}
+    t0       = time.time()
+    x, info = cg( A, b, tol=1e-13, maxiter=1000 )
+    t1       = time.time()
+
+    T = comm.reduce(t1-t0, op=MPI.MAX)
+    uh = FemField(Vh, coeffs=x)
+
+    l2_error = l2norm_h.assemble(u=uh)
+    h1_error = h1norm_h.assemble(u=uh)
+
+    return uh, info, T, l2_error, h1_error
+
+
+if __name__ == '__main__':
+
+    domain    = Cube()
+    x,y,z     = domain.coordinates
+    solution  = sin(pi*x)*sin(pi*y)*sin(pi*z)
+    f         = 3*pi**2*solution
+
+    ne     = [2**5,2**5,2**5]
+    degree = [3,3,3]
+
+    comm=MPI.COMM_WORLD
+    u_h, info, T, l2_error, h1_error = run_poisson_3d(solution, f, domain, ncells=ne, degree=degree, comm=comm)
+
+    if comm.rank == 0:
+        # ...
+        print( '> Grid          :: [{ne1},{ne2},{ne3}]'.format( ne1=ne[0], ne2=ne[1], ne3=ne[2]) )
+        print( '> Degree        :: [{p1},{p2},{p3}]'  .format( p1=degree[0], p2=degree[1], p3=degree[2] ) )
+        print( '> CG info       :: ',info )
+        print( '> CG time       :: ',T )
+        print( '> L2 error      :: {:.2e}'.format( l2_error ) )
+        print( '> H1 error      :: {:.2e}'.format( h1_error ) )
 
 

--- a/examples/test_cg_perf.py
+++ b/examples/test_cg_perf.py
@@ -1,0 +1,53 @@
+import time
+import numpy as np
+
+from mpi4py       import MPI
+from psydac.ddm.cart       import CartDecomposition
+from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
+from psydac.api.settings   import PSYDAC_BACKEND_GPYCCEL
+from psydac.linalg.iterative_solvers import cg
+
+n1 = 10000
+p1 = 1
+P1 = False
+
+comm = MPI.COMM_WORLD
+cart = CartDecomposition(
+    npts    = [n1],
+    pads    = [p1],
+    periods = [P1],
+    reorder = False,
+    comm    = comm,
+    reverse_axis = False,
+)
+
+V = StencilVectorSpace( cart )
+s1, = V.starts
+e1, = V.ends
+
+A = StencilMatrix( V, V , backend=PSYDAC_BACKEND_GPYCCEL)
+x0 = StencilVector( V )
+
+A[:, 0]  = 2
+A[:,-1] = -1
+A[:, 1] = -1
+
+A.remove_spurious_entries()
+
+for i1 in range(s1,e1+1):
+    x0[i1] = 2.0*np.random.random() - 1.0
+
+b = A.dot(x0)
+
+t0 = time.time()
+x, info = cg( A, b, tol=1e-13, maxiter=30000 )
+t1 = time.time()
+T  = t1-t0
+T  = comm.reduce(T, op=MPI.MAX)
+
+if comm.rank == 0:
+    print(info)
+    print("Elapsed time ::", t1-t0)
+
+
+

--- a/examples/test_cg_perf.py
+++ b/examples/test_cg_perf.py
@@ -36,6 +36,7 @@ from psydac.api.discretization import discretize
 from psydac.fem.basic          import FemField
 from psydac.utilities.utils    import refine_array_1d
 from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
+from psydac.linalg.iterative_solvers import cg
 
 from mpi4py import MPI
 #==============================================================================

--- a/examples/test_cg_perf.py
+++ b/examples/test_cg_perf.py
@@ -1,120 +1,50 @@
-import pytest      
 import time
-import matplotlib.pyplot as plt
 import numpy as np
 
-from sympy.core.containers import Tuple
-from sympy                 import Matrix               
-from sympy                 import Function                                
-from sympy                 import pi, cos, sin, exp                        
-      
-from sympde.core     import Constant
-from sympde.calculus import grad, dot, inner, rot, div
-from sympde.calculus import laplace, bracket, convect
-from sympde.calculus import jump, avg, Dn, minus, plus
-
-from sympde.topology import ScalarFunctionSpace
-from sympde.topology import element_of, elements_of
-from sympde.topology import InteriorDomain, Union
-from sympde.topology import Boundary, NormalVector
-from sympde.topology import Domain
-from sympde.topology import trace_1
-from sympde.topology import Cube
-from sympde.topology import ElementDomain
-from sympde.topology import Area
-from sympde.topology import IdentityMapping, PolarMapping, AffineMapping
-                         
-from sympde.expr.expr          import LinearExpr
-from sympde.expr.expr          import LinearForm, BilinearForm
-from sympde.expr.expr          import integral              
-from sympde.expr.expr          import Functional, Norm                       
-from sympde.expr.expr          import linearize                      
-from sympde.expr.evaluation    import TerminalExpr
-from sympde.expr               import find, EssentialBC
-
-from psydac.api.discretization import discretize
-from psydac.fem.basic          import FemField
-from psydac.utilities.utils    import refine_array_1d
-from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
+from mpi4py       import MPI
+from psydac.ddm.cart       import CartDecomposition
+from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
+from psydac.api.settings   import PSYDAC_BACKEND_GPYCCEL
 from psydac.linalg.iterative_solvers import cg
 
-from mpi4py import MPI
-#==============================================================================
+n1 = 10000
+p1 = 1
+P1 = False
 
-def run_poisson_3d(solution, f, domain, ncells, degree, comm):
+comm = MPI.COMM_WORLD
+cart = CartDecomposition(
+    npts    = [n1],
+    pads    = [p1],
+    periods = [P1],
+    reorder = False,
+    comm    = comm,
+    reverse_axis = False,
+)
 
-    #+++++++++++++++++++++++++++++++
-    # 1. Abstract model
-    #+++++++++++++++++++++++++++++++
+V = StencilVectorSpace( cart )
+s1, = V.starts
+e1, = V.ends
 
-    V   = ScalarFunctionSpace('V', domain, kind='h1')
+A = StencilMatrix( V, V , backend=PSYDAC_BACKEND_GPYCCEL)
+x0 = StencilVector( V )
 
-    u, v = elements_of(V, names='u, v')
-    nn   = NormalVector('nn')
+A[:, 0]  = 2
+A[:,-1] = -1
+A[:, 1] = -1
+A = A.T
+A.remove_spurious_entries()
 
-    kappa  = 10**3
-    error  = u - solution
-    expr   = dot(grad(u),grad(v))
-    expr_b = -v*dot(grad(u),nn) -dot(grad(v), nn)*u + kappa*u*v
+for i1 in range(s1,e1+1):
+    x0[i1] = 1
 
-    a = BilinearForm((u,v),  integral(domain, expr) + integral(domain.boundary, expr_b))
-    l = LinearForm(v, integral(domain, f*v))
+b = A.dot(x0)
 
-    equation = find(u, forall=v, lhs=a(u,v), rhs=l(v))
+t0 = time.time()
+x, info = cg( A, b, tol=1e-13, maxiter=30000 )
+t1 = time.time()
+T  = t1-t0
+T  = comm.reduce(T, op=MPI.MAX)
 
-    l2norm = Norm(error, domain, kind='l2')
-    h1norm = Norm(error, domain, kind='h1')
-
-    #+++++++++++++++++++++++++++++++
-    # 2. Discretization
-    #+++++++++++++++++++++++++++++++
-    domain_h = discretize(domain, ncells=ncells, comm=comm)
-    Vh       = discretize(V, domain_h, degree=degree)
-
-    equation_h = discretize(equation, domain_h, [Vh, Vh], backend=PSYDAC_BACKEND_GPYCCEL)
-
-    l2norm_h = discretize(l2norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
-    h1norm_h = discretize(h1norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
-
-    equation_h.set_solver('cg', info=True, tol=1e-14)
-
-    A = equation_h.lhs.assemble()
-    b = equation_h.rhs.assemble()
-
-    timing   = {}
-    t0       = time.time()
-    x, info = cg( A, b, tol=1e-13, maxiter=1000 )
-    t1       = time.time()
-
-    T = comm.reduce(t1-t0, op=MPI.MAX)
-    uh = FemField(Vh, coeffs=x)
-
-    l2_error = l2norm_h.assemble(u=uh)
-    h1_error = h1norm_h.assemble(u=uh)
-
-    return uh, info, T, l2_error, h1_error
-
-
-if __name__ == '__main__':
-
-    domain    = Cube()
-    x,y,z     = domain.coordinates
-    solution  = sin(pi*x)*sin(pi*y)*sin(pi*z)
-    f         = 3*pi**2*solution
-
-    ne     = [2**5,2**5,2**5]
-    degree = [3,3,3]
-
-    comm=MPI.COMM_WORLD
-    u_h, info, T, l2_error, h1_error = run_poisson_3d(solution, f, domain, ncells=ne, degree=degree, comm=comm)
-
-    if comm.rank == 0:
-        # ...
-        print( '> Grid          :: [{ne1},{ne2},{ne3}]'.format( ne1=ne[0], ne2=ne[1], ne3=ne[2]) )
-        print( '> Degree        :: [{p1},{p2},{p3}]'  .format( p1=degree[0], p2=degree[1], p3=degree[2] ) )
-        print( '> CG info       :: ',info )
-        print( '> CG time       :: ',T )
-        print( '> L2 error      :: {:.2e}'.format( l2_error ) )
-        print( '> H1 error      :: {:.2e}'.format( h1_error ) )
-
-
+if comm.rank == 0:
+    print("CG info      ::", info)
+    print("Elapsed time ::", t1-t0)

--- a/examples/test_cg_perf.py
+++ b/examples/test_cg_perf.py
@@ -76,7 +76,7 @@ def run_poisson_3d(solution, f, domain, ncells, degree, comm):
     l2norm_h = discretize(l2norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
     h1norm_h = discretize(h1norm, domain_h, Vh, backend=PSYDAC_BACKEND_GPYCCEL)
 
-    equation_h.set_solver('cg', info=True, tol=1e-14, maxiter=2)
+    equation_h.set_solver('cg', info=True, tol=1e-14)
 
     A = equation_h.lhs.assemble()
     b = equation_h.rhs.assemble()

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -4,13 +4,10 @@ This module provides iterative solvers and precondionners.
 
 """
 import numpy as np
-import time
 
 from math import sqrt
 from psydac.linalg.basic     import LinearSolver, LinearOperator
 from psydac.linalg.utilities import _sym_ortho
-from mpi4py import MPI
-comm = MPI.COMM_WORLD
 
 
 __all__ = ['cg', 'pcg', 'bicg', 'lsmr', 'minres', 'jacobi', 'weighted_jacobi']
@@ -90,8 +87,7 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         print( "+---------+---------------------+")
         template = "| {:7d} | {:19.2e} |"
         print( template.format( 1, sqrt( am ) ) )
-    comm.Barrier()
-    t0 = time.time()
+
     # Iterate to convergence
     for m in range( 2, maxiter+1 ):
 
@@ -110,13 +106,12 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
 
         if verbose:
             print( template.format( m, sqrt( am ) ) )
-    t1 = time.time()
+
     if verbose:
         print( "+---------+---------------------+")
 
-    T = comm.reduce(t1-t0, op=MPI.MAX)
     # Convergence information
-    info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt( am ),'elapsed_time':T }
+    info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt( am ) }
 
     return x, info
 # ...

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -92,14 +92,15 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         template = "| {:7d} | {:19.2e} |"
         print( template.format( 1, sqrt( am ) ) )
 
+    comm.Barrier()
+    t0 = time()
     # Iterate to convergence
     for m in range( 2, maxiter+1 ):
 
         if am < tol_sqr:
             m -= 1
             break
-        comm.Barrier()
-        t0 = time()
+
         p.update_ghost_regions()
         v   = A.dot(p, out=v)
         t1 = time()
@@ -110,11 +111,10 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         p  *= (am1/am)
         p  += r
         am  = am1
-        t1 = time()
 
         if verbose:
             print( template.format( m, sqrt( am ) ) )
-
+    t1 = time()
 
     if verbose:
         print( "+---------+---------------------+")

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -98,6 +98,7 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         if am < tol_sqr:
             m -= 1
             break
+        comm.Barrier()
         t0 = time()
         p.update_ghost_regions()
         v   = A.dot(p, out=v)

--- a/psydac/linalg/iterative_solvers.py
+++ b/psydac/linalg/iterative_solvers.py
@@ -8,7 +8,9 @@ import numpy as np
 from math import sqrt
 from psydac.linalg.basic     import LinearSolver, LinearOperator
 from psydac.linalg.utilities import _sym_ortho
-
+from time                    import time
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
 
 __all__ = ['cg', 'pcg', 'bicg', 'lsmr', 'minres', 'jacobi', 'weighted_jacobi']
 
@@ -73,7 +75,9 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         x = x0.copy()
 
     # First values
-    v  = A.dot(x)
+    x.update_ghost_regions()
+    v  = x.copy()
+    v  = A.dot(x, out=v)
     r  = b - v
     am = r.dot( r )
     p  = r.copy()
@@ -88,30 +92,66 @@ def cg( A, b, x0=None, tol=1e-6, maxiter=1000, verbose=False ):
         template = "| {:7d} | {:19.2e} |"
         print( template.format( 1, sqrt( am ) ) )
 
+
+    Ts = [0,0,0,0,0,0,0,0]
     # Iterate to convergence
     for m in range( 2, maxiter+1 ):
 
         if am < tol_sqr:
             m -= 1
             break
-
+        comm.Barrier()
+        t0 = time()
+        p.update_ghost_regions()
+        t1 = time()
+        comm.Barrier()
+        t0  = time()
         v   = A.dot(p, out=v)
+        t1 = time()
+        Ts[0] = t1-t0
+        comm.Barrier()
+        t0 = time()
         l   = am / v.dot( p )
+        t1 = time()
+        Ts[1] = t1-t0
+        comm.Barrier()
+        t0 = time()
         x  += l*p
+        t1 = time()
+        Ts[2] = t1-t0
+        comm.Barrier()
+        t0 = time()
         r  -= l*v
+        t1 = time()
+        Ts[3] = t1-t0
+        comm.Barrier()
+        t0 = time()
         am1 = r.dot( r )
+        t1 = time()
+        Ts[4] = t1-t0
+        comm.Barrier()
+        t0 = time()
         p  *= (am1/am)
+        t1 = time()
+        Ts[5] = t1-t0
+        comm.Barrier()
+        t0 = time()
         p  += r
+        t1 = time()
+        Ts[6] = t1-t0
+        comm.Barrier()
         am  = am1
 
         if verbose:
             print( template.format( m, sqrt( am ) ) )
 
+
     if verbose:
         print( "+---------+---------------------+")
-
+    for i in range(8):
+        Ts[i] = comm.reduce(Ts[i], op=MPI.MAX)
     # Convergence information
-    info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt( am ) }
+    info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt( am ), 'elapsed_time':Ts}
 
     return x, info
 # ...

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -304,12 +304,6 @@ class StencilVector( Vector ):
         assert isinstance( v, StencilVector )
         assert v._space is self._space
 
-#        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
-#        if self._space.parallel:
-#            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
-
-#        return res
-
         self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
         if self._space.parallel:
             self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -301,14 +301,8 @@ class StencilVector( Vector ):
     #...
     def dot( self, v ):
 
-#        assert isinstance( v, StencilVector )
-#        assert v._space is self._space
-
-#        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
-#        if self._space.parallel:
-#            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
-
-#        return res
+        assert isinstance( v, StencilVector )
+        assert v._space is self._space
 
         self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
         if self._space.parallel:

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -279,8 +279,8 @@ class StencilVector( Vector ):
         self._sizes = tuple(sizes)
         self._ndim  = len(V.starts)
         self._data  = np.zeros( sizes, dtype=V.dtype )
-        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
-        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
+#        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
+#        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
         self._space = V
 
         # TODO: distinguish between different directions
@@ -304,14 +304,19 @@ class StencilVector( Vector ):
         assert isinstance( v, StencilVector )
         assert v._space is self._space
 
-        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
         if self._space.parallel:
-            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
-                                            (self._dot_recv_data, self.space._mpi_type),
-                                            op=MPI.SUM )
-            self._dot_send_data[0] = self._dot_recv_data[0]
-        return self._dot_send_data[0]
+            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
 
+        return res
+
+#        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+#        if self._space.parallel:
+#            self._space.cart.global_comm.Allreduce((self._dot_send_data, self.space._mpi_type),
+#                                                   (self._dot_recv_data, self.space._mpi_type),
+#                                                   op=MPI.SUM )
+#            self._dot_send_data[0] = self._dot_recv_data[0]
+#        return self._dot_send_data[0]
     #...
     @staticmethod
     def _dot(v1, v2, pads, shifts):
@@ -745,7 +750,7 @@ class StencilMatrix( Matrix ):
 #        assert isinstance( v, StencilVector )
 #        assert v.space is self.domain
 
-        # Necessary if vector space is distributed across processes
+#        # Necessary if vector space is distributed across processes
 #        if not v.ghost_regions_in_sync:
 #            v.update_ghost_regions()
 

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -312,7 +312,7 @@ class StencilVector( Vector ):
 
         self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
         if self._space.parallel:
-            self._space.cart.global_comm.Allreduce((self._dot_send_data, self.space._mpi_type),
+            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
                                                    (self._dot_recv_data, self.space._mpi_type),
                                                    op=MPI.SUM )
             self._dot_send_data[0] = self._dot_recv_data[0]

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -311,6 +311,7 @@ class StencilVector( Vector ):
                                             op=MPI.SUM )
             self._dot_send_data[0] = self._dot_recv_data[0]
         return self._dot_send_data[0]
+
     #...
     @staticmethod
     def _dot(v1, v2, pads, shifts):
@@ -741,24 +742,24 @@ class StencilMatrix( Matrix ):
     # ...
     def dot( self, v, out=None):
 
-        assert isinstance( v, StencilVector )
-        assert v.space is self.domain
+#        assert isinstance( v, StencilVector )
+#        assert v.space is self.domain
 
         # Necessary if vector space is distributed across processes
-        if not v.ghost_regions_in_sync:
-            v.update_ghost_regions()
+#        if not v.ghost_regions_in_sync:
+#            v.update_ghost_regions()
 
-        if out is not None:
-            assert isinstance( out, StencilVector )
-            assert out.space is self.codomain
-        else:
-            out = StencilVector( self.codomain )
+#        if out is not None:
+#            assert isinstance( out, StencilVector )
+#            assert out.space is self.codomain
+#        else:
+#            out = StencilVector( self.codomain )
 
 
         self._func(self._data, v._data, out._data, **self._args)
 
         # IMPORTANT: flag that ghost regions are not up-to-date
-        out.ghost_regions_in_sync = False
+#        out.ghost_regions_in_sync = False
         return out
 
     # ...

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -279,8 +279,8 @@ class StencilVector( Vector ):
         self._sizes = tuple(sizes)
         self._ndim  = len(V.starts)
         self._data  = np.zeros( sizes, dtype=V.dtype )
-#        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
-#        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
+        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
+        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
         self._space = V
 
         # TODO: distinguish between different directions
@@ -304,19 +304,19 @@ class StencilVector( Vector ):
         assert isinstance( v, StencilVector )
         assert v._space is self._space
 
-        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
-        if self._space.parallel:
-            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
-
-        return res
-
-#        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+#        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
 #        if self._space.parallel:
-#            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
-#                                                   (self._dot_recv_data, self.space._mpi_type),
-#                                                   op=MPI.SUM )
-#            self._dot_send_data[0] = self._dot_recv_data[0]
-#        return self._dot_send_data[0]
+#            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
+
+#        return res
+
+        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+        if self._space.parallel:
+            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
+                                                   (self._dot_recv_data, self.space._mpi_type),
+                                                   op=MPI.SUM )
+            self._dot_send_data[0] = self._dot_recv_data[0]
+        return self._dot_send_data[0]
     #...
     @staticmethod
     def _dot(v1, v2, pads, shifts):

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -279,8 +279,8 @@ class StencilVector( Vector ):
         self._sizes = tuple(sizes)
         self._ndim  = len(V.starts)
         self._data  = np.zeros( sizes, dtype=V.dtype )
-        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
-        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
+#        self._dot_send_data = np.zeros((1,), dtype=V.dtype)
+#        self._dot_recv_data = np.zeros((1,), dtype=V.dtype)
         self._space = V
 
         # TODO: distinguish between different directions
@@ -304,14 +304,19 @@ class StencilVector( Vector ):
         assert isinstance( v, StencilVector )
         assert v._space is self._space
 
-        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+        res = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
         if self._space.parallel:
-            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
-                                                   (self._dot_recv_data, self.space._mpi_type),
-                                                   op=MPI.SUM )
-            self._dot_send_data[0] = self._dot_recv_data[0]
-        return self._dot_send_data[0]
+            res = self._space.cart.comm_cart.allreduce( res, op=MPI.SUM )
 
+        return res
+
+#        self._dot_send_data[0] = self._dot(self._data, v._data , self.space.pads, self.space.shifts)
+#        if self._space.parallel:
+#            self._space.cart.comm.Allreduce((self._dot_send_data, self.space._mpi_type),
+#                                                   (self._dot_recv_data, self.space._mpi_type),
+#                                                   op=MPI.SUM )
+#            self._dot_send_data[0] = self._dot_recv_data[0]
+#        return self._dot_send_data[0]
     #...
     @staticmethod
     def _dot(v1, v2, pads, shifts):


### PR DESCRIPTION
The `allreduce` function of mpi4py uses serialization which is slower than using `Allreduce` function that uses numpy arrays.

To illustrate that we run this [script](https://github.com/pyccel/psydac/blob/devel-allreduce/examples/test_cg_perf.py) using the old implementation vs the new implementation. 
 
```
using Comm.allreduce ...
number of procs :: 72
CG info      :: {'niter': 5003, 'success': True, 'res_norm': 8.064672720977876e-14}
Elapsed time :: 3.9431095123291016

using Comm.Allreduce ...
number of procs :: 72
CG info      :: {'niter': 5003, 'success': True, 'res_norm': 7.648109028693814e-14}
Elapsed time :: 1.0101466178894043
```
