### PR TITLE
Fix `DirectionalDerivativeOperator.tosparse` w/ 1 cell & periodic

### DIFF
--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -320,7 +320,7 @@ class DirectionalDerivativeOperator(LinearOperator):
             if self._diffdir == d:
                 # if we are at the differentiation direction, construct differentiation matrix
                 if codomain_local == 1 and domain_local == 1 and self.domain.periods[d]:
-                    # case of one cell and periodic BC should be treated as a constant
+                    # case of one cell and periodic BC should be treated as a constant, thus zero matrix
                     addmatrix = spa.coo_array((codomain_local, domain_local))
 
                 else:
@@ -413,9 +413,8 @@ class Derivative_1D(DiffOperator):
         assert H1.periodic[0] == L2.periodic[0]
         assert H1.degree[0] == L2.degree[0] + 1
 
-        self._domain   = H1
-        self._codomain = L2
-        self._matrix   = DirectionalDerivativeOperator(H1.vector_space, L2.vector_space, 0)
+        # Store data in object   
+        super().__init__(H1, L2, DirectionalDerivativeOperator(H1.vector_space, L2.vector_space, 0))
 
 #====================================================================================================
 class Gradient_2D(DiffOperator):
@@ -453,10 +452,9 @@ class Gradient_2D(DiffOperator):
                   [DirectionalDerivativeOperator(B_B, B_M, 1)]]
         matrix = BlockLinearOperator(H1.vector_space, Hcurl.vector_space, blocks=blocks)
 
-        # Store data in object
-        self._domain   = H1
-        self._codomain = Hcurl
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(H1, Hcurl, matrix)
+
 
 #====================================================================================================
 class Gradient_3D(DiffOperator):
@@ -497,10 +495,8 @@ class Gradient_3D(DiffOperator):
                   [DirectionalDerivativeOperator(B_B_B, B_B_M, 2)]]
         matrix = BlockLinearOperator(H1.vector_space, Hcurl.vector_space, blocks=blocks)
 
-        # Store data in object
-        self._domain   = H1
-        self._codomain = Hcurl
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(H1, Hcurl, matrix)
 
 #====================================================================================================
 class ScalarCurl_2D(DiffOperator):
@@ -538,10 +534,8 @@ class ScalarCurl_2D(DiffOperator):
                   DirectionalDerivativeOperator(B_M, M_M, 0)]]
         matrix = BlockLinearOperator(Hcurl.vector_space, L2.vector_space, blocks=blocks)
 
-        # Store data in object
-        self._domain   = Hcurl
-        self._codomain = L2
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(Hcurl, L2, matrix)
 
 #====================================================================================================
 class VectorCurl_2D(DiffOperator):
@@ -580,10 +574,8 @@ class VectorCurl_2D(DiffOperator):
                   [-DirectionalDerivativeOperator(B_B, M_B, 0)]]
         matrix = BlockLinearOperator(H1.vector_space, Hdiv.vector_space, blocks=blocks)
 
-        # Store data in object
-        self._domain   = H1
-        self._codomain = Hdiv
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(H1, Hdiv, matrix)
 
 #====================================================================================================
 class Curl_3D(DiffOperator):
@@ -632,10 +624,8 @@ class Curl_3D(DiffOperator):
         matrix = BlockLinearOperator(Hcurl.vector_space, Hdiv.vector_space, blocks=blocks)
         # ...
 
-        # Store data in object
-        self._domain   = Hcurl
-        self._codomain = Hdiv
-        self._matrix   = matrix
+        # Store data in object        
+        super().__init__(Hcurl, Hdiv, matrix)
 
 #====================================================================================================
 class Divergence_2D(DiffOperator):
@@ -673,10 +663,8 @@ class Divergence_2D(DiffOperator):
         blocks = [[DirectionalDerivativeOperator(B_M, M_M, 0), DirectionalDerivativeOperator(M_B, M_M, 1)]]
         matrix = BlockLinearOperator(Hdiv.vector_space, L2.vector_space, blocks=blocks) 
 
-        # Store data in object
-        self._domain   = Hdiv
-        self._codomain = L2
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(Hdiv, L2, matrix)
 
 #====================================================================================================
 class Divergence_3D(DiffOperator):
@@ -717,7 +705,5 @@ class Divergence_3D(DiffOperator):
                    DirectionalDerivativeOperator(M_M_B, M_M_M, 2)]]
         matrix = BlockLinearOperator(Hdiv.vector_space, L2.vector_space, blocks=blocks) 
 
-        # Store data in object
-        self._domain   = Hdiv
-        self._codomain = L2
-        self._matrix   = matrix
+        # Store data in object   
+        super().__init__(Hdiv, L2, matrix)

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -321,7 +321,7 @@ class DirectionalDerivativeOperator(LinearOperator):
                 # if we are at the differentiation direction, construct differentiation matrix
                 if codomain_local == 1 and domain_local == 1 and self.domain.periods[d]:
                     # case of one cell and periodic BC should be treated as a constant, thus zero matrix
-                    addmatrix = spa.coo_array((codomain_local, domain_local))
+                    directional_matrix = spa.coo_array((codomain_local, domain_local))
 
                 else:
                     maindiag = np.ones(domain_local) * (-sign)
@@ -338,13 +338,13 @@ class DirectionalDerivativeOperator(LinearOperator):
                         offsets = (0,1)
                         diags = (maindiag, adddiag)
 
-                    addmatrix = spa.diags(diags, offsets=offsets, shape=(codomain_local, domain_local), format='coo')
+                    directional_matrix = spa.diags(diags, offsets=offsets, shape=(codomain_local, domain_local), format='coo')
             else:
                 # avoid using padding, if possible
-                addmatrix = spa.identity(domain_local)
+                directional_matrix = spa.identity(domain_local)
             
             # finally, take the Kronecker product
-            matrix = spa.kron(matrix, addmatrix)
+            matrix = spa.kron(matrix, directional_matrix)
         
         # now, we may transpose (this should be very cheap)
         if self._transposed:

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -9,7 +9,7 @@ from psydac.linalg.block    import BlockVector, BlockLinearOperator
 from psydac.fem.vector      import ProductFemSpace, VectorFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.basic    import IdentityOperator
-from psydac.fem.basic       import FemField
+from psydac.fem.basic       import FemField, FemSpace
 from psydac.linalg.basic    import LinearOperator
 from psydac.ddm.cart        import DomainDecomposition, CartDecomposition
 
@@ -361,6 +361,16 @@ class DirectionalDerivativeOperator(LinearOperator):
 
 #====================================================================================================
 class DiffOperator:
+    def __init__(self, domain, codomain, matrix):
+        assert isinstance(domain, FemSpace)
+        assert isinstance(codomain, FemSpace)
+        assert isinstance(matrix, LinearOperator)
+        assert domain.vector_space is matrix.domain
+        assert codomain.vector_space is matrix.codomain
+
+        self._domain = domain
+        self._codomain = codomain
+        self._matrix = matrix
 
     @property
     def matrix(self):

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -319,21 +319,26 @@ class DirectionalDerivativeOperator(LinearOperator):
 
             if self._diffdir == d:
                 # if we are at the differentiation direction, construct differentiation matrix
-                maindiag = np.ones(domain_local) * (-sign)
-                adddiag = np.ones(domain_local) * sign
+                if codomain_local == 1 and domain_local == 1 and self.domain.periods[d]:
+                    # case of one cell and periodic BC should be treated as a constant
+                    addmatrix = spa.coo_array((codomain_local, domain_local))
 
-                # handle special case with not self.domain.parallel and not with_pads and periodic
-                if self.domain.periods[d] and not self.domain.parallel and not with_pads:
-                    # then: add element to other side of the array
-                    adddiagcirc = np.array([sign])
-                    offsets = (-codomain_local+1, 0, 1)
-                    diags = (adddiagcirc, maindiag, adddiag)
                 else:
-                    # else, just take main and off diagonal
-                    offsets = (0,1)
-                    diags = (maindiag, adddiag)
-                
-                addmatrix = spa.diags(diags, offsets=offsets, shape=(codomain_local, domain_local), format='coo')
+                    maindiag = np.ones(domain_local) * (-sign)
+                    adddiag = np.ones(domain_local) * sign
+
+                    # handle special case with not self.domain.parallel and not with_pads and periodic
+                    if self.domain.periods[d] and not self.domain.parallel and not with_pads:
+                        # then: add element to other side of the array
+                        adddiagcirc = np.array([sign])
+                        offsets = (-codomain_local+1, 0, 1)
+                        diags = (adddiagcirc, maindiag, adddiag)
+                    else:
+                        # else, just take main and off diagonal
+                        offsets = (0,1)
+                        diags = (maindiag, adddiag)
+
+                    addmatrix = spa.diags(diags, offsets=offsets, shape=(codomain_local, domain_local), format='coo')
             else:
                 # avoid using padding, if possible
                 addmatrix = spa.identity(domain_local)

--- a/psydac/feec/tests/test_commuting_projections.py
+++ b/psydac/feec/tests/test_commuting_projections.py
@@ -71,8 +71,8 @@ def test_3d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 #==============================================================================
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -146,8 +146,8 @@ def test_3d_commuting_pro_2(Nel, Nq, p, bc):
     Dfun_h    = curl(u1)
     Dfun_proj = u2
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 #==============================================================================
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -212,8 +212,8 @@ def test_3d_commuting_pro_3(Nel, Nq, p, bc):
     Dfun_h    = div(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [5])
@@ -266,8 +266,8 @@ def test_2d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [5])
@@ -320,8 +320,8 @@ def test_2d_commuting_pro_2(Nel, Nq, p, bc):
     Dfun_h    = curl(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [8])
@@ -381,8 +381,8 @@ def test_2d_commuting_pro_3(Nel, Nq, p, bc):
     Dfun_h    = div(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [8])
@@ -442,8 +442,8 @@ def test_2d_commuting_pro_4(Nel, Nq, p, bc):
     Dfun_h    = curl(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 
 @pytest.mark.parametrize('Nel', [16, 20])
 @pytest.mark.parametrize('Nq', [5])
@@ -491,8 +491,8 @@ def test_1d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
-    assert abs(error).max()<1e-9
+    error = abs((Dfun_proj.coeffs-Dfun_h.coeffs).toarray()).max()
+    assert error < 1e-9
 #==============================================================================
 if __name__ == '__main__':
 

--- a/psydac/feec/tests/test_commuting_projections.py
+++ b/psydac/feec/tests/test_commuting_projections.py
@@ -71,8 +71,8 @@ def test_3d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 #==============================================================================
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -146,8 +146,8 @@ def test_3d_commuting_pro_2(Nel, Nq, p, bc):
     Dfun_h    = curl(u1)
     Dfun_proj = u2
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 #==============================================================================
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -212,8 +212,8 @@ def test_3d_commuting_pro_3(Nel, Nq, p, bc):
     Dfun_h    = div(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [5])
@@ -266,8 +266,8 @@ def test_2d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [5])
@@ -320,8 +320,8 @@ def test_2d_commuting_pro_2(Nel, Nq, p, bc):
     Dfun_h    = curl(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [8])
@@ -381,8 +381,8 @@ def test_2d_commuting_pro_3(Nel, Nq, p, bc):
     Dfun_h    = div(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 @pytest.mark.parametrize('Nel', [8, 12])
 @pytest.mark.parametrize('Nq', [8])
@@ -442,8 +442,8 @@ def test_2d_commuting_pro_4(Nel, Nq, p, bc):
     Dfun_h    = curl(u2)
     Dfun_proj = u3
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 
 @pytest.mark.parametrize('Nel', [16, 20])
 @pytest.mark.parametrize('Nq', [5])
@@ -491,8 +491,8 @@ def test_1d_commuting_pro_1(Nel, Nq, p, bc):
     Dfun_h    = grad(u0)
     Dfun_proj = u1
 
-    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray().max()
-    assert abs(error)<1e-9
+    error = (Dfun_proj.coeffs-Dfun_h.coeffs).toarray()
+    assert abs(error).max()<1e-9
 #==============================================================================
 if __name__ == '__main__':
 

--- a/psydac/feec/tests/test_commuting_projections_dual.py
+++ b/psydac/feec/tests/test_commuting_projections_dual.py
@@ -47,7 +47,7 @@ def test_3d_commuting_pro_dual_1(Nel, p, bc):
 
     divT_u3 = - div.matrix.T.dot(u3)
 
-    error = np.linalg.norm((u2-divT_u3).toarray())
+    error = abs((u2-divT_u3).toarray()).max()
     assert error < 9e-05
 
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -100,7 +100,7 @@ def test_3d_commuting_pro_dual_2(Nel, p, bc):
 
     curlT_u2 = curl.matrix.T.dot(u2)
 
-    error = np.linalg.norm((u1-curlT_u2).toarray())
+    error = abs((u1-curlT_u2).toarray()).max()
     assert error < 9e-3
 
 
@@ -143,7 +143,7 @@ def test_3d_commuting_pro_dual_3(Nel, p, bc):
 
     gradT_u1 = -grad.matrix.T.dot(u1)
 
-    error = np.linalg.norm((u0-gradT_u1).toarray())
+    error = abs((u0-gradT_u1).toarray()).max()
     assert error < 4e-3 
 
 

--- a/psydac/feec/tests/test_commuting_projections_dual.py
+++ b/psydac/feec/tests/test_commuting_projections_dual.py
@@ -1,0 +1,149 @@
+from psydac.feec.derivatives import Gradient_3D
+from psydac.feec.derivatives import Curl_3D
+from psydac.feec.derivatives import Divergence_3D
+
+from sympde.expr                    import LinearForm, integral      
+from sympde.topology                import Derham, element_of, Cube  
+from psydac.api.discretization import discretize
+from psydac.api.settings import PSYDAC_BACKENDS
+
+import numpy as np
+from sympy import sin, cos
+import pytest
+
+
+@pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('bc', [True, False])
+def test_3d_commuting_pro_dual_1(Nel, p, bc):
+    # Test transpose div
+
+    fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
+    D1fun1  = lambda xi1, xi2, xi3 : cos(xi1)*sin(xi2)*sin(xi3)
+    D2fun1  = lambda xi1, xi2, xi3 : sin(xi1)*cos(xi2)*sin(xi3)
+    D3fun1  = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*cos(xi3)
+
+    Nel = [Nel]*3
+    p   = [p]*3
+    bc  = [bc]*3
+
+    # Side lengths of logical cube [0, L]^3
+    L = [2*np.pi, 2*np.pi , 2*np.pi]
+
+    domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
+    derham = Derham(domain)
+    domain_h = discretize(domain, ncells=Nel, periodic=bc)
+    derham_h = discretize(derham, domain_h, degree=p)
+
+    v2 = element_of(derham.V2, name='v2')
+    v3 = element_of(derham.V3, name='v3')
+    div = Divergence_3D(derham_h.V2, derham_h.V3)
+
+    f2 = LinearForm(v2, integral(domain, D1fun1(*domain.coordinates)*v2[0] + D2fun1(*domain.coordinates)*v2[1] + D3fun1(*domain.coordinates)*v2[2]))
+    f3 = LinearForm(v3, integral(domain, fun1(*domain.coordinates) * v3))
+
+    u2 = discretize(f2, domain_h, derham_h.V2, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u3 = discretize(f3, domain_h, derham_h.V3, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+
+    divT_u3 = - div.matrix.T.dot(u3)
+
+    error = np.linalg.norm((u2-divT_u3).toarray())
+    assert error < 9e-05
+
+@pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('bc', [True, False])
+def test_3d_commuting_pro_dual_2(Nel, p, bc):
+    # Test transpose curl
+
+    fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
+    D1fun1  = lambda xi1, xi2, xi3 : cos(xi1)*sin(xi2)*sin(xi3)
+    D2fun1  = lambda xi1, xi2, xi3 : sin(xi1)*cos(xi2)*sin(xi3)
+    D3fun1  = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*cos(xi3)
+
+    fun2    = lambda xi1, xi2, xi3 :   sin(2*xi1)*sin(2*xi2)*sin(2*xi3)
+    D1fun2  = lambda xi1, xi2, xi3 : 2*cos(2*xi1)*sin(2*xi2)*sin(2*xi3)
+    D2fun2  = lambda xi1, xi2, xi3 : 2*sin(2*xi1)*cos(2*xi2)*sin(2*xi3)
+    D3fun2  = lambda xi1, xi2, xi3 : 2*sin(2*xi1)*sin(2*xi2)*cos(2*xi3)
+
+    fun3    = lambda xi1, xi2, xi3 :   sin(3*xi1)*sin(3*xi2)*sin(3*xi3)
+    D1fun3  = lambda xi1, xi2, xi3 : 3*cos(3*xi1)*sin(3*xi2)*sin(3*xi3)
+    D2fun3  = lambda xi1, xi2, xi3 : 3*sin(3*xi1)*cos(3*xi2)*sin(3*xi3)
+    D3fun3  = lambda xi1, xi2, xi3 : 3*sin(3*xi1)*sin(3*xi2)*cos(3*xi3)
+
+    #curl
+    cf1 = lambda xi1, xi2, xi3 : D2fun3(xi1, xi2, xi3) - D3fun2(xi1, xi2, xi3)
+    cf2 = lambda xi1, xi2, xi3 : D3fun1(xi1, xi2, xi3) - D1fun3(xi1, xi2, xi3)
+    cf3 = lambda xi1, xi2, xi3 : D1fun2(xi1, xi2, xi3) - D2fun1(xi1, xi2, xi3)
+
+    Nel = [Nel]*3
+    p   = [p]*3
+    bc  = [bc]*3
+
+    # Side lengths of logical cube [0, L]^3
+    L = [2*np.pi, 2*np.pi , 2*np.pi]
+
+    domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
+    derham = Derham(domain)
+    domain_h = discretize(domain, ncells=Nel, periodic=bc)
+    derham_h = discretize(derham, domain_h, degree=p)
+
+    v1 = element_of(derham.V1, name='v1')
+    v2 = element_of(derham.V2, name='v2')
+    curl = Curl_3D(derham_h.V1, derham_h.V2)
+
+    f1 = LinearForm(v1, integral(domain, cf1(*domain.coordinates)*v1[0] + cf2(*domain.coordinates)*v1[1] + cf3(*domain.coordinates)*v1[2]))
+    f2 = LinearForm(v2, integral(domain, fun1(*domain.coordinates)*v2[0] + fun2(*domain.coordinates)*v2[1] + fun3(*domain.coordinates)*v2[2]))
+
+    u1 = discretize(f1, domain_h, derham_h.V1, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u2 = discretize(f2, domain_h, derham_h.V2, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+
+    curlT_u2 = curl.matrix.T.dot(u2)
+
+    error = np.linalg.norm((u1-curlT_u2).toarray())
+    assert error < 9e-3
+
+
+@pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('bc', [True, False])
+def test_3d_commuting_pro_dual_3(Nel, p, bc):
+    # Test transpose grad
+        
+    fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
+    D1fun1  = lambda xi1, xi2, xi3 : cos(xi1)*sin(xi2)*sin(xi3)
+
+    fun2    = lambda xi1, xi2, xi3 :   sin(2*xi1)*sin(2*xi2)*sin(2*xi3)
+    D2fun2  = lambda xi1, xi2, xi3 : 2*sin(2*xi1)*cos(2*xi2)*sin(2*xi3)
+
+    fun3    = lambda xi1, xi2, xi3 :   sin(3*xi1)*sin(3*xi2)*sin(3*xi3)
+    D3fun3  = lambda xi1, xi2, xi3 : 3*sin(3*xi1)*sin(3*xi2)*cos(3*xi3)
+
+    Nel = [Nel]*3
+    p   = [p]*3
+    bc  = [bc]*3
+
+    # Side lengths of logical cube [0, L]^3
+    L = [2*np.pi, 2*np.pi , 2*np.pi]
+
+    domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
+    derham = Derham(domain)
+    domain_h = discretize(domain, ncells=Nel, periodic=bc)
+    derham_h = discretize(derham, domain_h, degree=p)
+
+    v0 = element_of(derham.V0, name='v0')
+    v1 = element_of(derham.V1, name='v1')
+    grad = Gradient_3D(derham_h.V0, derham_h.V1)    
+
+    f0 = LinearForm(v0, integral(domain, (D1fun1(*domain.coordinates) + D2fun2(*domain.coordinates) + D3fun3(*domain.coordinates))*v0))
+    f1 = LinearForm(v1, integral(domain, fun1(*domain.coordinates)*v1[0] + fun2(*domain.coordinates)*v1[1] + fun3(*domain.coordinates)*v1[2]))
+
+    u0 = discretize(f0, domain_h, derham_h.V0, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u1 = discretize(f1, domain_h, derham_h.V1, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+
+    gradT_u1 = -grad.matrix.T.dot(u1)
+
+    error = np.linalg.norm((u0-gradT_u1).toarray())
+    assert error < 4e-3 
+
+

--- a/psydac/feec/tests/test_commuting_projections_dual.py
+++ b/psydac/feec/tests/test_commuting_projections_dual.py
@@ -1,21 +1,20 @@
-from psydac.feec.derivatives import Gradient_3D
-from psydac.feec.derivatives import Curl_3D
-from psydac.feec.derivatives import Divergence_3D
-
+from psydac.feec.derivatives        import Gradient_3D
+from psydac.feec.derivatives        import Curl_3D
+from psydac.feec.derivatives        import Divergence_3D
 from sympde.expr                    import LinearForm, integral      
 from sympde.topology                import Derham, element_of, Cube  
-from psydac.api.discretization import discretize
-from psydac.api.settings import PSYDAC_BACKENDS
-
+from psydac.api.discretization      import discretize
+from psydac.api.settings            import PSYDAC_BACKENDS
+from sympy                          import sin, cos
 import numpy as np
-from sympy import sin, cos
 import pytest
 
 
 @pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('Nq', [4])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
-def test_3d_commuting_pro_dual_1(Nel, p, bc):
+def test_transpose_div_3d(Nel, Nq, p, bc):
     # Test transpose div
 
     fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
@@ -24,6 +23,7 @@ def test_3d_commuting_pro_dual_1(Nel, p, bc):
     D3fun1  = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*cos(xi3)
 
     Nel = [Nel]*3
+    Nq = [Nq]*3
     p   = [p]*3
     bc  = [bc]*3
 
@@ -33,7 +33,7 @@ def test_3d_commuting_pro_dual_1(Nel, p, bc):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p)
+    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq)
 
     v2 = element_of(derham.V2, name='v2')
     v3 = element_of(derham.V3, name='v3')
@@ -42,18 +42,19 @@ def test_3d_commuting_pro_dual_1(Nel, p, bc):
     f2 = LinearForm(v2, integral(domain, D1fun1(*domain.coordinates)*v2[0] + D2fun1(*domain.coordinates)*v2[1] + D3fun1(*domain.coordinates)*v2[2]))
     f3 = LinearForm(v3, integral(domain, fun1(*domain.coordinates) * v3))
 
-    u2 = discretize(f2, domain_h, derham_h.V2, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
-    u3 = discretize(f3, domain_h, derham_h.V3, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u2 = discretize(f2, domain_h, derham_h.V2, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u3 = discretize(f3, domain_h, derham_h.V3, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
 
     divT_u3 = - div.matrix.T.dot(u3)
 
     error = abs((u2-divT_u3).toarray()).max()
-    assert error < 9e-05
+    assert error < 2e-11
 
 @pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('Nq', [5])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
-def test_3d_commuting_pro_dual_2(Nel, p, bc):
+def test_transpose_curl_3d(Nel, Nq, p, bc):
     # Test transpose curl
 
     fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
@@ -77,6 +78,7 @@ def test_3d_commuting_pro_dual_2(Nel, p, bc):
     cf3 = lambda xi1, xi2, xi3 : D1fun2(xi1, xi2, xi3) - D2fun1(xi1, xi2, xi3)
 
     Nel = [Nel]*3
+    Nq = [Nq]*3
     p   = [p]*3
     bc  = [bc]*3
 
@@ -86,7 +88,7 @@ def test_3d_commuting_pro_dual_2(Nel, p, bc):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p)
+    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq)
 
     v1 = element_of(derham.V1, name='v1')
     v2 = element_of(derham.V2, name='v2')
@@ -95,19 +97,19 @@ def test_3d_commuting_pro_dual_2(Nel, p, bc):
     f1 = LinearForm(v1, integral(domain, cf1(*domain.coordinates)*v1[0] + cf2(*domain.coordinates)*v1[1] + cf3(*domain.coordinates)*v1[2]))
     f2 = LinearForm(v2, integral(domain, fun1(*domain.coordinates)*v2[0] + fun2(*domain.coordinates)*v2[1] + fun3(*domain.coordinates)*v2[2]))
 
-    u1 = discretize(f1, domain_h, derham_h.V1, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
-    u2 = discretize(f2, domain_h, derham_h.V2, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u1 = discretize(f1, domain_h, derham_h.V1, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u2 = discretize(f2, domain_h, derham_h.V2, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
 
     curlT_u2 = curl.matrix.T.dot(u2)
 
     error = abs((u1-curlT_u2).toarray()).max()
-    assert error < 9e-3
-
+    assert error < 5e-10
 
 @pytest.mark.parametrize('Nel', [8, 12])
+@pytest.mark.parametrize('Nq', [5])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
-def test_3d_commuting_pro_dual_3(Nel, p, bc):
+def test_transpose_grad_3d(Nel, Nq, p, bc):
     # Test transpose grad
         
     fun1    = lambda xi1, xi2, xi3 : sin(xi1)*sin(xi2)*sin(xi3)
@@ -120,6 +122,7 @@ def test_3d_commuting_pro_dual_3(Nel, p, bc):
     D3fun3  = lambda xi1, xi2, xi3 : 3*sin(3*xi1)*sin(3*xi2)*cos(3*xi3)
 
     Nel = [Nel]*3
+    Nq = [Nq]*3
     p   = [p]*3
     bc  = [bc]*3
 
@@ -129,7 +132,7 @@ def test_3d_commuting_pro_dual_3(Nel, p, bc):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p)
+    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq)
 
     v0 = element_of(derham.V0, name='v0')
     v1 = element_of(derham.V1, name='v1')
@@ -138,12 +141,10 @@ def test_3d_commuting_pro_dual_3(Nel, p, bc):
     f0 = LinearForm(v0, integral(domain, (D1fun1(*domain.coordinates) + D2fun2(*domain.coordinates) + D3fun3(*domain.coordinates))*v0))
     f1 = LinearForm(v1, integral(domain, fun1(*domain.coordinates)*v1[0] + fun2(*domain.coordinates)*v1[1] + fun3(*domain.coordinates)*v1[2]))
 
-    u0 = discretize(f0, domain_h, derham_h.V0, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
-    u1 = discretize(f1, domain_h, derham_h.V1, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u0 = discretize(f0, domain_h, derham_h.V0, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
+    u1 = discretize(f1, domain_h, derham_h.V1, nquads=Nq, backend=PSYDAC_BACKENDS['pyccel-gcc']).assemble()
 
     gradT_u1 = -grad.matrix.T.dot(u1)
 
     error = abs((u0-gradT_u1).toarray()).max()
-    assert error < 4e-3 
-
-
+    assert error < 3e-10

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -450,14 +450,17 @@ def test_Gradient_2D(domain, ncells, degree, periodic, seed):
 
 #==============================================================================
 @pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  # 1 case
-@pytest.mark.parametrize('ncells', [(4, 5, 7)])                       # 1 case
-@pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7)])            # 2 cases
+@pytest.mark.parametrize('ncells', [(1,1,1), (4, 5, 7)])                       # 2 case
+@pytest.mark.parametrize('degree', [(1,1,1), (3, 2, 5), (2, 4, 7)])            # 3 cases
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
                                       (False, False,  True)])
 @pytest.mark.parametrize('seed', [1,3])
 
 def test_Gradient_3D(domain, ncells, degree, periodic, seed):
+    if ncells == (1,1,1) and any(periodic) and degree != (1,1,1):
+        return
+    
     # determinize tests
     np.random.seed(seed)
 

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -21,6 +21,13 @@ from mpi4py                  import MPI
 # They do not check, if it really computes the derivatives
 # (this is done in the gradient etc. tests below already)
 def run_directional_derivative_operator(comm, domain, ncells, degree, periodic, direction, negative, transposed, seed, matrix_assembly=False):
+
+    if ncells == (1,1,1) and degree != (1,1,1):
+        return
+    
+    # assemble matrix when 1 cell in each direction
+    matrix_assembly = (ncells == (1,1,1))
+    
     # determinize tests
     np.random.seed(seed)
 
@@ -281,8 +288,8 @@ def test_directional_derivative_operator_2d_ser(domain, ncells, degree, periodic
     run_directional_derivative_operator(None, domain, ncells, degree, periodic, direction, negative, transposed, seed, True) 
 
 @pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])
-@pytest.mark.parametrize('ncells', [(4, 5, 7)])
-@pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7)])
+@pytest.mark.parametrize('ncells', [(4, 5, 7), (1, 1, 1)])
+@pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7), (1, 1, 1)])
 @pytest.mark.parametrize('periodic', [( True, False, False),
                                       (False,  True, False),
                                       (False, False,  True)])
@@ -645,7 +652,7 @@ def test_VectorCurl_2D(domain, ncells, degree, periodic, seed):
 @pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7)])            # 2 cases
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
-                                      (False, False,  True)])
+                                      (False, False, True)])
 @pytest.mark.parametrize('seed', [1,3])
 
 def test_Curl_3D(domain, ncells, degree, periodic, seed):

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -22,8 +22,8 @@ from mpi4py                  import MPI
 # (this is done in the gradient etc. tests below already)
 def run_directional_derivative_operator(comm, domain, ncells, degree, periodic, direction, negative, transposed, seed, matrix_assembly=False):
 
-    if ncells == (1,1,1) and degree != (1,1,1):
-        return
+    if not all([not periodic[i] or (ncells[i] >= degree[i]) for i in range(len(degree)) ]):
+       return
     
     # assemble matrix when 1 cell in each direction
     matrix_assembly = (ncells == (1,1,1))
@@ -648,14 +648,17 @@ def test_VectorCurl_2D(domain, ncells, degree, periodic, seed):
 
 #==============================================================================
 @pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  # 1 case
-@pytest.mark.parametrize('ncells', [(4, 5, 7)])                       # 1 case
-@pytest.mark.parametrize('degree', [(3, 2, 5), (2, 4, 7)])            # 2 cases
+@pytest.mark.parametrize('ncells', [(1, 1, 1), (4, 5, 7)])            # 2 cases
+@pytest.mark.parametrize('degree', [(1, 3, 5), (3, 2, 5), (2, 4, 7)]) # 2 cases
 @pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
                                       (False,  True, False),
                                       (False, False, True)])
 @pytest.mark.parametrize('seed', [1,3])
 
 def test_Curl_3D(domain, ncells, degree, periodic, seed):
+    if ncells == (1,1,1) and any(periodic) and degree != (1,1,1):
+        return
+
     # determinize tests
     np.random.seed(seed)
 

--- a/psydac/feec/tests/test_differentiation_matrices.py
+++ b/psydac/feec/tests/test_differentiation_matrices.py
@@ -449,16 +449,16 @@ def test_Gradient_2D(domain, ncells, degree, periodic, seed):
     assert maxnorm_error / maxnorm_field <= 1e-14
 
 #==============================================================================
-@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  # 1 case
-@pytest.mark.parametrize('ncells', [(1,1,1), (4, 5, 7)])                       # 2 case
-@pytest.mark.parametrize('degree', [(1,1,1), (3, 2, 5), (2, 4, 7)])            # 3 cases
-@pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])             # 1 case
+@pytest.mark.parametrize('ncells', [(1, 8, 3), (7, 1, 2), (2, 2, 1), (4, 5, 7)]) # 4 cases
+@pytest.mark.parametrize('degree', [(1, 3, 1), (3, 1, 5), (2, 4, 7)])            # 3 cases
+@pytest.mark.parametrize('periodic', [( True, False, False),                     # 3 cases
                                       (False,  True, False),
                                       (False, False,  True)])
 @pytest.mark.parametrize('seed', [1,3])
 
 def test_Gradient_3D(domain, ncells, degree, periodic, seed):
-    if ncells == (1,1,1) and any(periodic) and degree != (1,1,1):
+    if any([ncells[d] <= degree[d] and periodic[d] for d in range(3)]):
         return
     
     # determinize tests
@@ -650,16 +650,16 @@ def test_VectorCurl_2D(domain, ncells, degree, periodic, seed):
     assert maxnorm_error / maxnorm_field <= 1e-14
 
 #==============================================================================
-@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])  # 1 case
-@pytest.mark.parametrize('ncells', [(1, 1, 1), (4, 5, 7)])            # 2 cases
-@pytest.mark.parametrize('degree', [(1, 3, 5), (3, 2, 5), (2, 4, 7)]) # 2 cases
-@pytest.mark.parametrize('periodic', [( True, False, False),          # 3 cases
+@pytest.mark.parametrize('domain', [([-2, 3], [6, 8], [-0.5, 0.5])])             # 1 case
+@pytest.mark.parametrize('ncells', [(1, 8, 3), (5, 1, 2), (2, 2, 1), (4, 5, 7)]) # 3 cases
+@pytest.mark.parametrize('degree', [(1, 3, 5), (3, 1, 2), (2, 4, 7)])            # 3 cases
+@pytest.mark.parametrize('periodic', [( True, False, False),                     # 3 cases
                                       (False,  True, False),
                                       (False, False, True)])
 @pytest.mark.parametrize('seed', [1,3])
 
 def test_Curl_3D(domain, ncells, degree, periodic, seed):
-    if ncells == (1,1,1) and any(periodic) and degree != (1,1,1):
+    if any([ncells[d] <= degree[d] and periodic[d] for d in range(3)]):
         return
 
     # determinize tests


### PR DESCRIPTION
Ensure the directional derivative is correctly converted to sparse matrix when we use one cell and periodic BC along a certain axis. In this case the spline space has dimension 1 and contains only constant functions, and the application of the directional derivative operator should always return zero.

Fixes #337.

