### PR TITLE
Fix installation and improve README

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -80,6 +80,10 @@ jobs:
 #          restore-keys: |
 #            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
+      - name: Install wheel
+        run: |
+          python -m pip install wheel
+
       - name: Install Python dependencies
 #        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
@@ -90,7 +94,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install -v wheel Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
+          python -m pip install -v Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
           python -m pip list
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,8 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install wheel Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
+          python -m pip install -v wheel Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
+          python -m pip list
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install wheel Cython>=0.25 numpy>=1.16,<1.22 pkgconfig mpi4py>=3.0.0 # h5py requirements
+          python -m pip install wheel Cython>=0.25 numpy>=1.16,<1.22 pkgconfig mpi4py>=3.0.0
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements.txt --no-build-isolation
           python -m pip install -r requirements_extra.txt --no-build-isolation
           python -m pip list
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install wheel cython
+          python -m pip install Cython numpy>=1.15.1 pkgconfig mpi4py>=3.0.0 # h5py requirements
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install -no-build-isolation .
+          python -m pip install .
           pyccel psydac/core/kernels.py --language fortran
           pyccel psydac/core/bsplines_pyccel.py --language fortran
           python -m pip freeze

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,8 +90,9 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install -r requirements.txt
-          python -m pip install -r requirements_extra.txt --no-build-isolation
+          python -m pip install wheel cython
+          python -m pip install --no-build-isolation -r requirements.txt
+          python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list
 
       - name: Install project

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
             python-version: 3.9
 
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
 
           - os: macos-latest
             python-version: 3.9

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install --no-build-isolation .
+          python -m pip install -no-build-isolation .
           pyccel psydac/core/kernels.py --language fortran
           pyccel psydac/core/bsplines_pyccel.py --language fortran
           python -m pip freeze

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install -r requirements.txt --no-build-isolation
+          python -m pip install -r requirements.txt
           python -m pip install -r requirements_extra.txt --no-build-isolation
           python -m pip list
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,10 +31,10 @@ jobs:
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,19 +66,19 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Get pip cache dir
-        id: pip-cache-dir
-        run: |
-          echo "::set-output name=dir::$(python -m pip cache dir)"
-
-      - name: pip cache
-        uses: actions/cache@v2
-        id: pip-cache
-        with:
-          path: ${{ steps.pip-cache-dir.outputs.dir }}
-          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
+#      - name: Get pip cache dir
+#        id: pip-cache-dir
+#        run: |
+#          echo "::set-output name=dir::$(python -m pip cache dir)"
+#
+#      - name: pip cache
+#        uses: actions/cache@v2
+#        id: pip-cache
+#        with:
+#          path: ${{ steps.pip-cache-dir.outputs.dir }}
+#          key: ${{ matrix.os }}-${{ matrix.python-version }}-pip-${{ hashFiles('**/requirements.txt') }}
+#          restore-keys: |
+#            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
       - name: Install Python dependencies
 #        if: steps.pip-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,6 +95,10 @@ jobs:
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list
 
+      - name: Check h5py installation
+        run: |
+            python3 -c "from h5py import File; print(File)"
+
       - name: Install project
         run: |
           python -m pip install .

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install h5py dependencies
         run: |
-          python -m pip install Cython>=0.25 "numpy>=1.16,<1.22" mpi4py>=3.0.0
+          python -m pip install pkgconfig Cython>=0.25 "numpy>=1.16,<1.22" mpi4py>=3.0.0
           python -m pip list
 
       - name: Determine directory of parallel HDF5 library

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,7 +56,8 @@ jobs:
           brew install hdf5-mpi
           brew install libomp
           if [[ ! -f "/usr/local/bin/gfortran" ]]; then
-            ln -s /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
+            gfort=$(ls /usr/local/bin/gfortran-* | tail -n 1)
+            ln -s ${gfort} /usr/local/bin/gfortran
           fi
           echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install -no-build-isolation .
+          python -m pip install --no-build-isolation .
           pyccel psydac/core/kernels.py --language fortran
           pyccel psydac/core/bsplines_pyccel.py --language fortran
           python -m pip freeze

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install Cython numpy>=1.15.1 pkgconfig mpi4py>=3.0.0 # h5py requirements
+          python -m pip install wheel Cython numpy>=1.15.1 pkgconfig mpi4py>=3.0.0 # h5py requirements
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,6 +25,9 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.9
 
+          - os: ubuntu-latest
+            python-version: 3.10
+
           - os: macos-latest
             python-version: 3.9
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install wheel Cython>=0.25 numpy>=1.16,<1.22 pkgconfig mpi4py>=3.0.0
+          python -m pip install wheel Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Install project
         run: |
-          python -m pip install .
+          python -m pip install -no-build-isolation .
           pyccel psydac/core/kernels.py --language fortran
           pyccel psydac/core/bsplines_pyccel.py --language fortran
           python -m pip freeze

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,10 +66,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
-      - name: Upgrade setuptools
-        run: |
-          python -m pip install --upgrade setuptools!=67.2.0
-
 #      - name: Get pip cache dir
 #        id: pip-cache-dir
 #        run: |
@@ -84,15 +80,6 @@ jobs:
 #          restore-keys: |
 #            ${{ matrix.os }}-${{ matrix.python-version }}-pip-
 
-      - name: Install wheel
-        run: |
-          python -m pip install wheel
-
-      - name: Install h5py dependencies
-        run: |
-          python -m pip install pkgconfig Cython>=0.25 "numpy>=1.16,<1.22" mpi4py>=3.0.0
-          python -m pip list
-
       - name: Determine directory of parallel HDF5 library
         run: |
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
@@ -102,20 +89,11 @@ jobs:
           fi
           echo $HDF5_DIR
 
-      - name: Install h5py library in parallel mode
-        run: |
-          export CC="mpicc" HDF5_MPI="ON"
-          python -m pip install --no-build-isolation h5py --no-binary h5py
-          python -m pip list
-
-      - name: Check h5py installation
-        run: |
-          python3 -c "from h5py import File; print(File)"
-
       - name: Install Python dependencies
         run: |
-          python -m pip install --no-build-isolation -r requirements.txt
-          python -m pip install --no-build-isolation -r requirements_extra.txt
+          export CC="mpicc" HDF5_MPI="ON"
+          python -m pip install -r requirements.txt
+          python -m pip install -r requirements_extra.txt --no-build-isolation
           python -m pip list
 
 #      - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,21 +84,50 @@ jobs:
         run: |
           python -m pip install wheel
 
-      - name: Install Python dependencies
-#        if: steps.pip-cache.outputs.cache-hit != 'true'
+      - name: Install h5py dependencies
         run: |
-          export CC="mpicc"
-          export HDF5_MPI="ON"
+          python -m pip install Cython>=0.25 "numpy>=1.16,<1.22" mpi4py>=3.0.0
+          python -m pip list
+
+      - name: Determine directory of parallel HDF5 library
+        run: |
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
             export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install -v Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
+          echo $HDF5_DIR
+
+      - name: Install h5py library in parallel mode
+        run: |
+          python -m pip install --no-build-isolation h5py --no-binary h5py
           python -m pip list
+
+      - name: Check h5py installation
+        run: |
+          python3 -c "from h5py import File; print(File)"
+
+      - name: Install Python dependencies
+        run: |
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list
+
+#      - name: Install Python dependencies
+##        if: steps.pip-cache.outputs.cache-hit != 'true'
+#        run: |
+#          export CC="mpicc"
+#          export HDF5_MPI="ON"
+#          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+#            export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+#            export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
+#          fi
+#          python -m pip install -v Cython>=0.25 "numpy>=1.16,<1.22" pkgconfig mpi4py>=3.0.0
+#          python -m pip list
+#          python -m pip install --no-build-isolation -r requirements.txt
+#          python -m pip install --no-build-isolation -r requirements_extra.txt
+#          python -m pip list
 
       - name: Check h5py installation
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -66,6 +66,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
 
+      - name: Upgrade setuptools
+        run: |
+          python -m pip install --upgrade setuptools!=67.2.0
+
 #      - name: Get pip cache dir
 #        id: pip-cache-dir
 #        run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,7 +90,7 @@ jobs:
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
-          python -m pip install wheel Cython numpy>=1.15.1 pkgconfig mpi4py>=3.0.0 # h5py requirements
+          python -m pip install wheel Cython>=0.25 numpy>=1.16,<1.22 pkgconfig mpi4py>=3.0.0 # h5py requirements
           python -m pip install --no-build-isolation -r requirements.txt
           python -m pip install --no-build-isolation -r requirements_extra.txt
           python -m pip list

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Install h5py library in parallel mode
         run: |
+          export CC="mpicc" HDF5_MPI="ON"
           python -m pip install --no-build-isolation h5py --no-binary h5py
           python -m pip list
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 
 Psydac requires a certain number of components to be installed on the machine:
 
-  - Fortran and C compilers with OpenMP support
-  - OpenMP library
-  - BLAS and LAPACK libraries
-  - MPI library
-  - HDF5 library with MPI support
+-   Fortran and C compilers with OpenMP support
+-   OpenMP library
+-   BLAS and LAPACK libraries
+-   MPI library
+-   HDF5 library with MPI support
 
 The installations instructions depend on the operating system and on the packaging manager used.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Table of contents
 
 -   [Requirements](#requirements)
--   [Python setup and dependencies](#python-setup-and-dependencies)
+-   [Python setup and project download](#python-setup-and-project-download)
 -   [Installing the library](#installing-the-library)
 -   [Uninstall](#uninstall)
 -   [Running tests](#running-tests)
@@ -58,7 +58,7 @@ brew install hdf5-mpi
 Please see the [instructions for the pyccel library](https://github.com/pyccel/pyccel#Requirements) for further details.
 
 
-## Python setup and dependencies
+## Python setup and project download
 
 We recommend creating a clean Python virtual environment using [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
 ```sh
@@ -82,25 +82,26 @@ git clone git@github.com:pyccel/psydac.git
 ```
 The latter command requires a GitHub account.
 
-At this point please take note of the **installation point** of your parallel HDF5 library, which can be found with
-```sh
-h5pcc -showconfig -echo || true
-```
-The absolute path to this folder should be stored in the `HDF5_DIR` environment variable for use in the next step.
-```sh
-export HDF5_DIR=/path/to/parallel/hdf5
-```
+
+## Installing the library
 
 Psydac depends on several Python packages, which should be installed in the newly created virtual environment.
 These dependencies can be installed from the cloned directory `<ROOT-PATH>/psydac` using
 ```sh
-export CC="mpicc" HDF5_MPI="ON"
+export CC="mpicc"
+export HDF5_MPI="ON"
+export HDF5_DIR=/path/to/parallel/hdf5
+
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install -r requirements_extra.txt --no-build-isolation
 ```
+where the `HDF5_DIR` environment variable should store the absolute path to the **installation point** of your parallel HDF5 library, which can be found with
+```sh
+h5pcc -showconfig
+```
 
-## Installing the library
+At this point the Psydac library may be installed in **standard mode**, which copies the relevant files to the correct locations of the virtual environment, or in **development mode**, which only installs symbolic links to the Psydac directory. The latter mode allows one to effect the behavior of Psydac by modifying the source files.
 
 *   **Standard mode**:
     ```bash
@@ -109,7 +110,7 @@ python3 -m pip install -r requirements_extra.txt --no-build-isolation
 
 *   **Development mode**:
     ```bash
-    python3 -m pip install --user -e .
+    python3 -m pip install --editable .
     ```
 
 ## Uninstall

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@
 -   [User Documentation](#user-documentation)
 
 ## Requirements
------
 
 Psydac requires a certain number of components to be installed on the machine:
 
@@ -60,7 +59,6 @@ Please see the [instructions for the pyccel library](https://github.com/pyccel/p
 
 
 ## Python setup and dependencies
------
 
 We recommend creating a clean Python virtual environment using [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
 ```sh
@@ -103,7 +101,6 @@ python3 -m pip install -r requirements_extra.txt --no-build-isolation
 ```
 
 ## Installing the library
------
 
 *   **Standard mode**:
     ```bash
@@ -116,14 +113,14 @@ python3 -m pip install -r requirements_extra.txt --no-build-isolation
     ```
 
 ## Uninstall
------
+
 *   **Whichever the install mode**:
     ```bash
     python3 -m pip uninstall psydac
     ```
 
 ## Running tests
------
+
 ```bash
 export PSYDAC_MESH_DIR=/path/to/psydac/mesh/
 python3 -m pytest --pyargs psydac -m "not parallel"
@@ -131,7 +128,7 @@ python3 /path/to/psydac/mpi_tester.py --pyargs psydac -m "parallel"
 ```
 
 ## Speeding up **Psydac**'s core
------
+
 Some of the low-level functions in psydac are written in python in a way that can be accelerated by pyccel. Currently, all of those are in `psydac/core/kernels.py`, `psydac/core/bsplines_pyccel.py` and `psydac/linalg/kernels.py`.
 ```bash
 cd path/to/psydac/core
@@ -149,10 +146,11 @@ pyccel kernels.py --language fortran
 -   [Other examples](./examples/)
 
 ## Mesh Generation
------
+
 After installation, a command `psydac-mesh` will be available.
 
 ### Example of usage
+
 ```bash
 psydac-mesh -n='16,16' -d='3,3' square mesh.h5
 ```

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 
 Psydac requires a certain number of components to be installed on the machine:
 
-- Fortran and C compilers with OpenMP support
-- OpenMP library
-- BLAS and LAPACK libraries
-- MPI library
-- HDF5 library with MPI support
+  - Fortran and C compilers with OpenMP support
+  - OpenMP library
+  - BLAS and LAPACK libraries
+  - MPI library
+  - HDF5 library with MPI support
 
 The installations instructions depend on the operating system and on the packaging manager used.
 
@@ -57,7 +57,6 @@ brew install hdf5-mpi
 
 Please see the [instructions for the pyccel library](https://github.com/pyccel/pyccel#Requirements) for further details.
 
-
 ## Python setup and project download
 
 We recommend creating a clean Python virtual environment using [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
@@ -81,7 +80,6 @@ or
 git clone git@github.com:pyccel/psydac.git
 ```
 The latter command requires a GitHub account.
-
 
 ## Installing the library
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ## Table of contents
 
 -   [Requirements](#requirements)
+-   [Python setup and dependencies](#python-setup-and-dependencies)
 -   [Installing the library](#installing-the-library)
 -   [Uninstall](#uninstall)
 -   [Running tests](#running-tests)
@@ -16,26 +17,90 @@
 ## Requirements
 -----
 
-*   **Python3**:
-    ```bash
-    sudo apt-get install python3 python3-dev
-    ```
+Psydac requires a certain number of components to be installed on the machine:
 
-*   **pip3**:
-    ```bash
-    sudo apt-get install python3-pip
-    ```
+- Fortran and C compilers with OpenMP support
+- OpenMP library
+- BLAS and LAPACK libraries
+- MPI library
+- HDF5 library with MPI support
 
-*   All *non-Python* dependencies can be installed by following the [instructions for the pyccel library](https://github.com/pyccel/pyccel#Requirements)
+The installations instructions depend on the operating system and on the packaging manager used.
 
-*   All *Python* dependencies can be installed using:
-    ```bash
-    export CC="mpicc"
-    export HDF5_MPI="ON"
-    export HDF5_DIR=/path/to/hdf5/openmpi
-    python3 -m pip install -r requirements.txt
-    python3 -m pip install -r requirements_extra.txt --no-build-isolation
-     ```
+### Linux Debian-Ubuntu-Mint
+
+To install all requirements on a Linux Ubuntu operating system, just use APT, the Advanced Packaging Tool:
+```sh
+sudo apt update
+sudo apt install python3 python3-dev python3-pip
+sudo apt install gcc gfortran
+sudo apt install libblas-dev liblapack-dev
+sudo apt install libopenmpi-dev openmpi-bin
+sudo apt install libomp-dev libomp5
+sudo apt install libhdf5-openmpi-dev
+```
+
+### macOS
+
+To install all the requirements on a macOS operating system we recommend using [Homebrew](https://brew.sh/):
+
+```eh
+brew update
+brew install gcc
+brew install openblas
+brew install lapack
+brew install open-mpi
+brew install libomp
+brew install hdf5-mpi
+```
+
+### Other operating systems
+
+Please see the [instructions for the pyccel library](https://github.com/pyccel/pyccel#Requirements) for further details.
+
+
+## Python setup and dependencies
+-----
+
+We recommend creating a clean Python virtual environment using [venv](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment):
+```sh
+python3 -m venv <ENV-PATH>
+```
+where `<ENV-PATH>` is the location to create the virtual environment.
+(A new directory will be created at the required location.)
+
+In order to activate the environment from a new terminal session just run the command
+```sh
+source <ENV-PATH>/bin/activate
+```
+
+One can clone the Psydac repository at any location `<ROOT-PATH>` in the filesystem which does not require administrator privileges, using either
+```sh
+git clone https://github.com/pyccel/psydac.git
+```
+or
+```sh
+git clone git@github.com:pyccel/psydac.git
+```
+The latter command requires a GitHub account.
+
+At this point please take note of the **installation point** of your parallel HDF5 library, which can be found with
+```sh
+h5pcc -showconfig -echo || true
+```
+The absolute path to this folder should be stored in the `HDF5_DIR` environment variable for use in the next step.
+```sh
+export HDF5_DIR=/path/to/parallel/hdf5
+```
+
+Psydac depends on several Python packages, which should be installed in the newly created virtual environment.
+These dependencies can be installed from the cloned directory `<ROOT-PATH>/psydac` using
+```sh
+export CC="mpicc" HDF5_MPI="ON"
+python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+python3 -m pip install -r requirements_extra.txt --no-build-isolation
+```
 
 ## Installing the library
 -----

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,8 @@
-# h5py must be built from source using MPI compiler
-# and linked to parallel HDF5 library. To do so set
-#
-# CC="mpicc"
-# HDF5_MPI="ON"
-# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-#
-setuptools
 wheel
+setuptools >=61,!=67.2.0
 numpy >=1.16,<1.22
 Cython>=0.25
-numba
-mpi4py
-h5py
---no-binary h5py
+mpi4py>=3.0.0
+
+# Required to build h5py from source
+pkgconfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,15 @@
+# h5py must be built from source using MPI compiler
+# and linked to parallel HDF5 library. To do so set
+#
+# CC="mpicc"
+# HDF5_MPI="ON"
+# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#
 setuptools
 wheel
 numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py
+h5py
+--no-binary h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py
+
+# Needed to build h5py with --no-build-isolation flag
+pkgconfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,6 @@
-# h5py must be built from source using MPI compiler
-# and linked to parallel HDF5 library. To do so set
-#
-# CC="mpicc"
-# HDF5_MPI="ON"
-# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-#
 setuptools
 wheel
 numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py
-h5py
---no-binary h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,3 @@ numpy >=1.16,<1.22
 Cython>=0.25
 numba
 mpi4py
-
-# Needed to build h5py with --no-build-isolation flag
-pkgconfig

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,12 +1,2 @@
-# h5py must be built from source using MPI compiler
-# and linked to parallel HDF5 library. To do so set
-#
-# CC="mpicc"
-# HDF5_MPI="ON"
-# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
-#
-h5py
---no-binary h5py
-
 # IGAKIT - not on PyPI
-igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip
+https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,12 @@
+# h5py must be built from source using MPI compiler
+# and linked to parallel HDF5 library. To do so set
+#
+# CC="mpicc"
+# HDF5_MPI="ON"
+# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#
+h5py
+--no-binary h5py
+
 # IGAKIT - not on PyPI
-https://github.com/dalcinl/igakit/archive/refs/heads/master.zip
+igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip

--- a/requirements_extra.txt
+++ b/requirements_extra.txt
@@ -1,2 +1,12 @@
+# h5py must be built from source using MPI compiler
+# and linked to parallel HDF5 library. To do so set
+#
+# CC="mpicc"
+# HDF5_MPI="ON"
+# HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+#
+h5py
+--no-binary h5py
+
 # IGAKIT - not on PyPI
 https://github.com/dalcinl/igakit/archive/refs/heads/master.zip


### PR DESCRIPTION
- Fix installation of `h5py` library by using `--no-build-isolation` flag and correct version of `setuptools`
- Fix macOS install by linking to correct version of `gfortran` (fixes #252)
- Also run tests with Python 3.10 on Ubuntu
- Use newer versions of actions: `checkout@v3` and `setup-python@v4`
- Update and improve README file