### PR TITLE
Multipatch discrete geometry tests for `PostProcessManager`

### DIFF
--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -391,7 +391,7 @@ class OutputManager:
         if spaces_info == {}:
             spaces_info = {
                            'ndim': pdim,
-                           'fields': self.filename_fields,
+                           'fields': os.path.basename(self.filename_fields), # Only the basename to avoid issues
                            'patches': [{'name': patch,
                                         'breakpoints': [scalar_space.breaks[i].tolist() for i in range(ldim)],
                                         'scalar_spaces': [new_space]
@@ -495,7 +495,7 @@ class OutputManager:
                 mpi_dd_gp = fh5['mpi_dd']
 
         if not 'spaces' in fh5.attrs.keys():
-            fh5.attrs.create('spaces', self.filename_space)
+            fh5.attrs.create('spaces', os.path.basename(self.filename_space)) # Use basename to avoid issues
 
 
         saving_group = self._current_hdf5_group
@@ -816,7 +816,7 @@ class PostProcessManager:
         pdim = space_info['ndim']
 
         assert pdim == domain.dim
-        assert space_info['fields'] == self.fields_filename
+        assert space_info['fields'] == os.path.basename(self.fields_filename) # Use basename to compare
 
         # -------------------------------------------------
         # Space reconstruction
@@ -1423,7 +1423,7 @@ class PostProcessManager:
             size = self.comm.Get_size()
             # Get ranked filename
             if size > 1:
-                filename_same_dir = filename.split('/')[-1]
+                filename_same_dir = os.path.basename(filename)
                 filename = filename + f'.{rank}'
             else:
                 number_by_rank_visu = False

--- a/psydac/api/tests/test_postprocessing.py
+++ b/psydac/api/tests/test_postprocessing.py
@@ -628,11 +628,10 @@ def test_incorrect_arg_export_to_vtk():
 
 @pytest.mark.parallel
 @pytest.mark.parametrize('geometry', ['identity_2d.h5',
-                                      'identity_3d.h5',])
-                                    #   'pipe.h5',]) # Doesn't work, see issue
-                                    #   'multipatch/magnet.h5',
-                                    #   'multipatch/plate_with_hole_mp_7'])
-                                    # Arguments to be added when Said's PR is merged
+                                      'identity_3d.h5',
+                                    #   'pipe.h5',]) # Doesn't work, see issue #229
+                                      'multipatch/magnet.h5',
+                                      'multipatch/plate_with_hole_mp_7.h5'])
 @pytest.mark.parametrize('kind', ['h1', 'l2', 'hdiv', 'hcurl'])
 @pytest.mark.parametrize('space', [ScalarFunctionSpace, VectorFunctionSpace])
 def test_parallel_export_discrete_domain(geometry, kind, space):


### PR DESCRIPTION
This PR uncomments the tests using multi-patch geometry file in `psydac/api/tests/test_postprocessing.py` and changes the cross referencing of the space and fields file to use only the base name to avoid issues that could arise if the saving and post processing wasn't done in the same working directory.