### PR TITLE
PETSc interface

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           python -m pytest --pyargs psydac -m "not parallel"
-          python mpi_tester.py --pyargs psydac -m "parallel" -m "not petsc"
+          python mpi_tester.py --pyargs psydac -m "parallel and not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,7 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           python -m pytest --pyargs psydac -m "not parallel"
-          python mpi_tester.py --pyargs psydac -m "parallel"
+          python mpi_tester.py --pyargs psydac -m "parallel" -m "not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -190,7 +190,7 @@ def reduce_space_degrees(V, Vh, *, basis='B', sequence='DR'):
 
 #==============================================================================
 # TODO knots
-def discretize_space(V, domain_h, *, degree=None, knots=None, quad_order=None, basis='B', sequence='DR'):
+def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None, quad_order=None, basis='B', sequence='DR'):
     """
     This function creates the discretized space starting from the symbolic space.
 
@@ -283,6 +283,11 @@ def discretize_space(V, domain_h, *, degree=None, knots=None, quad_order=None, b
         else:
             assert isinstance(degree, (list, tuple))
 
+        if isinstance( multiplicity, (list, tuple) ):
+            multiplicity = {I.name:multiplicity for I in interiors}
+        else:
+            assert isinstance(multiplicity, (list, tuple))
+
         if isinstance(knots, (list, tuple)):
             assert len(interiors) == 1
             knots = {interiors[0].name:knots}
@@ -297,10 +302,11 @@ def discretize_space(V, domain_h, *, degree=None, knots=None, quad_order=None, b
             ncells     = domain_h.ncells[interior.name]
             periodic   = domain_h.periodic[interior.name]
             degree_i   = degree[interior.name]
+            multiplicity_i = multiplicity[interior.name]
             min_coords = interior.min_coords
             max_coords = interior.max_coords
 
-            assert len(ncells) == len(periodic) == len(degree_i) == len(min_coords) == len(max_coords)
+            assert len(ncells) == len(periodic) == len(degree_i)  == len(multiplicity_i) == len(min_coords) == len(max_coords)
 
             if knots is None:
                 # Create uniform grid
@@ -308,7 +314,7 @@ def discretize_space(V, domain_h, *, degree=None, knots=None, quad_order=None, b
                          for xmin, xmax, ne in zip(min_coords, max_coords, ncells)]
 
                 # Create 1D finite element spaces and precompute quadrature data
-                spaces[i] = [SplineSpace( p, grid=grid , periodic=P) for p,grid, P in zip(degree_i, grids, periodic)]
+                spaces[i] = [SplineSpace( p, multiplicity=m, grid=grid , periodic=P) for p,m,grid,P in zip(degree_i, multiplicity_i,grids, periodic)]
             else:
                  # Create 1D finite element spaces and precompute quadrature data
                 spaces[i] = [SplineSpace( p, knots=T , periodic=P) for p,T, P in zip(degree_i, knots[interior.name], periodic)]

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -281,12 +281,14 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
         if isinstance( degree, (list, tuple) ):
             degree = {I.name:degree for I in interiors}
         else:
-            assert isinstance(degree, (list, tuple))
+            assert isinstance(degree, dict)
 
         if isinstance( multiplicity, (list, tuple) ):
             multiplicity = {I.name:multiplicity for I in interiors}
+        elif multiplicity is None:
+            multiplicity = {I.name:(1,)*len(degree[I.name]) for I in interiors}
         else:
-            assert isinstance(multiplicity, (list, tuple))
+            assert isinstance(multiplicity, dict)
 
         if isinstance(knots, (list, tuple)):
             assert len(interiors) == 1

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -206,6 +206,9 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
     degree : list | dict
         The degree of the h1 space in each direction.
 
+    multiplicity: list | dict
+        The multiplicity of knots for the h1 space in each direction.
+
     knots: list | dict
         The knots sequence of the h1 space in each direction.
 

--- a/psydac/api/tests/test_2d_multipatch_mapping_maxwell.py
+++ b/psydac/api/tests/test_2d_multipatch_mapping_maxwell.py
@@ -24,7 +24,6 @@ from psydac.fem.basic                import FemField
 from psydac.linalg.iterative_solvers import *
 from psydac.api.settings             import PSYDAC_BACKEND_GPYCCEL
 from psydac.feec.pull_push           import pull_2d_hcurl
-from psydac.linalg.utilities         import array_to_stencil
 
 # ... get the mesh directory
 try:

--- a/psydac/api/tests/test_2d_navier_stokes.py
+++ b/psydac/api/tests/test_2d_navier_stokes.py
@@ -30,7 +30,7 @@ from psydac.fem.basic          import FemField
 from psydac.fem.vector         import ProductFemSpace
 from psydac.core.bsplines      import make_knots
 from psydac.api.discretization import discretize
-from psydac.linalg.utilities   import array_to_stencil
+from psydac.linalg.utilities   import array_to_psydac
 from psydac.linalg.stencil     import *
 from psydac.linalg.block       import *
 from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
@@ -68,7 +68,7 @@ def get_boundaries(*args):
 #------------------------------------------------------------------------------
 def scipy_solver(M, b):
     x  = spsolve(M.tosparse().tocsr(), b.toarray())
-    x  = array_to_stencil(x, b.space)
+    x  = array_to_psydac(x, b.space)
     return x,0
 
 #------------------------------------------------------------------------------

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -23,7 +23,7 @@ from sympde.expr import find, EssentialBC
 from psydac.fem.basic          import FemField
 from psydac.fem.vector         import ProductFemSpace
 from psydac.api.discretization import discretize
-from psydac.linalg.utilities   import array_to_stencil
+from psydac.linalg.utilities   import array_to_psydac
 from psydac.linalg.iterative_solvers import pcg, bicg
 
 #==============================================================================
@@ -77,7 +77,7 @@ def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     rhs = ah.linear_system.rhs.toarray()
 
     x   = spsolve(M, rhs)
-    x   = array_to_stencil(x, Xh.vector_space)
+    x   = array_to_psydac(x, Xh.vector_space)
     
     # ...
     Fh = FemField( V2h )
@@ -159,7 +159,7 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
             print('Solution with scipy.sparse: success = {}'.format(info == 0))
 
         # Convert to stencil format
-        x = array_to_stencil(x, Xh.vector_space)
+        x = array_to_psydac(x, Xh.vector_space)
 
     else:
         equation_h.set_solver('cg', info=True)

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -85,7 +85,6 @@ def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     # ...
 
     # ... compute norms
-#    l2norm_F_h._set_func('dependencies_evlw0ux7','assembly')
     l2_error = l2norm_F_h.assemble(F=Fh)
 
     return l2_error
@@ -168,6 +167,143 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
         x = phi_h.coeffs
         print(info)
 
+    # Numerical solution: velocity field
+    # TODO: allow this: uh = FemField(V1h, coeffs=x[0:2]) or similar
+    uh = FemField(V1h)
+    uh.coeffs[0][:] = x[0][:]
+    uh.coeffs[1][:] = x[1][:]
+
+    # Numerical solution: pressure field
+    # TODO: allow this: uh = FemField(V2h, coeffs=x[2])
+    ph = FemField(V2h)
+    ph.coeffs[:] = x[2][:]
+
+    # Compute norms of exact solution
+    x1, x2 = domain.coordinates
+    ue_1 = lambdify([x1, x2], ue[0])
+    ue_2 = lambdify([x1, x2], ue[1])
+    pe_c = lambdify([x1, x2], pe   )
+    l2_norm_ue = np.sqrt(V1h.spaces[0].integral(lambda *x: ue_1(*x)**2 + ue_2(*x)**2))
+    l2_norm_pe = np.sqrt(V2h.integral(lambda *x: pe_c(*x)**2))
+
+    # Average value of the pressure (should be 0)
+    domain_area = V2h.integral(lambda x1, x2: 1.0)
+    p_avg = V2h.integral(ph) / domain_area
+
+    # L2 error norm of the velocity field
+    error_u   = [ue[0]-u[0], ue[1]-u[1]]
+    l2norm_u  = Norm(error_u, domain, kind='l2')
+    l2norm_uh = discretize(l2norm_u, domain_h, V1h)
+
+    # L2 error norm of the pressure, after removing the average value from the field
+    l2norm_p  = Norm(pe - (p - p_avg), domain, kind='l2')
+    l2norm_ph = discretize(l2norm_p, domain_h, V2h)
+
+    # Compute error norms
+    l2_error_u = l2norm_uh.assemble(u = uh)
+    l2_error_p = l2norm_ph.assemble(p = ph)
+
+    print()
+    print('Relative l2_error(u) = {}'.format(l2_error_u / l2_norm_ue))
+    print('Relative l2_error(p) = {}'.format(l2_error_p / l2_norm_pe))
+    print('Average(p) = {}'.format(p_avg))
+
+    return locals()
+
+#==============================================================================
+def run_stokes_2d_dir_petsc(domain, f, ue, pe, *, homogeneous, ncells, degree):
+
+    from mpi4py   import MPI
+    from petsc4py import PETSc
+    from psydac.linalg.utilities import petsc_to_stencil
+
+    comm = MPI.COMM_WORLD
+
+    # ... abstract model
+    V1 = VectorFunctionSpace('V1', domain, kind='H1')
+    V2 = ScalarFunctionSpace('V2', domain, kind='L2')
+    X  = ProductSpace(V1, V2)
+
+    u, v = elements_of(V1, names='u, v')
+    p, q = elements_of(V2, names='p, q')
+
+    x, y  = domain.coordinates
+    int_0 = lambda expr: integral(domain , expr)
+
+    a  = BilinearForm(((u, p), (v, q)), int_0(inner(grad(u), grad(v)) - div(u)*q - p*div(v)) )
+    l  = LinearForm((v, q), int_0(dot(f, v)))
+
+    # Dirichlet boundary conditions are given in the form u = g where g may be
+    # just 0 (hence homogeneous BCs are prescribed) or a symbolic expression
+    # g(x, y) that represents the boundary data. Here we use the exact solution
+    if homogeneous:
+        bc = EssentialBC(u, 0, domain.boundary)
+    else:
+        bc = EssentialBC(u, ue, domain.boundary)
+
+    equation = find((u, p), forall=(v, q), lhs=a((u, p), (v, q)), rhs=l(v, q), bc=bc)
+
+    # ... create the computational domain from a topological domain
+    domain_h = discretize(domain, ncells=ncells, comm=comm)
+
+    # ... discrete spaces
+    V1h = discretize(V1, domain_h, degree=degree)
+    V2h = discretize(V2, domain_h, degree=degree, basis='M')
+    Xh  = discretize(X , domain_h, degree=degree, basis='M')
+
+    # ... discretize the equation using Dirichlet bc
+    equation_h = discretize(equation, domain_h, [Xh, Xh])
+
+    # ... solve linear system using petsc4py or psydac
+
+    ksp = PETSc.KSP()
+    ksp.create(domain_h.comm)
+    tol = 1e-11
+
+    opts = PETSc.Options()
+    opts["ksp_type"] = "minres"
+    opts["pc_type"] = "none"
+    opts["ksp_rtol"] = tol
+    opts["ksp_atol"] = tol
+    ksp.setFromOptions()
+
+    equation_h.assemble()
+    A0 = equation_h.linear_system.lhs.topetsc()
+    b0 = equation_h.linear_system.rhs.topetsc()
+
+    if not homogeneous:
+        a1 = BilinearForm(((u, p), (v, q)), integral(domain.boundary, dot(u, v)))
+        l1 = LinearForm((v, q), integral(domain.boundary, dot(ue, v)))
+
+        a1_h = discretize(a1, domain_h, [Xh, Xh])
+        l1_h = discretize(l1, domain_h, Xh)
+
+        A1 = a1_h.assemble().topetsc()
+        b1 = l1_h.assemble().topetsc()
+
+        ksp.setOperators(A1)
+        x1 = b1.duplicate()
+        ksp.solve(b1, x1)
+        print('Boundary solution with petsc4py: success = {}'.format(ksp.converged))
+
+        ksp.setOperators(A0)
+        b0 = b0 - A0*x1
+        x0 = b0.duplicate()
+        ksp.solve(b0, x0)
+        print('Interior solution with petsc4py: success = {}'.format(ksp.converged))
+
+        # Solution is sum of boundary and interior contributions
+        x = x0 + x1
+
+    else:
+        ksp.setOperators(A0)
+        x = b0.duplicate()
+        ksp.solve(b0, x)
+
+        print('Solution with petsc4py: success = {}'.format(ksp.converged))
+
+
+    x = petsc_to_stencil(x, Xh.vector_space)
     # Numerical solution: velocity field
     # TODO: allow this: uh = FemField(V1h, coeffs=x[0:2]) or similar
     uh = FemField(V1h)
@@ -383,6 +519,46 @@ def test_maxwell_time_harmonic_2d_dir_1():
     expected_l2_error = 0.0029394893438220502
 
     assert abs(l2_error-expected_l2_error)<1e-13
+
+##------------------------------------------------------------------------------
+#def test_stokes_2d_dir_non_homogeneous_petsc():
+
+#    # ... Exact solution
+#    domain = Square()
+#    x, y   = domain.coordinates
+
+#    ux =  sin(pi * x) * cos(pi * y)
+#    uy = -cos(pi * x) * sin(pi * y)
+#    ue = Tuple(ux, uy)
+#    pe = cos(2*pi * (x + y)) * sin(2*pi * (x - y))
+#    # ...
+
+#    # Verify that div(u) = 0
+#    assert (ux.diff(x) + uy.diff(y)).simplify() == 0
+
+#    # ... Compute right-hand side
+#    from sympde.calculus import laplace, grad
+#    from sympde.expr import TerminalExpr
+
+#    kwargs = dict(dim=2, logical=True)
+#    a = TerminalExpr(-laplace(ue), domain)
+#    b = TerminalExpr(    grad(pe), domain)
+#    f = (a.T + b).simplify()
+
+#    fx = -ux.diff(x, 2) - ux.diff(y, 2) + pe.diff(x)
+#    fy = -uy.diff(x, 2) - uy.diff(y, 2) + pe.diff(y)
+#    f  = Tuple(fx, fy)
+#    # ...
+
+#    # Run test
+#    namespace = run_stokes_2d_dir_petsc(domain, f, ue, pe,
+#            homogeneous=False, ncells=[10, 10], degree=[3, 3])
+
+#    # Check that expected absolute error on velocity and pressure fields
+#    # is obtained with at least 7 digits of accuracy
+#    print(namespace['l2_error_u'], namespace['l2_error_p'])
+#    assert abs(1 - namespace['l2_error_u'] / 8.658427958128542e-06) < 1e-7
+#    assert abs(1 - namespace['l2_error_p'] / 0.007600728271522273 ) < 1e-7
 
 #==============================================================================
 # CLEAN UP SYMPY NAMESPACE

--- a/psydac/api/tests/test_api_feec_3d.py
+++ b/psydac/api/tests/test_api_feec_3d.py
@@ -16,7 +16,7 @@ from psydac.fem.basic          import FemField
 from psydac.api.discretization import discretize
 from psydac.feec.pull_push     import push_3d_hcurl, push_3d_hdiv
 from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL, PSYDAC_BACKEND_NUMBA
-from psydac.linalg.utilities   import array_to_stencil
+from psydac.linalg.utilities   import array_to_psydac
 from psydac.linalg.iterative_solvers import cg
 
 from mpi4py import MPI
@@ -139,7 +139,7 @@ def run_maxwell_3d_scipy(logical_domain, mapping, e_ex, b_ex, ncells, degree, pe
     e_history, b_history = splitting_integrator_scipy(e0_coeff.toarray(), b0_coeff.toarray(), M1, M2, CURL, dt, niter)
 
     # study of fields
-    b_history = [array_to_stencil(bi, derham_h.V2.vector_space) for bi in b_history]
+    b_history = [array_to_psydac(bi, derham_h.V2.vector_space) for bi in b_history]
     b_fields  = [FemField(derham_h.V2, bi).fields for bi in b_history]
 
     bx_fields = [bi[0] for bi in b_fields]

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from psydac.linalg.utilities      import array_to_stencil
 from psydac.linalg.kron           import KroneckerLinearSolver
 from psydac.linalg.stencil        import StencilVector
 from psydac.linalg.block          import BlockDiagonalSolver, BlockVector

--- a/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
@@ -26,7 +26,7 @@ from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_
 from psydac.feec.multipatch.examples.ppc_test_cases     import get_source_and_solution
 from psydac.feec.multipatch.utilities                   import time_count
 
-from psydac.linalg.utilities import array_to_stencil
+from psydac.linalg.utilities import array_to_psydac
 from psydac.fem.basic        import FemField
 
 def solve_h1_source_pbm(
@@ -227,7 +227,7 @@ def solve_h1_source_pbm(
         u         = element_of(V0h.symbolic_space, name='u')
         l2norm    = Norm(u - u_ex, domain, kind='l2')
         l2norm_h  = discretize(l2norm, domain_h, V0h)
-        uh_c      = array_to_stencil(uh_c, V0h.vector_space)
+        uh_c      = array_to_psydac(uh_c, V0h.vector_space)
         l2_error  = l2norm_h.assemble(u=FemField(V0h, coeffs=uh_c))
         return l2_error
 

--- a/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
@@ -26,7 +26,7 @@ from psydac.feec.multipatch.plotting_utilities          import plot_field
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 from psydac.feec.multipatch.examples.ppc_test_cases     import get_source_and_solution
 from psydac.feec.multipatch.utilities                   import time_count
-from psydac.linalg.utilities                            import array_to_stencil
+from psydac.linalg.utilities                            import array_to_psydac
 from psydac.fem.basic                                   import FemField
 
 def solve_hcurl_source_pbm(
@@ -300,7 +300,7 @@ def solve_hcurl_source_pbm(
         u         = element_of(V1h.symbolic_space, name='u')
         l2norm    = Norm(Matrix([u[0] - u_ex[0],u[1] - u_ex[1]]), domain, kind='l2')
         l2norm_h  = discretize(l2norm, domain_h, V1h)
-        uh_c      = array_to_stencil(uh_c, V1h.vector_space)
+        uh_c      = array_to_psydac(uh_c, V1h.vector_space)
         l2_error  = l2norm_h.assemble(u=FemField(V1h, coeffs=uh_c))
         return l2_error
 

--- a/psydac/feec/multipatch/plotting_utilities.py
+++ b/psydac/feec/multipatch/plotting_utilities.py
@@ -9,7 +9,7 @@ from matplotlib  import cm, colors
 from mpl_toolkits import mplot3d
 from collections import OrderedDict
 
-from psydac.linalg.utilities import array_to_stencil
+from psydac.linalg.utilities import array_to_psydac
 from psydac.fem.basic        import FemField
 from psydac.fem.vector       import ProductFemSpace, VectorFemSpace
 from psydac.utilities.utils  import refine_array_1d
@@ -207,7 +207,7 @@ def plot_field(fem_field=None, stencil_coeffs=None, numpy_coeffs=None, Vh=None, 
     if vh is None:
         if numpy_coeffs is not None:
             assert stencil_coeffs is None
-            stencil_coeffs = array_to_stencil(numpy_coeffs, Vh.vector_space)
+            stencil_coeffs = array_to_psydac(numpy_coeffs, Vh.vector_space)
         vh = FemField(Vh, coeffs=stencil_coeffs)
 
     mappings = OrderedDict([(P.logical_domain, P.mapping) for P in domain.interior])

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -74,23 +74,17 @@ class SplineSpace( FemSpace ):
         if (knots is None) and (grid is None):
             raise ValueError('Either knots or grid must be provided.')
 
+        if (knots is not None) and (multiplicity is not None):
+            raise ValueError( 'Cannot provide both knots and multiplicity.' )
+
         if (multiplicity is not None) and multiplicity<1:
             raise ValueError('multiplicity should be >=1')
 
         if (parent_multiplicity is not None) and parent_multiplicity<1:
             raise ValueError('parent_multiplicity should be >=1')
 
-        if multiplicity is None:multiplicity = 1
-                
-        if parent_multiplicity is None:
-            if multiplicity is not None:
-                parent_multiplicity = multiplicity
-            else:
-                parent_multiplicity = 1
-
-        assert parent_multiplicity >= multiplicity
-
         if knots is None:
+            if multiplicity is None:multiplicity = 1
             knots = make_knots( grid, degree, periodic, multiplicity )
 
         if grid is None:
@@ -102,6 +96,11 @@ class SplineSpace( FemSpace ):
             multiplicity = np.diff(indices).max(initial=1)
         else:
             multiplicity = max(1,len(knots[degree+1:-degree-1]))
+
+        if parent_multiplicity is None:
+            parent_multiplicity = multiplicity
+
+        assert parent_multiplicity >= multiplicity
 
         # TODO: verify that user-provided knots make sense in periodic case
 

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -82,7 +82,11 @@ class SplineSpace( FemSpace ):
 
         if multiplicity is None:multiplicity = 1
                 
-        if parent_multiplicity is None:parent_multiplicity = 1
+        if parent_multiplicity is None:
+            if multiplicity is not None:
+                parent_multiplicity = multiplicity
+            else:
+                parent_multiplicity = 1
 
         assert parent_multiplicity >= multiplicity
 

--- a/psydac/linalg/__init__.py
+++ b/psydac/linalg/__init__.py
@@ -1,5 +1,3 @@
-__all__ = ['basic', 'block', 'direct_solvers', 'iterative_solvers', 'stencil', 'kron', 'topetsc', 'utilities']
-
 from psydac.linalg import basic
 from psydac.linalg import block
 from psydac.linalg import direct_solvers

--- a/psydac/linalg/__init__.py
+++ b/psydac/linalg/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['basic', 'block', 'direct_solvers', 'iterative_solvers', 'stencil', 'kron', 'utilities']
+__all__ = ['basic', 'block', 'direct_solvers', 'iterative_solvers', 'stencil', 'kron', 'topetsc', 'utilities']
 
 from psydac.linalg import basic
 from psydac.linalg import block
@@ -8,3 +8,4 @@ from psydac.linalg import stencil
 from psydac.linalg import kron
 from psydac.linalg import utilities
 from psydac.linalg import identity
+from psydac.linalg import topetsc

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -407,13 +407,10 @@ class BlockVector( Vector ):
 
     # ...
     def topetsc( self ):
-        """ Convert to petsc Nest vector.
+        """ Convert to petsc data structure.
         """
-
-        blocks    = [v.topetsc() for v in self._blocks]
-        cart      = self._space.spaces[0].cart
-        petsccart = cart.topetsc()
-        vec       = petsccart.petsc.Vec().createNest(blocks, comm=cart.comm)
+        from psydac.linalg.topetsc import vec_topetsc
+        vec = vec_topetsc( self )
         return vec
 
 #===============================================================================
@@ -895,21 +892,11 @@ class BlockMatrix( BlockLinearOperator, Matrix ):
 
     # ...
     def topetsc( self ):
-        """ Convert to petsc Nest Matrix.
+        """ Convert to petsc data structure.
         """
-        # Convert all blocks to petsc format
-        blocks = [[None for j in range( self.n_block_cols )] for i in range( self.n_block_rows )]
-        for (i,j), Mij in self._blocks.items():
-            blocks[i][j] = Mij.topetsc()
-
-        if self.n_block_cols == 1:
-            cart = self.domain.cart
-        else:
-            cart = self.domain.spaces[0].cart
-
-        petsccart = cart.topetsc()
-
-        return petsccart.petsc.Mat().createNest(blocks, comm=cart.comm)
+        from psydac.linalg.topetsc import mat_topetsc
+        mat = mat_topetsc( self )
+        return mat
 
     def compute_interface_matrices_transpose(self):
         blocks = self._blocks.copy()

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -557,23 +557,10 @@ class StencilVector( Vector ):
     def topetsc( self ):
         """ Convert to petsc data structure.
         """
+        from psydac.linalg.topetsc import vec_topetsc
+        vec = vec_topetsc( self )
+        return vec
 
-        space = self.space
-        assert space.parallel
-        cart      = space.cart
-        petsccart = cart.topetsc()
-        petsc     = petsccart.petsc
-        lgmap     = petsccart.l2g_mapping
-
-        size  = (petsccart.local_size, None)
-        gvec  = petsc.Vec().createMPI(size, comm=cart.comm)
-        gvec.setLGMap(lgmap)
-        gvec.setUp()
-
-        idx = tuple( slice(m*p,-m*p) for m,p in zip(self.pads, self.space.shifts) )
-        gvec.setArray(self._data[idx])
-
-        return gvec
     # ...
     def __getitem__(self, key):
         index = self._getindex( key )
@@ -1252,35 +1239,9 @@ class StencilMatrix( Matrix ):
     def topetsc( self ):
         """ Convert to petsc data structure.
         """
-
-        dspace = self.domain
-        cspace = self.codomain
-        assert cspace.parallel and dspace.parallel
-
-        ccart      = cspace.cart
-        cpetsccart = ccart.topetsc()
-        clgmap     = cpetsccart.l2g_mapping
-
-        dcart      = dspace.cart
-        dpetsccart = dcart.topetsc()
-        dlgmap     = dpetsccart.l2g_mapping
-
-        petsc      = dpetsccart.petsc
-
-        r_size  = (cpetsccart.local_size, None)
-        c_size  = (dpetsccart.local_size, None)
-
-        gmat = petsc.Mat().create(comm=dcart.comm)
-        gmat.setSizes((r_size, c_size))
-        gmat.setType('mpiaij')
-        gmat.setLGMap(clgmap, dlgmap)
-        gmat.setUp()
-
-        mat_csr = self.tocoo_local().tocsr()
-
-        gmat.setValuesLocalCSR(mat_csr.indptr,mat_csr.indices,mat_csr.data)
-        gmat.assemble()
-        return gmat
+        from psydac.linalg.topetsc import mat_topetsc
+        mat = mat_topetsc( self )
+        return mat
 
     #--------------------------------------
     # Private methods

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -9,7 +9,7 @@ from psydac.linalg.direct_solvers import SparseSolver
 from psydac.linalg.stencil        import StencilVectorSpace, StencilVector, StencilMatrix
 from psydac.linalg.block          import BlockVectorSpace, BlockVector
 from psydac.linalg.block          import BlockLinearOperator, BlockDiagonalSolver, BlockMatrix
-from psydac.linalg.utilities      import array_to_stencil
+from psydac.linalg.utilities      import array_to_psydac
 from psydac.linalg.kron           import KroneckerLinearSolver
 from psydac.api.settings          import PSYDAC_BACKEND_GPYCCEL
 from psydac.ddm.cart              import DomainDecomposition, CartDecomposition
@@ -358,7 +358,7 @@ def test_block_matrix( n1, n2, p1, p2, P1, P2  ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True, False] )
 
-def test_block_2d_array_to_stencil_1( n1, n2, p1, p2, P1, P2 ):
+def test_block_2d_array_to_psydac_1( n1, n2, p1, p2, P1, P2 ):
     # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
@@ -386,7 +386,7 @@ def test_block_2d_array_to_stencil_1( n1, n2, p1, p2, P1, P2 ):
     x.update_ghost_regions()
 
     xa = x.toarray()
-    v  = array_to_stencil(xa, W)
+    v  = array_to_psydac(xa, W)
 
     assert np.allclose( xa , v.toarray() )
 
@@ -398,7 +398,7 @@ def test_block_2d_array_to_stencil_1( n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True, False] )
 
-def test_block_2d_array_to_stencil_2( n1, n2, p1, p2, P1, P2 ):
+def test_block_2d_array_to_psydac_2( n1, n2, p1, p2, P1, P2 ):
     # set seed for reproducibility
     seed(n1*n2*p1*p2)
 
@@ -429,7 +429,7 @@ def test_block_2d_array_to_stencil_2( n1, n2, p1, p2, P1, P2 ):
     x.update_ghost_regions()
 
     xa = x.toarray()
-    v  = array_to_stencil(xa, W)
+    v  = array_to_psydac(xa, W)
 
     assert np.allclose( xa , v.toarray() )
 

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -1372,7 +1372,7 @@ def test_stencil_matrix_2d_parallel_dot( n1, n2, p1, p2, P1, P2 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
+    D = DomainDecomposition([n1,n2], periods=[P1,P2])
 
     # Partition the points
     npts = [n1,n2]
@@ -1514,7 +1514,7 @@ def test_stencil_matrix_2d_parallel_sync( n1, n2, p1, p2, P1, P2):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
+    D = DomainDecomposition([n1,n2], periods=[P1,P2])
 
     # Partition the points
     npts = [n1,n2]
@@ -1797,7 +1797,7 @@ def test_stencil_matrix_2d_parallel_backend_dot( n1, n2, p1, p2, P1, P2, backend
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
+    D = DomainDecomposition([n1,n2], periods=[P1,P2])
 
     # Partition the points
     npts = [n1,n2]

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -315,7 +315,7 @@ def test_stencil_matrix_2d_serial_dot_2( n1, n2, p1, p2, P1, P2 ):
     y2a_exact = np.dot( M2a, x2a )
 
     # Check data in 1D array
-    print(y2a-y2a_exact)
+
     assert np.allclose( y1a, y1a_exact, rtol=1e-13, atol=1e-13 )
     assert np.allclose( y2a, y2a_exact, rtol=1e-13, atol=1e-13 )
 
@@ -1368,7 +1368,7 @@ def test_stencil_matrix_1d_parallel_dot( n1, p1, P1 ):
 
 def test_stencil_matrix_2d_parallel_dot( n1, n2, p1, p2, P1, P2 ):
 
-    from mpi4py       import MPI
+    from mpi4py import MPI
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
@@ -1432,7 +1432,7 @@ def test_stencil_matrix_1d_parallel_sync( n1, p1, P1):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1], periods=[P1])
+    D = DomainDecomposition([n1], periods=[P1], comm=comm)
 
     # Partition the points
     npts = [n1]
@@ -1514,7 +1514,7 @@ def test_stencil_matrix_2d_parallel_sync( n1, n2, p1, p2, P1, P2):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2])
+    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
 
     # Partition the points
     npts = [n1,n2]
@@ -1626,7 +1626,7 @@ def test_stencil_matrix_1d_parallel_transpose( n1, p1, P1 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1])
+    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
 
     # Partition the points
     npts = [n1]
@@ -1675,7 +1675,7 @@ def test_stencil_matrix_2d_parallel_transpose( n1, n2, p1, p2, P1, P2 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2])
+    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
 
     # Partition the points
     npts = [n1,n2]
@@ -1736,7 +1736,7 @@ def test_stencil_matrix_1d_parallel_backend_dot( n1, p1, P1 , backend):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1])
+    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
 
     # Partition the points
     npts = [n1]
@@ -1797,7 +1797,7 @@ def test_stencil_matrix_2d_parallel_backend_dot( n1, n2, p1, p2, P1, P2, backend
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2])
+    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
 
     # Partition the points
     npts = [n1,n2]

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -1313,7 +1313,7 @@ def test_stencil_matrix_1d_parallel_dot( n1, p1, P1 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
+    D = DomainDecomposition([n1-1], periods=[P1])
 
     # Partition the points
     npts = [n1]
@@ -1432,7 +1432,7 @@ def test_stencil_matrix_1d_parallel_sync( n1, p1, P1):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1], periods=[P1], comm=comm)
+    D = DomainDecomposition([n1], periods=[P1])
 
     # Partition the points
     npts = [n1]
@@ -1626,7 +1626,7 @@ def test_stencil_matrix_1d_parallel_transpose( n1, p1, P1 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
+    D = DomainDecomposition([n1-1], periods=[P1])
 
     # Partition the points
     npts = [n1]
@@ -1675,7 +1675,7 @@ def test_stencil_matrix_2d_parallel_transpose( n1, n2, p1, p2, P1, P2 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
+    D = DomainDecomposition([n1,n2], periods=[P1,P2])
 
     # Partition the points
     npts = [n1,n2]
@@ -1736,7 +1736,7 @@ def test_stencil_matrix_1d_parallel_backend_dot( n1, p1, P1 , backend):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
+    D = DomainDecomposition([n1-1], periods=[P1])
 
     # Partition the points
     npts = [n1]

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -1372,7 +1372,7 @@ def test_stencil_matrix_2d_parallel_dot( n1, n2, p1, p2, P1, P2 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1,n2], periods=[P1,P2])
+    D = DomainDecomposition([n1,n2], periods=[P1,P2], comm=comm)
 
     # Partition the points
     npts = [n1,n2]

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -1313,7 +1313,7 @@ def test_stencil_matrix_1d_parallel_dot( n1, p1, P1 ):
 
     comm = MPI.COMM_WORLD
     # Create domain decomposition
-    D = DomainDecomposition([n1-1], periods=[P1])
+    D = DomainDecomposition([n1-1], periods=[P1], comm=comm)
 
     # Partition the points
     npts = [n1]

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -3,9 +3,9 @@
 import pytest
 import numpy as np
 
-from psydac.linalg.stencil import StencilVectorSpace, StencilVector
-from psydac.linalg.utilities import array_to_stencil
-from psydac.ddm.cart import DomainDecomposition, CartDecomposition
+from psydac.linalg.stencil   import StencilVectorSpace, StencilVector
+from psydac.linalg.utilities import array_to_psydac
+from psydac.ddm.cart         import DomainDecomposition, CartDecomposition
 
 #===============================================================================
 def compute_global_starts_ends(domain_decomposition, npts):
@@ -234,7 +234,7 @@ def test_stencil_vector_2d_serial_dot( n1, n2, p1, p2, P1=True, P2=False ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True, False] )
 
-def test_stencil_2d_array_to_stencil( n1, n2, p1, p2, P1, P2 ):
+def test_stencil_2d_array_to_psydac( n1, n2, p1, p2, P1, P2 ):
 
     D = DomainDecomposition([n1,n2], periods=[P1,P2])
 
@@ -251,7 +251,7 @@ def test_stencil_2d_array_to_stencil( n1, n2, p1, p2, P1, P2 ):
             x[i1,i2] = 10*i1 + i2
 
     xa = x.toarray()
-    v  = array_to_stencil(xa, V)
+    v  = array_to_psydac(xa, V)
 
     assert np.allclose( xa , v.toarray() )
 

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -16,11 +16,12 @@ def flatten_vec( vec ):
 
     Returns
     -------
+    indices: numpy.ndarray
+        The global indices the data array collapsed into one dimension.
+
     array : numpy.ndarray
         A copy of the data array collapsed into one dimension.
 
-    indices: numpy.ndarray
-        The global indices the data array collapsed into one dimension.
     """
 
     if isinstance(vec, StencilVector):

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -1,0 +1,81 @@
+import numpy as np
+
+from psydac.linalg.block import BlockVectorSpace, BlockVector, BlockMatrix
+from psydac.linalg.stencil import StencilVectorSpace, StencilVector
+from scipy.sparse import coo_matrix, bmat
+
+from mpi4py import MPI
+
+def get_npts( space ):
+
+    if isinstance(space, StencilVectorSpace):
+        npts = np.product(space.npts)
+    elif isinstance(space, BlockVectorSpace):
+        npts = sum([get_npts(s) for s in space.spaces])
+    else:
+        raise TypeError("Expected StencilVectorSpace or BlockVectorSpace, found instead {}".format(type(space)))
+
+    return npts
+
+def vec_tocoo( vec ):
+
+    if isinstance(vec, StencilVector):
+        npts = vec.space.npts
+        idx = tuple( slice(m*p,-m*p) for m,p in zip(vec.pads, vec.space.shifts) )
+        shape = vec._data[idx].shape
+        starts = vec.space.starts
+        indices = np.array([np.ravel_multi_index( [s+x for s,x in zip(starts, xx)], dims=npts,  order='C' ) for xx in np.ndindex(*shape)] )
+        data = vec._data[idx].flatten()
+        vec = coo_matrix(
+                    (data,(indices,indices)),
+                    shape = [np.prod(npts),np.prod(npts)],
+                    dtype = vec.space.dtype)
+    elif isinstance(vec, BlockVector):
+        vecs = [vec_tocoo(b) for b in vec.blocks]
+        blocks = [[None]*len(vecs) for v in vecs]
+        for i,v in enumerate(vecs):
+            blocks[i][i] = v
+        return bmat(blocks,format='coo')
+    else:
+        raise TypeError("Expected StencilVector or BlockVector, found instead {}".format(type(vec)))
+    return vec
+
+def vec_topetsc( vec ):
+    """ Convert to petsc data structure.
+    """
+
+    from petsc4py import PETSc
+    comm = vec.space.spaces[0].cart.global_comm if isinstance(vec, BlockVector) else vec.space.cart.global_comm
+    globalsize = get_npts(vec.space)
+    vec = vec_tocoo(vec)
+    gvec  = PETSc.Vec().create(comm=comm)
+    gvec.setSizes(globalsize)
+    gvec.setFromOptions()
+    gvec.setValues(vec.row, vec.data)
+    gvec.assemble()
+    return gvec
+
+def mat_topetsc( mat ):
+    """ Convert to petsc data structure.
+    """
+
+    from petsc4py import PETSc
+
+    comm = mat.domain.spaces[0].cart.global_comm if isinstance(mat, BlockMatrix) else mat.domain.cart.global_comm
+    mat_coo = mat.tosparse()
+    ncols = get_npts(mat.domain)
+    nrows = get_npts(mat.codomain)
+    gmat  = PETSc.Mat().create(comm=comm)
+    gmat.setSizes((nrows, ncols))
+    gmat.setType("mpiaij")
+    gmat.setFromOptions()
+
+    rows, cols, data = mat_coo.row, mat_coo.col, mat_coo.data
+    NNZ = comm.allreduce(data.size, op=MPI.SUM)
+    gmat.setPreallocationNNZ(NNZ)
+    for i in range(len(rows)):
+        gmat.setValues(rows[i], cols[i], data[i])
+
+    gmat.assemble()
+    return gmat
+

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -7,7 +7,7 @@ from scipy.sparse import coo_matrix, bmat
 from mpi4py import MPI
 
 def flatten_vec( vec ):
-    """ Return the flattened 1D array values and indices corresponding to the given vector.
+    """ Return the flattened 1D array values and indices owned by the process of the given vector.
 
     Parameters
     ----------

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -32,14 +32,19 @@ def flatten_vec( vec ):
         data = vec._data[idx].flatten()
         vec = coo_matrix(
                     (data,(indices,indices)),
-                    shape = [np.prod(npts),np.prod(npts)],
+                    shape = [vec.space.dimension,vec.space.dimension],
                     dtype = vec.space.dtype)
 
     elif isinstance(vec, BlockVector):
-        vecs = [vec_tocoo(b) for b in vec.blocks]
+        vecs = [flatten_vec(b) for b in vec.blocks]
+        vecs = [coo_matrix((v[1],(v[0],v[0])),
+                shape=[vs.space.dimension,vs.space.dimension],
+                dtype=vs.space.dtype) for v,vs in zip(vecs, vec.blocks)]
+
         blocks = [[None]*len(vecs) for v in vecs]
         for i,v in enumerate(vecs):
             blocks[i][i] = v
+
         vec = bmat(blocks,format='coo')
 
     else:
@@ -47,7 +52,7 @@ def flatten_vec( vec ):
 
     array   = vec.data
     indices = vec.row
-    return array, indices
+    return indices, array
 
 def vec_topetsc( vec ):
     """ Convert Psydac Vector to PETSc data structure.

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -50,6 +50,7 @@ def array_to_psydac(x, Xh):
 def petsc_to_psydac(vec, Xh):
     """ converts a petsc Vec object to a StencilVector or a BlockVector format.
         We gather the petsc global vector in all the processes and extract the chunk owned by the Psydac Vector.
+        .. warning: This function will not work if the global vector does not fit in the process memory.
     """
 
     if isinstance(Xh, BlockVectorSpace):

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -49,7 +49,7 @@ def array_to_psydac(x, Xh):
 
 def petsc_to_psydac(vec, Xh):
     """ converts a petsc Vec object to a StencilVector or a BlockVector format.
-        We gather the petsc global vector in all the processes and extract the chunck owned by the Psydac Vector.
+        We gather the petsc global vector in all the processes and extract the chunk owned by the Psydac Vector.
     """
 
     if isinstance(Xh, BlockVectorSpace):

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -5,7 +5,7 @@ from math                  import sqrt
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector
 from psydac.linalg.block   import BlockVector, BlockVectorSpace
 
-__all__ = ['array_to_stencil', 'petsc_to_stencil', '_sym_ortho']
+__all__ = ['array_to_stencil', 'petsc_to_psydac', '_sym_ortho']
 
 def array_to_stencil(x, Xh):
     """ converts a numpy array to StencilVector or BlockVector format"""
@@ -47,8 +47,8 @@ def array_to_stencil(x, Xh):
     u.update_ghost_regions()
     return u
 
-def petsc_to_stencil(vec, Xh):
-    """ converts a numpy array to StencilVector or BlockVector format"""
+def petsc_to_psydac(vec, Xh):
+    """ converts a petsc Vec object to a StencilVector or a BlockVector format"""
 
     if isinstance(Xh, BlockVectorSpace):
         u = BlockVector(Xh)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,7 +8,7 @@ addopts = --strict-markers
 markers =
     serial: single-process test
     parallel: test to be run using 'mpiexec'
-    petsc: test to be run using 'petsc'
+    petsc: test requiring a working PETSc installation with petsc4py Python bindings
 
 python_files = test_*.py
 python_classes = 

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ addopts = --strict-markers
 markers =
     serial: single-process test
     parallel: test to be run using 'mpiexec'
+    petsc: test to be run using 'petsc'
 
 python_files = test_*.py
 python_classes = 


### PR DESCRIPTION
- Add conversion methods called `topetsc` between Psydac data structures and PETSc data structures
- Add conversion method `petsc_to_psydac` between `Vec` data structure of PETSc and `Vector` of Psydac
- Add pytest marker `petsc` (currently used to skip any tests requiring PETSc)

TO DO: install PETSc and petsc4py on CI runner, and run all tests marked with `petsc`