### PR TITLE
Enforce contiguity in `bsplines.py`

### DIFF
--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -82,7 +82,7 @@ def find_span(knots, degree, x):
         Knot span index.
     """
     x = float(x)
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     return find_span_p(knots, degree, x)
 
 #==============================================================================
@@ -114,8 +114,8 @@ def find_spans(knots, degree, x, out=None):
     spans : array of ints
         Knots span indexes.
     """
-    knots = np.asarray(knots, dtype=float)
-    x = np.asarray(x, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
+    x = np.ascontiguousarray(x, dtype=float)
     if out is None:
         out = np.zeros_like(x, dtype=int)
     else:
@@ -153,7 +153,7 @@ def basis_funs(knots, degree, x, span, out=None):
         1D array containing the values of ``degree + 1`` non-zero
         Bsplines at location ``x``.
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     # Get native float
     x = float(x)
     if out is None:
@@ -191,8 +191,8 @@ def basis_funs_array(knots, degree, span, x, out=None):
         2D array of shape ``(len(x), degree + 1)`` containing the values of ``degree + 1`` non-zero
         Bsplines at each location in ``x``.
     """
-    knots = np.asarray(knots, dtype=float)
-    x = np.asarray(x, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
+    x = np.ascontiguousarray(x, dtype=float)
     if out is None:
         out = np.zeros(x.shape + (degree + 1,), dtype=float)
     else:
@@ -238,7 +238,7 @@ def basis_funs_1st_der(knots, degree, x, span, out=None):
     ----------
     .. [2] SELALIB, Semi-Lagrangian Library. http://selalib.gforge.inria.fr
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     # Get native float to work on windows
     x = float(x)
     if out is None:
@@ -289,7 +289,7 @@ def basis_funs_all_ders(knots, degree, x, span, n, normalization='B', out=None):
         ders[i,j] = (d/dx)^i B_k(x) with k=(span-degree+j),
         for 0 <= i <= n and 0 <= j <= degree+1.
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     # Get native float to work on windows
     x = float(x)
     if out is None:
@@ -337,8 +337,8 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None):
     The collocation matrix :math:`C_ij = B_j(x_i)`, contains the
     values of each B-spline basis function :math:`B_j` at all locations :math:`x_i`.
     """
-    knots = np.asarray(knots, dtype=float)
-    xgrid = np.asarray(xgrid, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
+    xgrid = np.ascontiguousarray(xgrid, dtype=float)
     if out is None:
         nb = len(knots) - degree - 1
         if periodic:
@@ -416,8 +416,8 @@ def histopolation_matrix(knots, degree, periodic, normalization, xgrid, check_bo
     if not np.all(np.diff(xgrid) > 0):
         raise ValueError("Grid points must be ordered, with no repetitions: {}".format(xgrid))
 
-    knots = np.asarray(knots, dtype=float)
-    xgrid = np.asarray(xgrid, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
+    xgrid = np.ascontiguousarray(xgrid, dtype=float)
     elevated_knots = elevate_knots(knots, degree, periodic)
 
     normalization = normalization == "M"
@@ -463,7 +463,7 @@ def breakpoints(knots, degree, tol=1e-15, out=None):
     breaks : numpy.ndarray (1D)
         Abscissas of all breakpoints.
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     if out is None:
         out = np.zeros(len(knots), dtype=float)
     else:
@@ -497,7 +497,7 @@ def greville(knots, degree, periodic, out=None):
         Abscissas of all Greville points.
 
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     if out is None:
         n = len(knots) - 2 * degree - 1 if periodic else len(knots) - degree - 1
         out = np.zeros(n)
@@ -548,7 +548,7 @@ def elements_spans(knots, degree, out=None):
        spans  = np.searchsorted( knots, breaks[:-1], side='right' ) - 1
 
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     if out is None:
         out = np.zeros(len(knots), dtype=np.int64)
     else:
@@ -605,7 +605,7 @@ def make_knots(breaks, degree, periodic, multiplicity=1, out=None):
     if periodic:
         assert len(breaks) > degree
 
-    breaks = np.asarray(breaks, dtype=float)
+    breaks = np.ascontiguousarray(breaks, dtype=float)
     if out is None:
         out = np.zeros(multiplicity * len(breaks[1:-1]) + 2 + 2 * degree)
     else:
@@ -655,14 +655,14 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
         Knots sequence of spline space of degree p+1.
     """
     multiplicity = int(multiplicity)
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     if out is None:
         if periodic:
             out = np.zeros(knots.shape[0] + 2, dtype=float)
         else:
             shape = 2*(degree + 2)
             if len(knots) - 2 * (degree + 1) > 0:
-                uniques = np.asarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
+                uniques = np.ascontiguousarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
                 shape += multiplicity * (1 + uniques[0].shape[0])
             out = np.zeros(shape, dtype=float)
     else:
@@ -671,7 +671,7 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
         else:
             shape = 2*(degree + 2)
             if len(knots) - 2 * (degree + 1) > 0:
-                uniques = np.asarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
+                uniques = np.ascontiguousarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
                 shape += multiplicity * (1 + uniques[0].shape[0])
             assert out.shape == shape and out.dtype == np.dtype('float')
 
@@ -729,13 +729,15 @@ def quadrature_grid(breaks, quad_rule_x, quad_rule_w):
     assert min(quad_rule_x) >= -1
     assert max(quad_rule_x) <= +1
 
-    breaks = np.asarray(breaks, dtype=float)
-    quad_rule_x = np.asarray( quad_rule_x )
-    quad_rule_w = np.asarray( quad_rule_w )
+    breaks = np.ascontiguousarray(breaks, dtype=float)
+
+    quad_rule_x = np.ascontiguousarray( quad_rule_x, dtype=float )
+    quad_rule_w = np.ascontiguousarray( quad_rule_w, dtype=float )
 
     out1 = np.zeros((len(breaks) - 1, len(quad_rule_x)))
     out2 = np.zeros_like(out1)
-    quadrature_grid_p(breaks, quad_rule_x, quad_rule_w, out1, out2,)
+    
+    quadrature_grid_p(breaks, quad_rule_x, quad_rule_w, out1, out2)
 
     return out1, out2
 
@@ -796,7 +798,7 @@ def basis_ders_on_quad_grid(knots, degree, quad_grid, nders, normalization, offs
     """
     offset = int(offset)
     ne, nq = quad_grid.shape
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     quad_grid = np.ascontiguousarray(quad_grid, dtype=float)
     if out is None:
         out = np.zeros((ne, degree + 1, nders + 1, nq), dtype=float)
@@ -840,7 +842,7 @@ def basis_integrals(knots, degree, out=None):
     to (len(knots)-degree-1). In the periodic case the last (degree) values in
     the array are redundant, as they are a copy of the first (degree) values.
     """
-    knots = np.asarray(knots, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
     if out is None:
         out = np.zeros(len(knots) - degree - 1, dtype=float)
     else:
@@ -882,8 +884,8 @@ def cell_index(breaks, i_grid, tol=1e-15, out=None):
         ``cell_index[i]`` is the index of the cell in which
         ``i_grid[i]`` belong.
     """
-    breaks = np.asarray(breaks, dtype=float)
-    i_grid = np.asarray(i_grid, dtype=float)
+    breaks = np.ascontiguousarray(breaks, dtype=float)
+    i_grid = np.ascontiguousarray(i_grid, dtype=float)
     if out is None:
         out = np.zeros_like(i_grid, dtype=np.int64)
     else:
@@ -936,8 +938,8 @@ def basis_ders_on_irregular_grid(knots, degree, i_grid, cell_index, nders, norma
         . il: local basis function   (0 <= il <= degree)
         . id: derivative             (0 <= id <= nders )
     """
-    knots = np.asarray(knots, dtype=float)
-    i_grid = np.asarray(i_grid, dtype=float)
+    knots = np.ascontiguousarray(knots, dtype=float)
+    i_grid = np.ascontiguousarray(i_grid, dtype=float)
     if out is None:
         nx = i_grid.shape[0]
         out = np.zeros((nx, degree + 1, nders + 1), dtype=float)

--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -662,7 +662,7 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
         else:
             shape = 2*(degree + 2)
             if len(knots) - 2 * (degree + 1) > 0:
-                uniques = np.ascontiguousarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
+                uniques = (np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
                 shape += multiplicity * (1 + uniques[0].shape[0])
             out = np.zeros(shape, dtype=float)
     else:
@@ -671,7 +671,7 @@ def elevate_knots(knots, degree, periodic, multiplicity=1, tol=1e-15, out=None):
         else:
             shape = 2*(degree + 2)
             if len(knots) - 2 * (degree + 1) > 0:
-                uniques = np.ascontiguousarray(np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
+                uniques = (np.diff(knots[degree + 1:-degree - 1]) > tol).nonzero()
                 shape += multiplicity * (1 + uniques[0].shape[0])
             assert out.shape == shape and out.dtype == np.dtype('float')
 

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -694,8 +694,8 @@ def test_elevate_knots(knots, degree, periodic, multiplicity):
 @pytest.mark.parametrize('quad_order', (2, 3, 4, 5))
 def test_quadrature_grid(breaks, quad_order):
     quad_x, quad_w = gauss_legendre(quad_order)
-    expected = quadrature_grid_true(breaks, quad_x, quad_w)
-    out = quadrature_grid(breaks, quad_x, quad_w)
+    expected = quadrature_grid_true(breaks, quad_x[::-1], quad_w[::-1])
+    out = quadrature_grid(breaks, quad_x[::-1], quad_w[::-1])
 
     assert np.allclose(expected, out, atol=ATOL, rtol=RTOL)
 


### PR DESCRIPTION
In `fem/grid.py`, line 69-70, we reverse the order of arrays before giving them to `quadrature_grid`. Those view are not contiguous and thus need to be copied in a contiguous way before giving them to the pyccelised function in `bsplines_pyccel.py`. This wasn't done before and thus caused issue #223. 
To avoid further issues of the same kind, this PR replaced all of the `np.asarray` statements in `bsplines.py` into `np.ascontiguousarray`.