### PR TITLE
Add single 3d field evaluation kernel

### DIFF
--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -5,6 +5,32 @@ from pyccel.decorators import template
 # Field evaluation functions
 # =============================================================================
 # -----------------------------------------------------------------------------
+# 0: Evaluation of single 3d field at single point
+# -----------------------------------------------------------------------------
+@template(name='T1', types=['float[:,:,:]', 'complex[:,:,:]'])
+@template(name='T2', types=['float[:]', 'complex[:]'])
+def eval_field_3d_once(local_coeffs: 'T1', 
+                       local_bases_0: 'T2', local_bases_1: 'T2', local_bases_2: 'T2'):
+    """
+    Parameters
+    ----------
+    local_coeffs: ndarray of floats
+        Active (local) coefficients of the fields in all directions
+
+    local_bases: list of ndarrays
+        Active (local) 1D-basis functions values at the point of evaluation. 
+    """
+    res = local_bases_0[0] - local_bases_0[0]
+
+    for i, c1 in enumerate(local_coeffs):
+        for j, c2 in enumerate(c1):
+            for k, c3 in enumerate(c2):
+                res += c3 * local_bases_0[i] * local_bases_1[j] * local_bases_2[k]
+
+    return res
+
+
+# -----------------------------------------------------------------------------
 # 1: Regular tensor grid without weight
 # -----------------------------------------------------------------------------
 @template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -38,7 +38,8 @@ from psydac.core.field_evaluation_kernels import (eval_fields_2d_no_weights,
                                                   eval_fields_3d_no_weights,
                                                   eval_fields_3d_irregular_no_weights,
                                                   eval_fields_3d_weighted,
-                                                  eval_fields_3d_irregular_weighted)
+                                                  eval_fields_3d_irregular_weighted,
+                                                  eval_field_3d_once)
 
 __all__ = ('TensorFemSpace',)
 
@@ -230,9 +231,7 @@ class TensorFemSpace( FemSpace ):
         #   - Pros: small number of Python iterations = ldim
         #   - Cons: we create ldim-1 temporary objects of decreasing size
         #
-        res = coeffs
-        for basis in bases[::-1]:
-            res = np.dot( res, basis )
+        res = eval_field_3d_once(coeffs, bases[0], bases[1], bases[2])
 
 #        # Option 2: cycle over each element of 'coeffs' (touched only once)
 #        #   - Pros: no temporary objects are created


### PR DESCRIPTION
Adds the kernel `eval_field_3d_once` to `psydac.core.field_evaluation_kernels.py` and makes use of it in `psydac.fem.tensor.py`'s method `eval_field`.

The purpose of this kernel is to accelerate the evaluation of a single 3d field at a single point. This is needed repeatedly, for example, when creating a Poincarè plot tracing a single fieldline.