### PR TITLE
Add `recycle` flag to linear solvers' constructors

### DIFF
--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -101,12 +101,15 @@ class ConjugateGradient(InverseLinearOperator):
     verbose : bool
         If True, L2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     References
     ----------
     [1] A. Maister, Numerik linearer Gleichungssysteme, Springer ed. 2015.
 
     """
-    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False):
+    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -123,7 +126,7 @@ class ConjugateGradient(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'cg'
-        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose}
+        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         self._tmps = {key: domain.zeros() for key in ("v", "r", "p")}
         self._info = None
@@ -143,6 +146,8 @@ class ConjugateGradient(InverseLinearOperator):
                 assert value > 0, "maxiter must be positive"
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -190,6 +195,7 @@ class ConjugateGradient(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
         
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -247,6 +253,9 @@ class ConjugateGradient(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt(am) }
 
+        if recycle:
+            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+
         return x
 
     def dot(self, b, out=None):
@@ -288,8 +297,11 @@ class PConjugateGradient(InverseLinearOperator):
     verbose : bool
         If True, L2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     """
-    def __init__(self, A, *, pc='jacobi', x0=None, tol=1e-6, maxiter=1000, verbose=False):
+    def __init__(self, A, *, pc='jacobi', x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -306,7 +318,7 @@ class PConjugateGradient(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'pcg'
-        self._options = {"x0":x0, "pc":pc, "tol":tol, "maxiter":maxiter, "verbose":verbose}
+        self._options = {"x0":x0, "pc":pc, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         tmps_codomain = {key: codomain.zeros() for key in ("p", "s")}
         tmps_domain = {key: domain.zeros() for key in ("v", "r")}
@@ -331,6 +343,8 @@ class PConjugateGradient(InverseLinearOperator):
                 assert value > 0, "maxiter must be positive"
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -372,6 +386,7 @@ class PConjugateGradient(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
 
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -457,6 +472,9 @@ class PConjugateGradient(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': k, 'success': nrmr_sqr < tol_sqr, 'res_norm': sqrt(nrmr_sqr) }
 
+        if recycle:
+            self.set_options(x0=x.copy())
+
         return x
 
     def dot(self, b, out=None):
@@ -490,12 +508,15 @@ class BiConjugateGradient(InverseLinearOperator):
     verbose : bool
         If True, 2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     References
     ----------
     [1] A. Maister, Numerik linearer Gleichungssysteme, Springer ed. 2015.
 
     """
-    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False):
+    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -513,7 +534,7 @@ class BiConjugateGradient(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'bicg'
-        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose}
+        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         self._tmps = {key: domain.zeros() for key in ("v", "r", "p", "vs", "rs", "ps")}
         self._info = None
@@ -533,6 +554,8 @@ class BiConjugateGradient(InverseLinearOperator):
                 assert value > 0, "maxiter must be positive"
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -580,6 +603,7 @@ class BiConjugateGradient(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
 
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -676,6 +700,9 @@ class BiConjugateGradient(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': m, 'success': res_sqr < tol_sqr, 'res_norm': sqrt(res_sqr)}
 
+        if recycle:
+            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+
         return x
 
     def dot(self, b, out=None):
@@ -709,12 +736,15 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
     verbose : bool
         If True, 2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     References
     ----------
     [1] A. Maister, Numerik linearer Gleichungssysteme, Springer ed. 2015.
 
     """
-    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False):
+    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -731,32 +761,30 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'bicgstab'
-        self._options = {"x0": x0, "tol": tol, "maxiter": maxiter, "verbose": verbose}
+        self._options = {"x0": x0, "tol": tol, "maxiter": maxiter, "verbose": verbose, "recycle":recycle}
         self._check_options(**self._options)
         self._tmps = {key: domain.zeros() for key in ("v", "r", "p", "vr", "r0")}
         self._info = None
 
     def _check_options(self, **kwargs):
-        keys = ('x0', 'tol', 'maxiter', 'verbose')
         for key, value in kwargs.items():
-            idx = [key == keys[i] for i in range(len(keys))]
-            assert any(idx), "key not supported, check options"
-            true_idx = idx.index(True)
-            if true_idx == 0:
+
+            if key == 'x0':
                 if value is not None:
                     assert isinstance(value, Vector), "x0 must be a Vector or None"
                     assert value.space == self._codomain, "x0 belongs to the wrong VectorSpace"
-            elif true_idx == 1:
+            elif key == 'tol':
                 assert is_real(value), "tol must be a real number"
                 assert value > 0, "tol must be positive"
-            elif true_idx == 2:
+            elif key == 'maxiter':
                 assert isinstance(value, int), "maxiter must be an int"
                 assert value > 0, "maxiter must be positive"
-            elif true_idx == 3:
+            elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
-
-    def _update_options( self ):
-        self._options = {"x0":self._x0, "tol":self._tol, "maxiter": self._maxiter, "verbose": self._verbose}
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
+            else:
+                raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
     def transpose(self, conjugate=False):
         At = self._A.transpose(conjugate=conjugate)
@@ -806,6 +834,7 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
 
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -907,6 +936,9 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': m, 'success': res_sqr < tol_sqr, 'res_norm': sqrt(res_sqr)}
 
+        if recycle:
+            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+
         return x
 
     def dot(self, b, out=None):
@@ -942,6 +974,9 @@ class MinimumResidual(InverseLinearOperator):
     verbose : bool
         If True, 2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     Notes
     -----
     This is an adaptation of the MINRES Solver in Scipy, where the method is modified to accept Psydac data structures,
@@ -955,7 +990,7 @@ class MinimumResidual(InverseLinearOperator):
     https://web.stanford.edu/group/SOL/software/minres/
 
     """
-    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False):
+    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -973,7 +1008,7 @@ class MinimumResidual(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'minres'
-        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose}
+        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         self._tmps = {key: domain.zeros() for key in ("res_old", "res_new", "w_new", "w_work", "w_old", "v", "y")}
         self._info = None
@@ -993,6 +1028,8 @@ class MinimumResidual(InverseLinearOperator):
                 assert value > 0, "maxiter must be positive"
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -1052,6 +1089,7 @@ class MinimumResidual(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
 
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -1217,6 +1255,9 @@ class MinimumResidual(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': itn, 'success': rnorm<tol, 'res_norm': rnorm }
 
+        if recycle:
+            self.set_options(x0=x.copy())
+
         return x
 
     def dot(self, b, out=None):
@@ -1264,6 +1305,9 @@ class LSMR(InverseLinearOperator):
     verbose : bool
         If True, 2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     Notes
     -----
     This is an adaptation of the LSMR Solver in Scipy, where the method is modified to accept Psydac data structures,
@@ -1278,7 +1322,7 @@ class LSMR(InverseLinearOperator):
     .. [2] LSMR Software, https://web.stanford.edu/group/SOL/software/lsmr/
     
     """
-    def __init__(self, A, *, x0=None, tol=None, atol=None, btol=None, maxiter=1000, conlim=1e8, verbose=False):
+    def __init__(self, A, *, x0=None, tol=None, atol=None, btol=None, maxiter=1000, conlim=1e8, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -1296,7 +1340,7 @@ class LSMR(InverseLinearOperator):
         self._codomain = codomain
         self._solver = 'lsmr'
         self._options = {"x0":x0, "tol":tol, "atol":atol, "btol":btol,
-                         "maxiter":maxiter, "conlim":conlim, "verbose":verbose}
+                         "maxiter":maxiter, "conlim":conlim, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         self._info = None
         self._successful = None
@@ -1330,6 +1374,8 @@ class LSMR(InverseLinearOperator):
                 assert value > 0, "conlim must be positive" # supposedly
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -1391,6 +1437,7 @@ class LSMR(InverseLinearOperator):
         maxiter = options["maxiter"]
         conlim = options["conlim"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
 
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -1618,6 +1665,9 @@ class LSMR(InverseLinearOperator):
         # Seems necessary, as algorithm might terminate even though rnorm > tol.
         self._successful = istop in [1,2,3]
 
+        if recycle:
+            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+
         return x
 
     def dot(self, b, out=None):
@@ -1651,12 +1701,15 @@ class GMRES(InverseLinearOperator):
     verbose : bool
         If True, L2-norm of residual r is printed at each iteration.
 
+    recycle : bool
+        Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
+
     References
     ----------
     [1] Y. Saad and M.H. Schultz, "GMRES: A generalized minimal residual algorithm for solving nonsymmetric linear systems", SIAM J. Sci. Stat. Comput., 7:856–869, 1986.
 
     """
-    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=100, verbose=False):
+    def __init__(self, A, *, x0=None, tol=1e-6, maxiter=100, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -1673,7 +1726,7 @@ class GMRES(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'gmres'
-        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose}
+        self._options = {"x0":x0, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options) 
         self._tmps = {key: domain.zeros() for key in ("r", "p")}
 
@@ -1697,6 +1750,8 @@ class GMRES(InverseLinearOperator):
                 assert value > 0, "maxiter must be positive"
             elif key == 'verbose':
                 assert isinstance(value, bool), "verbose must be a bool"
+            elif key == 'recycle':
+                assert isinstance(value, bool), "recycle must be a bool"
             else:
                 raise ValueError(f"Key '{key}' not understood. See self._options for allowed keys.")
 
@@ -1743,6 +1798,7 @@ class GMRES(InverseLinearOperator):
         tol = options["tol"]
         maxiter = options["maxiter"]
         verbose = options["verbose"]
+        recycle = options["recycle"]
         
         assert isinstance(b, Vector)
         assert b.space is domain
@@ -1815,6 +1871,9 @@ class GMRES(InverseLinearOperator):
         # Convergence information
         self._info = {'niter': k+1, 'success': am < tol, 'res_norm': am }
         
+        if recycle:
+            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+
         return x
     
     def solve_triangular(self, T, d):

--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -254,7 +254,7 @@ class ConjugateGradient(InverseLinearOperator):
         self._info = {'niter': m, 'success': am < tol_sqr, 'res_norm': sqrt(am) }
 
         if recycle:
-            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -473,7 +473,7 @@ class PConjugateGradient(InverseLinearOperator):
         self._info = {'niter': k, 'success': nrmr_sqr < tol_sqr, 'res_norm': sqrt(nrmr_sqr) }
 
         if recycle:
-            self.set_options(x0=x.copy())
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -701,7 +701,7 @@ class BiConjugateGradient(InverseLinearOperator):
         self._info = {'niter': m, 'success': res_sqr < tol_sqr, 'res_norm': sqrt(res_sqr)}
 
         if recycle:
-            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -937,7 +937,7 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
         self._info = {'niter': m, 'success': res_sqr < tol_sqr, 'res_norm': sqrt(res_sqr)}
 
         if recycle:
-            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -1256,7 +1256,7 @@ class MinimumResidual(InverseLinearOperator):
         self._info = {'niter': itn, 'success': rnorm<tol, 'res_norm': rnorm }
 
         if recycle:
-            self.set_options(x0=x.copy())
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -1666,7 +1666,7 @@ class LSMR(InverseLinearOperator):
         self._successful = istop in [1,2,3]
 
         if recycle:
-            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+            x.copy(out=self._options["x0"])
 
         return x
 
@@ -1872,7 +1872,7 @@ class GMRES(InverseLinearOperator):
         self._info = {'niter': k+1, 'success': am < tol, 'res_norm': am }
         
         if recycle:
-            self.set_options(x0=x.copy()) # try x.copy(out=self._options["x0"]) instead
+            x.copy(out=self._options["x0"])
 
         return x
     

--- a/psydac/linalg/tests/test_solvers.py
+++ b/psydac/linalg/tests/test_solvers.py
@@ -88,7 +88,7 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
         V, A, xe = define_data(n, p, diagonals, dtype=dtype)
 
     # Tolerance for success: 2-norm of error in solution
-    tol = 1e-10
+    tol = 1e-13
 
     #---------------------------------------------------------------------------
     # TEST
@@ -102,31 +102,51 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
         print()
 
     #Create the solvers
-    solv  = inverse(A, solver, tol=1e-13, verbose=True)
+    solv  = inverse(A, solver, tol=tol, verbose=True, recycle=True)
     solvt = solv.transpose()
     solvh = solv.H
 
     # Manufacture right-hand-side vector from exact solution
-    b  = A.dot( xe )
-    b2 = A.dot( b ) # Test solver with consecutive solves
-    bt = A.T.dot( xe )
-    bh = A.H.dot( xe )
+    be  = A @ xe
+    be2 = A @ be # Test solver with consecutive solves
+    bet = A.T @ xe
+    beh = A.H @ xe
 
     # Solve linear system
-    x = solv @ b
+    x = solv @ be
     info = solv.get_info()
-    x2 = solv @ b2
-    xt = solvt.solve(bt)
-    xh = solvh.dot(bh)
+    # Assert x0 got updated correctly and is not the same object as the previous solution, but just a copy
+    solv_x0 = solv._options["x0"]
+    assert np.array_equal(x.toarray(), solv_x0.toarray())
+    assert x is not solv_x0
+    x2 = solv @ be2
+    xt = solvt.solve(bet)
+    xh = solvh.dot(beh)
+
+    # Assert x0 got updated correctly and is not the same object as the previous solution, but just a copy
+    solv_x0 = solv._options["x0"]
+    solvt_x0 = solvt._options["x0"]
+    solvh_x0 = solvh._options["x0"]
+    assert np.array_equal(x2.toarray(), solv_x0.toarray())
+    assert x2 is not solv_x0
+    assert np.array_equal(xt.toarray(), solvt_x0.toarray())
+    assert xt is not solvt_x0
+    assert np.array_equal(xh.toarray(), solvh_x0.toarray())
+    assert xh is not solvh_x0
 
     # Verify correctness of calculation: 2-norm of error
-    err = x - xe
+    b = A @ x
+    b2 = A @ x2
+    bt = A.T @ xt
+    bh = A.H @ xh
+
+    err = b - be
     err_norm = np.linalg.norm( err.toarray() )
-    err2 = x2 - b
+    err2 = b2 - be2
     err2_norm = np.linalg.norm( err2.toarray() )
-    errt = xt - xe
+    errt = bt - bet
     errt_norm = np.linalg.norm( errt.toarray() )
-    errh = xh - xe
+    errh = bh - beh
     errh_norm = np.linalg.norm( errh.toarray() )
 
     #---------------------------------------------------------------------------


### PR DESCRIPTION
Add a `recycle` flag to the `__init__` of the subclasses of `InverseLinearOperator` defined in `linalg/solvers`.
By default `False`. If `True`, updates the initial guess `x0` to be a copy of the previous solution, without creating a temporary vector.

Previously, this feature could be implicitly used:
Given `A_solv`, an object of one of the solver classes defined in `linalg/solvers`, you could write
`x = A_solv.dot(b, out=A_solv._options["x0"])` instead of simply
`x = A_solv.dot(b)` or equivalently `x = A_solv @ b`.

However, this method has (at least) one major drawback:

**Application in a composition of linear operators**
    Say you have to solve `Sx = b_n` for x at each type step of your simulation, where the right hand side `b_n` changes at each time step, and where S is a composition of linear operators, for example:
    `S = A1 @ A2 @ A_solv @ A3`
    Upon solving for x, `A_solv` is being called in up to `maxiter` (of `S_solv`) iterations, with A being called in up to `maxiter` (of `A_solv`) internal iterations. This number of internal iterations can be drastically decreased upon introducing the `recycle` flag. Implicit usage of this feature is not possible in this case.

A more rare case of the implicit usage not working is the case of a solver being a block of a `BlockLinearOperator`.