### PR TITLE
Fix dtype in GMRES and MINRES

### DIFF
--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -1678,7 +1678,7 @@ class GMRES(InverseLinearOperator):
         self._tmps = {key: domain.zeros() for key in ("r", "p")}
 
         # Initialize upper Hessenberg matrix
-        self._H = np.zeros((self._options["maxiter"] + 1, self._options["maxiter"]), dtype=A.dtype)
+        self._H = np.zeros((self._options["maxiter"] + 1, self._options["maxiter"]), dtype=A.domain.dtype)
         self._Q = []
         self._info = None
 
@@ -1820,7 +1820,7 @@ class GMRES(InverseLinearOperator):
     def solve_triangular(self, T, d):
         # Backwards substitution. Assumes T is upper triangular
         k = T.shape[0]
-        y = np.zeros((k,), dtype=self._A.dtype)
+        y = np.zeros((k,), dtype=self._A.domain.dtype)
 
         for k1 in range(k):
             temp = 0.

--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -959,7 +959,7 @@ class MinimumResidual(InverseLinearOperator):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
-        assert A.dtype == float
+        assert A.domain.dtype == float
         domain = A.codomain
         codomain = A.domain
 

--- a/psydac/linalg/tests/test_solvers.py
+++ b/psydac/linalg/tests/test_solvers.py
@@ -119,7 +119,6 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     x2 = solv @ b2
     xt = solvt.solve(bt)
     xh = solvh.dot(bh)
-    xc = solv2.dot(b2)
 
     # Verify correctness of calculation: 2-norm of error
     err = x - xe
@@ -130,8 +129,12 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     errt_norm = np.linalg.norm( errt.toarray() )
     errh = xh - xe
     errh_norm = np.linalg.norm( errh.toarray() )
-    errc = xc - xe
-    errc_norm = np.linalg.norm( errc.toarray() )
+
+    if solver != 'pcg':
+        # PCG only works with operators with diagonal
+        xc = solv2.dot(b2)    
+        errc = xc - xe
+        errc_norm = np.linalg.norm( errc.toarray() )
 
     #---------------------------------------------------------------------------
     # TERMINAL OUTPUT
@@ -160,8 +163,7 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     assert err2_norm < tol
     assert errt_norm < tol
     assert errh_norm < tol
-    assert errc_norm < tol
-
+    assert solver == 'pcg' or errc_norm < tol
 
 # ===============================================================================
 # SCRIPT FUNCTIONALITY

--- a/psydac/linalg/tests/test_solvers.py
+++ b/psydac/linalg/tests/test_solvers.py
@@ -195,7 +195,7 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
         assert err2_norm < tol
         assert errt_norm < tol
         assert errh_norm < tol
-        assert (solver == 'pcg' or errc_norm < tol)
+        assert solver == 'pcg' or errc_norm < tol
 
 # ===============================================================================
 # SCRIPT FUNCTIONALITY

--- a/psydac/linalg/tests/test_solvers.py
+++ b/psydac/linalg/tests/test_solvers.py
@@ -59,7 +59,7 @@ def define_data(n, p, matrix_data, dtype=float):
 @pytest.mark.parametrize( 'n', [5, 10, 13] )
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('dtype', [float, complex])
-@pytest.mark.parametrize('solver', ['cg', 'pcg', 'bicg', 'bicgstab', 'minres', 'lsmr', 'gmres'])
+@pytest.mark.parametrize('solver', ['cg', 'pcg' 'bicg', 'bicgstab', 'minres', 'lsmr', 'gmres'])
 
 def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
 
@@ -105,10 +105,11 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     solv  = inverse(A, solver, tol=1e-13, verbose=True)
     solvt = solv.transpose()
     solvh = solv.H
+    solv2 = inverse(A@A, solver, tol=1e-13, verbose=True) # Test solver of composition of operators
 
     # Manufacture right-hand-side vector from exact solution
     b  = A.dot( xe )
-    b2 = A.dot( b ) # Test solver with consecutive solves
+    b2 = A.dot( b ) # Test consecutive solves with same solver
     bt = A.T.dot( xe )
     bh = A.H.dot( xe )
 
@@ -118,6 +119,7 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     x2 = solv @ b2
     xt = solvt.solve(bt)
     xh = solvh.dot(bh)
+    xc = solv2.dot(b2)
 
     # Verify correctness of calculation: 2-norm of error
     err = x - xe
@@ -128,6 +130,8 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     errt_norm = np.linalg.norm( errt.toarray() )
     errh = xh - xe
     errh_norm = np.linalg.norm( errh.toarray() )
+    errc = xc - xe
+    errc_norm = np.linalg.norm( errc.toarray() )
 
     #---------------------------------------------------------------------------
     # TERMINAL OUTPUT
@@ -156,6 +160,7 @@ def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
     assert err2_norm < tol
     assert errt_norm < tol
     assert errh_norm < tol
+    assert errc_norm < tol
 
 
 # ===============================================================================

--- a/psydac/linalg/tests/test_solvers.py
+++ b/psydac/linalg/tests/test_solvers.py
@@ -59,7 +59,7 @@ def define_data(n, p, matrix_data, dtype=float):
 @pytest.mark.parametrize( 'n', [5, 10, 13] )
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('dtype', [float, complex])
-@pytest.mark.parametrize('solver', ['cg', 'pcg' 'bicg', 'bicgstab', 'minres', 'lsmr', 'gmres'])
+@pytest.mark.parametrize('solver', ['cg', 'pcg', 'bicg', 'bicgstab', 'minres', 'lsmr', 'gmres'])
 
 def test_solver_tridiagonal(n, p, dtype, solver, verbose=False):
 


### PR DESCRIPTION
In the iterative linear solvers take `dtype` from the domain or the codomain of the linear operator to be "inverted". This avoids reading the `dtype` property of the linear operator, which may not be properly defined in some cases. Specifically, the classes `GMRES` and `MinimumResidual` were fixed.