### PR TITLE
Reduce number of jobs run on pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,15 +28,7 @@ jobs:
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
-    steps:
-      - name: Check job configuration
-        run: |
-          echo ${{ matrix.os }}
-          echo ${{ matrix.python-version }}
-          echo ${{ github.event_name }}
-          echo ${{ github.ref }}
-          echo ${{ matrix.isMerge }}
-      
+    steps:      
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         exclude:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,8 +17,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
-        isMerge:
-          - [ ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        isMerge: [ ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }} ]
         exclude:
           - { isMerge: false, python-version: 3.8 }
           - { isMerge: false, python-version: 3.9 }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,11 +20,11 @@ jobs:
             python-version: 3.7
 
           - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel'}}
+            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
             python-version: 3.8
 
           - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel'}}
+            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
             python-version: 3.9
 
           - os: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,12 +19,12 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
 
-          - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+          - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+            os: ubuntu-latest
             python-version: 3.8
 
-          - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+          - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+            os: ubuntu-latest
             python-version: 3.9
 
           - os: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,14 @@ jobs:
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
     steps:
+      - name: Check job configuration
+        run: |
+          echo ${{ matrix.os }}
+          echo ${{ matrix.python-version }}
+          echo ${{ github.event_name }}
+          echo ${{ github.ref }}
+          echo ${{ matrix.isMerge }}
+      
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,11 +20,11 @@ jobs:
             python-version: 3.7
 
           - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' }}
+            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel'}}
             python-version: 3.8
 
           - os: ubuntu-latest
-            if: ${{ github.event_name == 'push' }}
+            if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel'}}
             python-version: 3.9
 
           - os: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ '3.7', '3.8', '3.9', '3.10' ]
-        isMerge: [ ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }} ]
+        isMerge:
+          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         exclude:
           - { isMerge: false, python-version: 3.8 }
           - { isMerge: false, python-version: 3.9 }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,7 +28,7 @@ jobs:
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
-    steps:      
+    steps:
       - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
         isMerge: [ ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }} ]
         exclude:
           - { isMerge: false, python-version: 3.8 }

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,10 +18,10 @@ jobs:
         os: [ ubuntu-latest ]
         python-version: [ 3.7, 3.8, 3.9, '3.10' ]
         isMerge:
-          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+          - [ ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         exclude:
-          - isMerge: false
-            python-version: [ 3.8, 3.9 ]
+          - { isMerge: false, python-version: 3.8 }
+          - { isMerge: false, python-version: 3.9 }
         include:
           - os: macos-latest
             python-version: 3.9

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,21 +15,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-latest ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        isMerge:
+          - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
+        exclude:
+          - isMerge: false
+            python-version: [ 3.8, 3.9 ]
         include:
-          - os: ubuntu-latest
-            python-version: 3.7
-
-          - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
-            os: ubuntu-latest
-            python-version: 3.8
-
-          - if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
-            os: ubuntu-latest
-            python-version: 3.9
-
-          - os: ubuntu-latest
-            python-version: '3.10'
-
           - os: macos-latest
             python-version: 3.9
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,11 +20,11 @@ jobs:
             python-version: 3.7
 
           - os: ubuntu-latest
-            if: github.event_name == 'push'
+            if: ${{ github.event_name == 'push' }}
             python-version: 3.8
 
           - os: ubuntu-latest
-            if: github.event_name == 'push'
+            if: ${{ github.event_name == 'push' }}
             python-version: 3.9
 
           - os: ubuntu-latest


### PR DESCRIPTION
Do not run tests on Linux with Python 3.8 and 3.9 on pull requests.
These jobs will be run after the merge into devel.

To see the changes at work please see [this PR](https://github.com/yguclu/psydac-docs-test/pull/1).