### PR TITLE
Delete print

### DIFF
--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -235,7 +235,6 @@ class LinearOperatorDot(SplBasic):
                     body = [For(i,j, body)]
 
                 body.insert(0,Assign(v, 0.0))
-                print(diag_keys, it, key)
                 if diag_keys:
                     body.append(Assign(v3,v))
                 else:


### PR DESCRIPTION
Remove forgotten `print` statement (used for debugging) from AST