### PR TITLE
Do not access '_name' attribute of object with no name

### DIFF
--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1233,8 +1233,9 @@ class Parser(object):
         lhs = lhs[:]
 
         # Create a new name for the temporaries used in each patch
-        name=lhs[0]._name[12:-8]
-        temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols(prefix=f'temp{name}'))
+        #name=lhs[0]._name[12:-8]
+        #temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols(prefix=f'temp{name}'))
+        temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols())
 
         normal_vec_stmts = []
         normal_vectors = expr.expr.atoms(NormalVector)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -1233,9 +1233,8 @@ class Parser(object):
         lhs = lhs[:]
 
         # Create a new name for the temporaries used in each patch
-        #name=lhs[0]._name[12:-8]
-        #temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols(prefix=f'temp{name}'))
-        temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols())
+        name = get_name(lhs)
+        temps, rhs = cse_main.cse(rhs, symbols=cse_main.numbered_symbols(prefix=f'temp{name}'))
 
         normal_vec_stmts = []
         normal_vectors = expr.expr.atoms(NormalVector)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -73,7 +73,7 @@ from .nodes import index_deriv, Max, Min
 
 from .nodes import Zeros, ZerosLike, Array
 from .fem import expand, expand_hdiv_hcurl
-from psydac.api.ast.utilities import variables, math_atoms_as_str
+from psydac.api.ast.utilities import variables, math_atoms_as_str, get_name
 from psydac.api.utilities     import flatten
 from psydac.api.ast.utilities import build_pythran_types_header
 from psydac.api.ast.utilities import build_pyccel_types_decorator

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -1044,5 +1044,5 @@ def math_atoms_as_str(expr, lib='math'):
 def get_name(lhs):
     for term in lhs:
         if term !=0:
-            return term._name
+            return term._name[12:-8]
     return "zero_term"

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -1042,7 +1042,26 @@ def math_atoms_as_str(expr, lib='math'):
     return set.union(math_functions, math_constants)
 
 def get_name(lhs):
+    """
+    Given a list of variable return the meaninfull part of the name of the
+    first variable that has a _name attribute.
+
+    Was added to solve issue #327 caused by trying to access the name of a 
+    variable that has not such attribute.
+
+    Parameters
+    ----------
+    lhs : list
+        list from whom we need to extract a name.
+
+    Returns
+    -------
+      : str
+        meaningfull part of the name of the variable or "zero term" if no 
+        variable has a name.
+
+    """
     for term in lhs:
-        if term !=0:
+        if hasattr(term, '_name'):
             return term._name[12:-8]
     return "zero_term"

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -1043,7 +1043,7 @@ def math_atoms_as_str(expr, lib='math'):
 
 def get_name(lhs):
     """
-    Given a list of variable return the meaninfull part of the name of the
+    Given a list of variable return the meaningful part of the name of the
     first variable that has a _name attribute.
 
     Was added to solve issue #327 caused by trying to access the name of a 
@@ -1056,8 +1056,8 @@ def get_name(lhs):
 
     Returns
     -------
-      : str
-        meaningfull part of the name of the variable or "zero term" if no 
+    str
+        meaningful part of the name of the variable or "zero term" if no 
         variable has a name.
 
     """

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -1040,3 +1040,9 @@ def math_atoms_as_str(expr, lib='math'):
                 sqrt = True
 
     return set.union(math_functions, math_constants)
+
+def get_name(lhs):
+    for term in lhs:
+        if term !=0:
+            return term._name
+    return "zero_term"

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -532,9 +532,9 @@ def test_assembly_no_synchr_args(backend):
 
 #==============================================================================
 if __name__ == '__main__':
-    #test_field_and_constant(None)
-    #test_multiple_fields(None)
-    #test_math_imports(None)
-    #test_non_symmetric_BilinearForm(None)
+    test_field_and_constant(None)
+    test_multiple_fields(None)
+    test_math_imports(None)
+    test_non_symmetric_BilinearForm(None)
     test_non_symmetric_different_space_BilinearForm(None)
-    #test_assembly_no_synchr_args(None)
+    test_assembly_no_synchr_args(None)

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -10,7 +10,7 @@ from sympde.topology import element_of, Derham
 from sympde.core     import Constant
 from sympde.expr     import LinearForm, BilinearForm, Functional, Norm
 from sympde.expr     import integral
-from sympde.calculus                  import Inner
+from sympde.calculus import Inner
 
 from psydac.linalg.solvers     import inverse
 from psydac.api.discretization import discretize
@@ -451,21 +451,21 @@ def test_non_symmetric_different_space_BilinearForm(backend):
 
     domain = Square()
     V = VectorFunctionSpace('V', domain, kind='Hdiv')
-    X   = VectorFunctionSpace('X', domain, kind='h1')
+    X = VectorFunctionSpace('X', domain, kind='h1')
 
-    u    = element_of(X, name='u')    
-    w   = element_of(V, name='w')
+    u = element_of(X, name='u')    
+    w = element_of(V, name='w')
 
-    A   = BilinearForm((u,w), integral(domain, Inner(u,w)))
+    A = BilinearForm((u, w), integral(domain, Inner(u, w)))
 
     ncells = [4, 4]
     degree = [2, 2]
 
     domain_h = discretize(domain, ncells=ncells)
     Vh = discretize(V, domain_h, degree=degree)
-    Xh  = discretize(X, domain_h, degree=degree)
+    Xh = discretize(X, domain_h, degree=degree)
 
-    ah  = discretize(A, domain_h, (Xh,Vh), **kwargs)
+    ah = discretize(A, domain_h, (Xh, Vh), **kwargs)
     A = ah.assemble()
 
     print("PASSED")

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -10,6 +10,7 @@ from sympde.topology import element_of, Derham
 from sympde.core     import Constant
 from sympde.expr     import LinearForm, BilinearForm, Functional, Norm
 from sympde.expr     import integral
+from sympde.calculus                  import Inner
 
 from psydac.linalg.solvers     import inverse
 from psydac.api.discretization import discretize
@@ -444,6 +445,32 @@ def test_non_symmetric_BilinearForm(backend):
     print("PASSED")
 
 #==============================================================================
+def test_non_symmetric_different_space_BilinearForm(backend):
+
+    kwargs = {'backend': PSYDAC_BACKENDS[backend]} if backend else {}
+
+    domain = Square()
+    V = VectorFunctionSpace('V', domain, kind='Hdiv')
+    X   = VectorFunctionSpace('X', domain, kind='h1')
+
+    u    = element_of(X, name='u')    
+    w   = element_of(V, name='w')
+
+    A   = BilinearForm((u,w), integral(domain, Inner(u,w)))
+
+    ncells = [4, 4]
+    degree = [2, 2]
+
+    domain_h = discretize(domain, ncells=ncells)
+    Vh = discretize(V, domain_h, degree=degree)
+    Xh  = discretize(X, domain_h, degree=degree)
+
+    ah  = discretize(A, domain_h, (Xh,Vh), **kwargs)
+    A = ah.assemble()
+
+    print("PASSED")
+
+#==============================================================================
 def test_assembly_no_synchr_args(backend):
 
     kwargs = {'backend': PSYDAC_BACKENDS[backend]} if backend else {}
@@ -505,8 +532,9 @@ def test_assembly_no_synchr_args(backend):
 
 #==============================================================================
 if __name__ == '__main__':
-    test_field_and_constant(None)
-    test_multiple_fields(None)
-    test_math_imports(None)
-    test_non_symmetric_BilinearForm(None)
-    test_assembly_no_synchr_args(None)
+    #test_field_and_constant(None)
+    #test_multiple_fields(None)
+    #test_math_imports(None)
+    #test_non_symmetric_BilinearForm(None)
+    test_non_symmetric_different_space_BilinearForm(None)
+    #test_assembly_no_synchr_args(None)


### PR DESCRIPTION
When collecting a common subexpression from a long expression in the AST, a temporary variable is created whose name is obtained from the `_name` attribute of the first SymPy object in a list. In certain unfortunate cases such an object does not have the `_name` attribute and an `AttributeError` is raised.

The problem is solved by cycling through each element in the aforementioned list, and extracting `_name` from the first object with such an attribute. This is done via the new `get_name` function. Fixes #327.