### PR TITLE
Do not decompose domain along user-specified dimensions

### DIFF
--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -356,7 +356,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
     return Vh
 
 #==============================================================================
-def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm=None):
+def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm=None, dims_mask=None):
 
     if comm is not None:
         # Create a copy of the communicator
@@ -372,7 +372,7 @@ def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm
         return Geometry(filename=filename, comm=comm)
 
     elif ncells:
-        return Geometry.from_topological_domain(domain, ncells, periodic=periodic, comm=comm)
+        return Geometry.from_topological_domain(domain, ncells, periodic=periodic, comm=comm, dims_mask=dims_mask)
 
 #==============================================================================
 def discretize(a, *args, **kwargs):

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -356,7 +356,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
     return Vh
 
 #==============================================================================
-def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm=None, dims_mask=None):
+def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm=None, mpi_dims_mask=None):
 
     if comm is not None:
         # Create a copy of the communicator
@@ -372,7 +372,7 @@ def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm
         return Geometry(filename=filename, comm=comm)
 
     elif ncells:
-        return Geometry.from_topological_domain(domain, ncells, periodic=periodic, comm=comm, dims_mask=dims_mask)
+        return Geometry.from_topological_domain(domain, ncells, periodic=periodic, comm=comm, mpi_dims_mask=mpi_dims_mask)
 
 #==============================================================================
 def discretize(a, *args, **kwargs):

--- a/psydac/cad/geometry.py
+++ b/psydac/cad/geometry.py
@@ -57,9 +57,9 @@ class Geometry( object ):
     comm: MPI.Comm
         MPI intra-communicator.
         
-    dims_mask: list of bool
+    mpi_dims_mask: list of bool
         True if the dimension is to be used in the domain decomposition (=default for each dimension). 
-        If dims_mask[i]=False, the i-th dimension will not be decomposed.
+        If mpi_dims_mask[i]=False, the i-th dimension will not be decomposed.
   
     """
     _ldim     = None
@@ -71,7 +71,7 @@ class Geometry( object ):
     # Option [1]: from a (domain, mappings) or a file
     #--------------------------------------------------------------------------
     def __init__( self, domain=None, ncells=None, periodic=None, mappings=None,
-                  filename=None, comm=None, dims_mask=None ):
+                  filename=None, comm=None, mpi_dims_mask=None ):
 
         # ... read the geometry if the filename is given
         if not( filename is None ):
@@ -104,7 +104,7 @@ class Geometry( object ):
 
             if len(domain) == 1:
                 name = domain.name
-                self._ddm = DomainDecomposition(ncells[name], periodic[name], comm=comm, dims_mask=dims_mask)
+                self._ddm = DomainDecomposition(ncells[name], periodic[name], comm=comm, mpi_dims_mask=mpi_dims_mask)
             else:
                 ncells    = [ncells[itr.name] for itr in domain.interior]
                 periodic  = [periodic[itr.name] for itr in domain.interior]
@@ -149,7 +149,7 @@ class Geometry( object ):
     # Option [3]: discrete topological line/square/cube
     #--------------------------------------------------------------------------
     @classmethod
-    def from_topological_domain(cls, domain, ncells, *, periodic=None, comm=None, dims_mask=None):
+    def from_topological_domain(cls, domain, ncells, *, periodic=None, comm=None, mpi_dims_mask=None):
         interior = domain.interior
         if not isinstance(interior, Union):
             interior = [interior]
@@ -170,7 +170,7 @@ class Geometry( object ):
         if isinstance(periodic, (list, tuple)):
             periodic = {itr.name:periodic for itr in interior}
 
-        geo = Geometry(domain=domain, mappings=mappings, ncells=ncells, periodic=periodic, comm=comm, dims_mask=dims_mask)
+        geo = Geometry(domain=domain, mappings=mappings, ncells=ncells, periodic=periodic, comm=comm, mpi_dims_mask=mpi_dims_mask)
 
         return geo
 

--- a/psydac/cad/geometry.py
+++ b/psydac/cad/geometry.py
@@ -56,6 +56,10 @@ class Geometry( object ):
 
     comm: MPI.Comm
         MPI intra-communicator.
+        
+    dims_mask: list of bool
+        True if the dimension is to be used in the domain decomposition (=default for each dimension). 
+        If dims_mask[i]=False, the i-th dimension will not be decomposed.
   
     """
     _ldim     = None
@@ -67,7 +71,7 @@ class Geometry( object ):
     # Option [1]: from a (domain, mappings) or a file
     #--------------------------------------------------------------------------
     def __init__( self, domain=None, ncells=None, periodic=None, mappings=None,
-                  filename=None, comm=None ):
+                  filename=None, comm=None, dims_mask=None ):
 
         # ... read the geometry if the filename is given
         if not( filename is None ):
@@ -100,7 +104,7 @@ class Geometry( object ):
 
             if len(domain) == 1:
                 name = domain.name
-                self._ddm = DomainDecomposition(ncells[name], periodic[name], comm=comm)
+                self._ddm = DomainDecomposition(ncells[name], periodic[name], comm=comm, dims_mask=dims_mask)
             else:
                 ncells    = [ncells[itr.name] for itr in domain.interior]
                 periodic  = [periodic[itr.name] for itr in domain.interior]
@@ -145,7 +149,7 @@ class Geometry( object ):
     # Option [3]: discrete topological line/square/cube
     #--------------------------------------------------------------------------
     @classmethod
-    def from_topological_domain(cls, domain, ncells, *, periodic=None, comm=None):
+    def from_topological_domain(cls, domain, ncells, *, periodic=None, comm=None, dims_mask=None):
         interior = domain.interior
         if not isinstance(interior, Union):
             interior = [interior]
@@ -166,7 +170,7 @@ class Geometry( object ):
         if isinstance(periodic, (list, tuple)):
             periodic = {itr.name:periodic for itr in interior}
 
-        geo = Geometry(domain=domain, mappings=mappings, ncells=ncells, periodic=periodic, comm=comm)
+        geo = Geometry(domain=domain, mappings=mappings, ncells=ncells, periodic=periodic, comm=comm, dims_mask=dims_mask)
 
         return geo
 

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -194,9 +194,13 @@ class DomainDecomposition:
         This information is needed when comm is None (sequential case) or comm == MPI.COMM_NULL (MPI rank does not own the domain),
         to be able to calculate global_element_starts and global_element_ends.
 
+    dims_mask: list of bool
+        True if the dimension is to be used in the domain decomposition (=default for each dimension). 
+        If dims_mask[i]=False, the i-th dimension will not be decomposed.
+
     """
 
-    def __init__(self, ncells, periods, comm=None, global_comm=None, num_threads=None, size=None):
+    def __init__(self, ncells, periods, comm=None, global_comm=None, num_threads=None, size=None, dims_mask=None):
 
         # Check input arguments
         # TODO: check that arguments are identical across all processes
@@ -225,7 +229,7 @@ class DomainDecomposition:
             self._rank = comm.Get_rank()
 
         self._ndims         = len(ncells)
-        nprocs, block_shape = compute_dims( self._size, self._ncells )
+        nprocs, block_shape = compute_dims( self._size, self._ncells, dims_mask=dims_mask )
 
         self._nprocs = nprocs
 

--- a/psydac/ddm/cart.py
+++ b/psydac/ddm/cart.py
@@ -194,13 +194,13 @@ class DomainDecomposition:
         This information is needed when comm is None (sequential case) or comm == MPI.COMM_NULL (MPI rank does not own the domain),
         to be able to calculate global_element_starts and global_element_ends.
 
-    dims_mask: list of bool
+    mpi_dims_mask: list of bool
         True if the dimension is to be used in the domain decomposition (=default for each dimension). 
-        If dims_mask[i]=False, the i-th dimension will not be decomposed.
+        If mpi_dims_mask[i]=False, the i-th dimension will not be decomposed.
 
     """
 
-    def __init__(self, ncells, periods, comm=None, global_comm=None, num_threads=None, size=None, dims_mask=None):
+    def __init__(self, ncells, periods, comm=None, global_comm=None, num_threads=None, size=None, mpi_dims_mask=None):
 
         # Check input arguments
         # TODO: check that arguments are identical across all processes
@@ -229,7 +229,7 @@ class DomainDecomposition:
             self._rank = comm.Get_rank()
 
         self._ndims         = len(ncells)
-        nprocs, block_shape = compute_dims( self._size, self._ncells, dims_mask=dims_mask )
+        nprocs, block_shape = compute_dims( self._size, self._ncells, mpi_dims_mask=mpi_dims_mask )
 
         self._nprocs = nprocs
 

--- a/psydac/ddm/partition.py
+++ b/psydac/ddm/partition.py
@@ -139,9 +139,11 @@ def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=
 def compute_dims_general( mpi_size, npts, dims_mask=None ):
 
     if dims_mask is None:
-        dims_mask = [True]*len( npts )
+        dims_mask = [True] * len(npts)
     else:
-        assert any(dims_mask), 'dims_mask must contain at least one True value.'
+        assert len(dims_mask) == len(npts), "dims_mask must have one entry for each dimension."
+        assert all(isinstance(m, bool) for m in dims_mask), "dims_mask must only contain True/False values."
+        assert any(dims_mask), "dims_mask must contain at least one True value."
 
     nprocs = [1]*len( npts )
     

--- a/psydac/ddm/partition.py
+++ b/psydac/ddm/partition.py
@@ -66,7 +66,7 @@ def partition_procs_per_patch(npts, size):
     return sizes, ranges
 
 #==============================================================================
-def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=False, dims_mask=None ):
+def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=False, mpi_dims_mask=None ):
     """
     With the aim of distributing a multi-dimensional array on a Cartesian
     topology, compute the number of processes along each dimension.
@@ -88,7 +88,7 @@ def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=
     try_uniform: bool
         try to decompose the array uniformly.
         
-    dims_mask: list of bool
+    mpi_dims_mask: list of bool
         True if the dimension is to be used in the domain decomposition (=default for each dimension). 
         If dim_mask[i]=False, the domain decomposition yields blocksizes[i]=gridsizes[i] along the i-th dimension.
 
@@ -117,7 +117,7 @@ def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=
     if try_uniform and uniform:
         dims, blocksizes = compute_dims_uniform( nnodes, gridsizes )
     else:
-        dims, blocksizes = compute_dims_general( nnodes, gridsizes, dims_mask=dims_mask )
+        dims, blocksizes = compute_dims_general( nnodes, gridsizes, mpi_dims_mask=mpi_dims_mask )
 
     # If a minimum block size is given, verify that condition is met
 
@@ -136,19 +136,19 @@ def compute_dims( nnodes, gridsizes, min_blocksizes=None, mpi=None, try_uniform=
     return dims, blocksizes
 
 #==============================================================================
-def compute_dims_general( mpi_size, npts, dims_mask=None ):
+def compute_dims_general( mpi_size, npts, mpi_dims_mask=None ):
 
-    if dims_mask is None:
-        dims_mask = [True] * len(npts)
+    if mpi_dims_mask is None:
+        mpi_dims_mask = [True] * len(npts)
     else:
-        assert len(dims_mask) == len(npts), "dims_mask must have one entry for each dimension."
-        assert all(isinstance(m, bool) for m in dims_mask), "dims_mask must only contain True/False values."
-        assert any(dims_mask), "dims_mask must contain at least one True value."
+        assert len(mpi_dims_mask) == len(npts), "mpi_dims_mask must have one entry for each dimension."
+        assert all(isinstance(m, bool) for m in mpi_dims_mask), "mpi_dims_mask must only contain True/False values."
+        assert any(mpi_dims_mask), "mpi_dims_mask must contain at least one True value."
 
     nprocs = [1]*len( npts )
     
     shape = []
-    for n, use_dim in zip(npts, dims_mask):
+    for n, use_dim in zip(npts, mpi_dims_mask):
         if use_dim:
             shape += [n]
         else:
@@ -168,7 +168,7 @@ def compute_dims_general( mpi_size, npts, dims_mask=None ):
         nprocs[i]  *= a
         shape [i] //= a
         
-    for i, use_dim in enumerate(dims_mask):
+    for i, use_dim in enumerate(mpi_dims_mask):
         if not use_dim:
             shape[i] = npts[i]
 

--- a/psydac/ddm/tests/test_partition.py
+++ b/psydac/ddm/tests/test_partition.py
@@ -54,15 +54,12 @@ def test_partition_1d_general( mpi_size ):
 @pytest.mark.parametrize( 'npts', [[64, 64], [58, 64], [64, 31]] )
 
 def test_partition_2d_dims_mask( mpi_size, npts, mask ):
-
-    print(f'\nmpi_size={mpi_size}:')    
+  
     # General partition: blocks are not all identical but closer to a cube
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3] )   
-    print(f'general:'.ljust(30), dims, blocksizes) 
     
     # Mask dimensions
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3], dims_mask=mask )   
-    print(f'dims_mask {mask}:'.ljust(30), dims, blocksizes) 
     
     # test
     assert dims[0]*dims[1] == mpi_size
@@ -103,15 +100,12 @@ def test_partition_3d():
 @pytest.mark.parametrize( 'npts', [[32, 64, 128], [62, 59, 41]] )
 
 def test_partition_3d_dims_mask( mpi_size, npts, mask ):
-
-    print(f'\nmpi_size={mpi_size}:')    
+   
     # General partition: blocks are not all identical but closer to a cube
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3] )   
-    print(f'general:'.ljust(35), dims, blocksizes) 
     
     # Mask dimensions
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3], dims_mask=mask )   
-    print(f'dims_mask {mask}:'.ljust(35), dims, blocksizes) 
     
     # test
     assert dims[0]*dims[1]*dims[2] == mpi_size

--- a/psydac/ddm/tests/test_partition.py
+++ b/psydac/ddm/tests/test_partition.py
@@ -59,7 +59,7 @@ def test_partition_2d_dims_mask( mpi_size, npts, mask ):
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3] )   
     
     # Mask dimensions
-    dims, blocksizes = compute_dims( mpi_size, npts, [3,3], dims_mask=mask )   
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3], mpi_dims_mask=mask )   
     
     # test
     assert dims[0]*dims[1] == mpi_size
@@ -105,7 +105,7 @@ def test_partition_3d_dims_mask( mpi_size, npts, mask ):
     dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3] )   
     
     # Mask dimensions
-    dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3], dims_mask=mask )   
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3], mpi_dims_mask=mask )   
     
     # test
     assert dims[0]*dims[1]*dims[2] == mpi_size

--- a/psydac/ddm/tests/test_partition.py
+++ b/psydac/ddm/tests/test_partition.py
@@ -49,6 +49,30 @@ def test_partition_1d_general( mpi_size ):
         dims, blocksizes = compute_dims( mpi_size, [n1,], [p1,] )
 
 #==============================================================================
+@pytest.mark.parametrize( 'mpi_size', [1,2,5,10] )
+@pytest.mark.parametrize( 'mask', [[True, False], [False, True]] )
+@pytest.mark.parametrize( 'npts', [[64, 64], [58, 64], [64, 31]] )
+
+def test_partition_2d_dims_mask( mpi_size, npts, mask ):
+
+    print(f'\nmpi_size={mpi_size}:')    
+    # General partition: blocks are not all identical but closer to a cube
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3] )   
+    print(f'general:'.ljust(30), dims, blocksizes) 
+    
+    # Mask dimensions
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3], dims_mask=mask )   
+    print(f'dims_mask {mask}:'.ljust(30), dims, blocksizes) 
+    
+    # test
+    assert dims[0]*dims[1] == mpi_size
+    for bsize, n, use_dim in zip(blocksizes, npts, mask):
+        if not use_dim:
+            assert bsize == n
+        else:
+            assert bsize == n//mpi_size
+
+#==============================================================================
 def test_partition_3d():
 
     npts = [64,128,50]
@@ -67,3 +91,40 @@ def test_partition_3d():
 
     assert tuple( dims ) == (5, 5, 4)
     assert tuple( blocksizes ) == (12, 25, 12)
+    
+#==============================================================================
+@pytest.mark.parametrize( 'mpi_size', [1,2,5,10] )
+@pytest.mark.parametrize( 'mask', [[True, False, False], 
+                                   [False, True, False], 
+                                   [False, False, True], 
+                                   [True, True, False],
+                                   [True, False, True],
+                                   [False, True, True]] )
+@pytest.mark.parametrize( 'npts', [[32, 64, 128], [62, 59, 41]] )
+
+def test_partition_3d_dims_mask( mpi_size, npts, mask ):
+
+    print(f'\nmpi_size={mpi_size}:')    
+    # General partition: blocks are not all identical but closer to a cube
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3] )   
+    print(f'general:'.ljust(35), dims, blocksizes) 
+    
+    # Mask dimensions
+    dims, blocksizes = compute_dims( mpi_size, npts, [3,3,3], dims_mask=mask )   
+    print(f'dims_mask {mask}:'.ljust(35), dims, blocksizes) 
+    
+    # test
+    assert dims[0]*dims[1]*dims[2] == mpi_size
+    for bsize, n, use_dim in zip(blocksizes, npts, mask):
+        if not use_dim:
+            assert bsize == n
+    
+    
+if __name__ == '__main__':
+    # test_partition_2d_dims_mask(10, [64, 64], [True, False])
+    # test_partition_2d_dims_mask(10, [58, 64], [True, False])
+    
+    test_partition_3d_dims_mask(10, [32, 64, 128], [True, False, True])
+
+
+


### PR DESCRIPTION
Add new flag `mpi_dims_mask` to `discretize_domain`, which is successively passed to:
- `ddm.cart.DomainDecomposition`
- `ddm.partition.compute_dims`
- `ddm.partition.compute_dims_general`

Function `compute_dims_general` is the ones responsible to create the Cartesian grid of MPI processes. It receives `mpi_dims_mask` which is either `None` or a list of `bool`. In the latter case each element is set to `True` if the dimension is to be used in the domain decomposition (=default for each dimension). If `mpi_dim_mask[i] == False`, the i-th dimension is not decomposed.

Two unit tests for 2d and 3d have been added.