### PR TITLE
Use type annotations in generated code

### DIFF
--- a/psydac/api/ast/evaluation.py
+++ b/psydac/api/ast/evaluation.py
@@ -15,7 +15,7 @@ from psydac.pyccel.ast.core      import FunctionDef
 
 from .basic     import SplBasic
 from .utilities import build_pythran_types_header, variables
-from .utilities import build_pyccel_types_decorator
+from .utilities import build_pyccel_type_annotations
 from .utilities import rationalize_eval_mapping
 from .utilities import compute_atoms_expr_mapping
 from .utilities import compute_atoms_expr_field
@@ -171,13 +171,14 @@ class EvalArrayField(SplBasic):
 
         decorators = {}
         header = None
+
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_pyccel_types_decorator(func_args)}
+            func_args = build_pyccel_type_annotations(func_args)
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(self.name, func_args)
 
         return FunctionDef(self.name, list(func_args), [], body,
-                           decorators=decorators,header=header)
+                           decorators=decorators, header=header)
 
 
 #==============================================================================
@@ -386,7 +387,6 @@ class EvalArrayMapping(SplBasic):
         if self.is_rational_mapping:
             stmts = rationalize_eval_mapping(self.mapping, self.nderiv,
                                              self.space, indices_quad)
-
             body += stmts
 
         assign_spans = []
@@ -407,7 +407,7 @@ class EvalArrayMapping(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_pyccel_types_decorator(func_args)}
+            func_args = build_pyccel_type_annotations(func_args)
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(self.name, func_args)
 

--- a/psydac/api/ast/expr.py
+++ b/psydac/api/ast/expr.py
@@ -32,7 +32,7 @@ from sympde.calculus.matrices    import SymbolicDeterminant
 from .basic      import SplBasic
 from .utilities  import random_string
 from .utilities  import build_pythran_types_header, variables
-from .utilities  import build_pyccel_types_decorator
+from .utilities  import build_pyccel_type_annotations
 from .utilities  import math_atoms_as_str
 
 from psydac.fem.vector import ProductFemSpace
@@ -246,7 +246,7 @@ class ExprKernel(SplBasic):
             for j in range(0, n_cols):
                 is_complex = False
                 mat = IndexedBase('val_{i}{j}'.format(i=i,j=j))
-                d_vals[i,j] = mat
+                d_vals[i, j] = mat
         # ...
 
         xs = [Symbol(x) for x in ['x', 'y', 'z'][:dim]]
@@ -279,14 +279,17 @@ class ExprKernel(SplBasic):
         fields = symbols(fields_str)
         vector_fields = symbols(vector_fields_str)
         
-        fields_coeff = ()
-        vector_fields_coeff = ()
         if fields:
-            fields_coeff    = variables(['F_coeff',],
-                                          dtype='real', rank=dim, cls=IndexedVariable)
+            fields_coeff = variables(['F_coeff',],
+                    dtype='real', rank=dim, cls=IndexedVariable)
+        else:
+            field_coeff = ()
+
         if vector_fields:                              
-            vector_fields_coeff    = variables(['F_{}_coeff'.format(str(i)) for i in range(size)],
-                                          dtype='real', rank=dim, cls=IndexedVariable)
+            vector_fields_coeff = variables(['F_{}_coeff'.format(str(i)) for i in range(size)],
+                    dtype='real', rank=dim, cls=IndexedVariable)
+        else:
+            vector_fields_coeff = ()
                                           
         self._fields_coeff        = fields_coeff
         self._vector_fields_coeff = vector_fields_coeff 
@@ -367,14 +370,14 @@ class ExprKernel(SplBasic):
                 val = val[indices]
 
                 if isinstance(expr, (Matrix, ImmutableDenseMatrix)):
-                    rhs   = SymbolicExpr(expr[i_row,i_col])
+                    rhs   = SymbolicExpr(expr[i_row, i_col])
                     body += [Assign(val, rhs)]
 
                 else:
                     rhs   = SymbolicExpr(expr)
                     body += [Assign(val, rhs)]
 
-        for i in range(dim-1,-1,-1):
+        for i in range(dim-1, -1, -1):
             x = indices[i]
             rx = ranges[i]
 
@@ -403,7 +406,7 @@ class ExprKernel(SplBasic):
         mats = []
         for i in range(0, n_rows):
             for j in range(0, n_cols):
-                mats.append(d_vals[i,j])
+                mats.append(d_vals[i, j])
         mats = tuple(mats)
         self._global_mats = mats
         # ...
@@ -412,7 +415,7 @@ class ExprKernel(SplBasic):
             for i in range(0, n_rows):
                 for j in range(0, n_cols):
                     dtype = 'float'
-                    if expr[i,j].atoms(ImaginaryUnit):
+                    if expr[i, j].atoms(ImaginaryUnit):
                         dtype = 'complex'
                     mats_types.append(dtype)
 
@@ -432,13 +435,14 @@ class ExprKernel(SplBasic):
         func_args = self.build_arguments(mats)
         decorators = {}
         header = None
+
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_pyccel_types_decorator(func_args)}
+            func_args = build_pyccel_type_annotations(func_args)
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(self.name, func_args)
 
         return FunctionDef(self.name, list(func_args), [], body,
-                           decorators=decorators,header=header)
+                           decorators=decorators, header=header)
 
 
 class ExprInterface(SplBasic):

--- a/psydac/api/ast/glt.py
+++ b/psydac/api/ast/glt.py
@@ -40,7 +40,7 @@ from gelato.expr import gelatize
 from .basic      import SplBasic
 from .utilities  import random_string
 from .utilities  import build_pythran_types_header, variables
-from .utilities  import build_pyccel_types_decorator
+from .utilities  import build_pyccel_type_annotations
 from .utilities  import is_mapping
 from .utilities  import math_atoms_as_str
 from .evaluation import EvalArrayMapping, EvalArrayField
@@ -561,7 +561,7 @@ class GltKernel(SplBasic):
         decorators = {}
         header = None
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_pyccel_types_decorator(func_args)}
+            func_args = build_pyccel_type_annotations(func_args)
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(self.name, func_args)
 

--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -28,7 +28,7 @@ from psydac.pyccel.ast.datatypes import NativeInteger
 
 from psydac.api.ast.nodes     import FloorDiv
 from psydac.api.ast.utilities import variables
-from psydac.api.ast.utilities import build_pyccel_types_decorator
+from psydac.api.ast.utilities import build_pyccel_type_annotations
 from psydac.api.utilities     import flatten
 
 from psydac.api.ast.basic     import SplBasic
@@ -343,19 +343,18 @@ class LinearOperatorDot(SplBasic):
         imports    = []
         if backend:
             if backend['name'] == 'pyccel':
-                a = [String(str(i)) for i in build_pyccel_types_decorator(func_args)]
-                decorators = {'types': Function('types')(*a)}
+                func_args = build_pyccel_type_annotations(func_args)
             elif backend['name'] == 'pythran':
                 header = build_pythran_types_header(name, func_args)
 
         if openmp:
-            shared  = ','.join(str(a) for a in shared)
-            firstprivate  = "firstprivate({})".format(','.join(str(a) for a in firstprivate)) if firstprivate else ""
+            shared = ','.join(str(a) for a in shared)
+            firstprivate = "firstprivate({})".format(','.join(str(a) for a in firstprivate)) if firstprivate else ""
             pragma1 = "#$omp parallel default(private) shared({}) {}\n".format(shared, firstprivate)
             pragma2 = "#$omp end parallel"
-            body     = [Comment(pragma1)] + body + [Comment(pragma2)]
-        func = FunctionDef(self.name, list(func_args), [], body, imports=imports, decorators=decorators)
-        return func
+            body    = [Comment(pragma1)] + body + [Comment(pragma2)]
+
+        return FunctionDef(self.name, list(func_args), [], body, imports=imports, decorators=decorators)
 
     def _initialize_folder(self, folder=None):
         # ...
@@ -384,15 +383,8 @@ class LinearOperatorDot(SplBasic):
         modname = 'dependencies_{}'.format(self.tag)
 
         if self.comm is None or self.comm.rank == 0:
-
-            if backend and backend['name'] == 'pyccel':
-                imports  = 'from pyccel.decorators import types\n'
-                imports += 'from numpy import shape'
-            else:
-                imports = 'from numpy import shape'
-
-            code = f'{imports}\n{pycode.pycode(self.code)}'
-            write_code(modname + '.py', code, folder=self.folder)
+            python_code = pycode.pycode(self.code)
+            write_code(modname + '.py', python_code, folder=self.folder)
 
         self._modname = modname
 
@@ -462,25 +454,25 @@ class VectorDot(SplBasic):
 
         ndim = self.ndim
 
-        indices = variables('i1:%s'%(ndim+1),'int')
-        dims    = variables('n1:%s'%(ndim+1),'int')
-        pads    = variables('p1:%s'%(ndim+1),'int')
+        indices = variables('i1:%s'%(ndim+1), 'int')
+        dims    = variables('n1:%s'%(ndim+1), 'int')
+        pads    = variables('p1:%s'%(ndim+1), 'int')
         out     = variables('out','real')
-        x1,x2   = variables('x1, x2','real',rank=ndim,cls=IndexedVariable)
+        x1,x2   = variables('x1, x2','real', rank=ndim, cls=IndexedVariable)
 
         body = []
-        ranges = [Range(p,n-p) for n,p in zip(dims,pads)]
+        ranges = [Range(p, n-p) for n, p in zip(dims, pads)]
         target = Product(*ranges)
 
         v1 = x1[indices]
         v2 = x2[indices]
 
-        body = [AugAssign(out,'+' ,Mul(v1,v2))]
+        body = [AugAssign(out, '+' , Mul(v1, v2))]
         body = [For(indices, target, body)]
-        body.insert(0,Assign(out, 0.0))
+        body.insert(0, Assign(out, 0.0))
         body.append(Return(out))
 
-        func_args =  (x1, x2) + pads + dims
+        func_args = (x1, x2) + pads + dims
 
         self._imports = [Import('itertools', 'product')]
 
@@ -488,9 +480,9 @@ class VectorDot(SplBasic):
         header = None
 
         if self.backend['name'] == 'pyccel':
-            decorators = {'types': build_pyccel_types_decorator(func_args), 'external':[]}
+            func_args = build_pyccel_type_annotations(func_args)
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(self.name, func_args)
 
         return FunctionDef(self.name, list(func_args), [], body,
-                           decorators=decorators,header=header)
+                           decorators=decorators, header=header)

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -485,19 +485,17 @@ class Parser(object):
             map_basis   = []
             map_span    = []
 
-        constants  = args.pop('constants', None)
-
-        f_coeffs   = args.pop('f_coeffs',    None)
+        constants = args.pop('constants', None)
+        f_coeffs  = args.pop('f_coeffs' , None)
 
         starts = args.pop('starts', [])
-        ends   = args.pop('ends', [])
+        ends   = args.pop('ends'  , [])
         if f_coeffs:
-            f_span     = args.pop('f_span',      [])
-            f_basis    = args.pop('field_basis', [])
-            f_degrees  = args.pop('fields_degrees', [])
-            f_pads     = args.pop('f_pads', [])
-            f_args     = (*f_basis, *f_span, *f_degrees, *f_pads, *f_coeffs)
-
+            f_span    = args.pop('f_span',      [])
+            f_basis   = args.pop('field_basis', [])
+            f_degrees = args.pop('fields_degrees', [])
+            f_pads    = args.pop('f_pads', [])
+            f_args    = (*f_basis, *f_span, *f_degrees, *f_pads, *f_coeffs)
 
         args = [*tests_basis, *trial_basis, *map_basis,\
                 *g_span, *map_span, *g_quad,\
@@ -505,10 +503,10 @@ class Parser(object):
                 *map_degrees, *lengths, *g_pads, *map_coeffs]
 
         if mats:
-            exprs     = [mat.expr for mat in mats]
-            mats      = [self._visit(mat) for mat in mats]
-            mats      = [[a for a,e in zip(mat[:],expr[:]) if e] for mat,expr in zip(mats, exprs)]
-            mats      = flatten(mats)
+            exprs = [mat.expr for mat in mats]
+            mats  = [self._visit(mat) for mat in mats]
+            mats  = [[a for a,e in zip(mat[:],expr[:]) if e] for mat,expr in zip(mats, exprs)]
+            mats  = flatten(mats)
 
         args      = [self._visit(i, **kwargs) for i in args]
         args      = [tuple(arg.values())[0] if isinstance(arg, dict) else arg for arg in args]
@@ -541,8 +539,8 @@ class Parser(object):
                 inits.append(Assign(var, Zeros(i, dtype=var.dtype)))
 
         inits.append(EmptyNode())
-        body          =  tuple(inits) + body
-        name          = expr.name
+        body = tuple(inits) + body
+        name = expr.name
 
         # TODO : when Pyccel will work on the cmath library, we should import the math function from cmath and not from numpy
         # If we are with complex object, we should import the mathematical function from numpy and not math to handle complex value.
@@ -558,16 +556,10 @@ class Parser(object):
                             ([Import('math', math_imports)] if math_imports else []) + \
                             [*expr.imports]
 
-        results       = [self._visit(a) for a in expr.results]
+        results = [self._visit(a) for a in expr.results]
 
         if self.backend['name'] == 'pyccel':
-#            a = [String(str(i)) for i in build_pyccel_types_decorator(arguments)]
-#            decorators = {'types': Function('types')(*a)}
             arguments = build_pyccel_type_annotations(arguments)
-#            print('-'*30)
-#            for a in arguments:
-#                print(self._visit(a))
-#            print('-'*30)
             decorators = {}
         elif self.backend['name'] == 'pythran':
             header = build_pythran_types_header(name, arguments) # Could this work??
@@ -581,7 +573,7 @@ class Parser(object):
         return stmts
 
     def _visit_EvalField(self, expr, **kwargs):
-        body       = self._visit(expr.body, **kwargs)
+        body = self._visit(expr.body, **kwargs)
         return body
 
     def _visit_EvalMapping(self, expr, **kwargs):

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -76,7 +76,6 @@ from .fem import expand, expand_hdiv_hcurl
 from psydac.api.ast.utilities import variables, math_atoms_as_str, get_name
 from psydac.api.utilities     import flatten
 from psydac.api.ast.utilities import build_pythran_types_header
-#from psydac.api.ast.utilities import build_pyccel_types_decorator
 from psydac.api.ast.utilities import build_pyccel_type_annotations
 
 #==============================================================================

--- a/psydac/api/ast/parser.py
+++ b/psydac/api/ast/parser.py
@@ -76,7 +76,8 @@ from .fem import expand, expand_hdiv_hcurl
 from psydac.api.ast.utilities import variables, math_atoms_as_str, get_name
 from psydac.api.utilities     import flatten
 from psydac.api.ast.utilities import build_pythran_types_header
-from psydac.api.ast.utilities import build_pyccel_types_decorator
+#from psydac.api.ast.utilities import build_pyccel_types_decorator
+from psydac.api.ast.utilities import build_pyccel_type_annotations
 
 #==============================================================================
 # TODO move it
@@ -560,10 +561,16 @@ class Parser(object):
         results       = [self._visit(a) for a in expr.results]
 
         if self.backend['name'] == 'pyccel':
-            a = [String(str(i)) for i in build_pyccel_types_decorator(arguments)]
-            decorators = {'types': Function('types')(*a)}
+#            a = [String(str(i)) for i in build_pyccel_types_decorator(arguments)]
+#            decorators = {'types': Function('types')(*a)}
+            arguments = build_pyccel_type_annotations(arguments)
+#            print('-'*30)
+#            for a in arguments:
+#                print(self._visit(a))
+#            print('-'*30)
+            decorators = {}
         elif self.backend['name'] == 'pythran':
-            header = build_pythran_types_header(name, arguments)
+            header = build_pythran_types_header(name, arguments) # Could this work??
         else:
             decorators = {}
 

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -33,6 +33,29 @@ from psydac.pyccel.ast.core import Comment
 from psydac.pyccel.ast.core import String
 from psydac.pyccel.ast.core import AnnotatedArgument
 
+__all__ = (
+    'build_pyccel_type_annotations',
+    'build_pyccel_types_decorator',
+    'build_pythran_types_header',
+    'compute_atoms_expr',
+    'compute_atoms_expr_field',
+    'compute_atoms_expr_mapping',
+    'compute_boundary_jacobian',
+    'compute_normal_vector',
+    'compute_tangent_vector',
+    'filter_loops',
+    'filter_product',
+    'fusion_loops',
+    'get_name',
+    'is_mapping',
+    'logical2physical',
+    'math_atoms_as_str',
+    'random_string',
+    'rationalize_eval_mapping',
+    'select_loops',
+    'variables',
+)
+
 #==============================================================================
 def random_string( n ):
     chars    = string.ascii_lowercase + string.digits

--- a/psydac/api/ast/utilities.py
+++ b/psydac/api/ast/utilities.py
@@ -35,7 +35,6 @@ from psydac.pyccel.ast.core import AnnotatedArgument
 
 __all__ = (
     'build_pyccel_type_annotations',
-    'build_pyccel_types_decorator',
     'build_pythran_types_header',
     'compute_atoms_expr',
     'compute_atoms_expr_field',
@@ -879,47 +878,6 @@ def build_pyccel_type_annotations(args, order=None):
         new_args.append(new_a)
 
     return new_args
-
-#==============================================================================
-def build_pyccel_types_decorator(args, order=None):
-    """
-    builds a types decorator from a list of arguments (of FunctionDef)
-    """
-    types = []
-    for a in args:
-        if isinstance(a, Variable):
-            rank  = a.rank
-            dtype = a.dtype.name.lower()
-
-        elif isinstance(a, IndexedVariable):
-            rank  = a.rank
-            dtype = a.dtype.name.lower()
-
-        elif isinstance(a, Constant):
-            rank = 0
-            if a.is_integer:
-                dtype = 'int'
-            elif a.is_real:
-                dtype = 'float'
-            elif a.is_complex:
-                dtype = 'complex'
-            else:
-                raise TypeError(f"The Constant {a} don't have any information about the type of the variable.\n"
-                                f"Please create the Constant like this Constant('{a}', real=True), Constant('{a}', complex=True) or Constant('{a}', integer=True).")
-
-        else:
-            raise TypeError('unexpected type for {}'.format(a))
-
-        if rank > 0:
-            shape = ','.join(':' * rank)
-            dtype = '{dtype}[{shape}]'.format(dtype=dtype, shape=shape)
-            if order and rank > 1:
-                dtype = "{dtype}(order={ordering})".format(dtype=dtype, ordering=order)
-
-        dtype = String(dtype)
-        types.append(dtype)
-
-    return types
 
 #==============================================================================
 def build_pythran_types_header(name, args, order=None):

--- a/psydac/api/basic.py
+++ b/psydac/api/basic.py
@@ -227,20 +227,22 @@ class BasicCodeGen:
         return folder
 
     def _generate_code(self):
-        # ... generate code that can be pyccelized
-        imports = ''
+        """
+        Generate Python code which can be pyccelized.
+        """
+        psydac_ast = self.ast
 
-        if self.backend['name'] == 'pyccel':
-            imports = "from pyccel.decorators import types"
-            imports += ", template \n@template(name='T', types=['float', 'complex']) "
+        parser_settings = {
+            'dim'    : psydac_ast.dim,
+            'nderiv' : psydac_ast.nderiv,
+            'mapping': psydac_ast.mapping,
+            'target' : psydac_ast.domain
+        }
 
-        ast = self.ast
-        expr = parse(ast.expr, settings={'dim': ast.dim, 'nderiv': ast.nderiv, 'mapping':ast.mapping, 'target':ast.domain}, backend=self.backend)
+        pyccel_ast  = parse(psydac_ast.expr, settings=parser_settings, backend=self.backend)
+        python_code = pycode(pyccel_ast)
 
-        dep = pycode(expr)
-        code = f'{imports}\n{dep}'
-
-        return code
+        return python_code
 
     def _save_code(self, code, backend=None):
         # ...

--- a/psydac/pyccel/ast/core.py
+++ b/psydac/pyccel/ast/core.py
@@ -5705,3 +5705,18 @@ class PyccelArraySize(Function, PyccelAstNode):
             code_init = 'size({0}, {1})'.format(init_value, index)
 
         return code_init
+
+
+class AnnotatedArgument(Symbol, PyccelAstNode):
+
+    def __new__(cls, name, annotation):
+        return Basic.__new__(cls, name, annotation)
+
+    @property
+    def name(self):
+        return self.args[0]
+
+    @property
+    def annotation(self):
+        return self.args[1]
+

--- a/psydac/pyccel/codegen/printing/pycode.py
+++ b/psydac/pyccel/codegen/printing/pycode.py
@@ -363,6 +363,11 @@ class PythonCodePrinter(SympyPythonCodePrinter):
         a = self._print(expr.args[0])
         return 'not {}'.format(a)
 
+    def _print_AnnotatedArgument(self, expr):
+        name       = self._print(expr.name)
+        annotation = self._print(expr.annotation)
+        return f'{name} : {annotation}'
+
 #==============================================================================
 def pycode(expr, **settings):
     """ Converts an expr to a string of Python code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
     # Our packages from PyPi
     'sympde == 0.18.1',
-    'pyccel == 1.8.1',
+    'pyccel >= 1.8.1',
     'gelato == 0.12',
 
     # In addition, we depend on mpi4py and h5py (MPI version).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 64.0", "wheel", "numpy < 1.25", "pyccel == 1.8.1"]
+requires = ["setuptools >= 64.0", "wheel", "numpy", "pyccel >= 1.8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Remove usage of `@types` decorators from the generated kernels. Use type annotations instead, as this allows using the future versions of Pyccel to accelerate our kernels. Fixes #342.

Main changes
--------------
* Create new AST node `AnnotatedArgument` in `psydac.pyccel.ast.core`, which contains a `name` (the original argument) and an `annotation` (a string specifying the type).
* Add method `_print_AnnotatedArgument` to `PythonCodePrinter` in `psydac.pyccel.codegen.printing.pycode`. This method just prints `f"{name} : {annotation}"`.
* Create function `build_pyccel_type_annotations` in `psydac.api.ast.utilities`, which takes a list of function arguments (currently of type `Variable`, `IndexedVariable`, or `Constant`) and returns a list of `AnnotatedArgument` objects.
* Make generated functions use type annotations instead of the old `@types` decorator. To this end use new function `build_pyccel_type_annotations` (instead of old `build_pyccel_types_decorator`) in:
   - method `_visit_DefNode` of class `Parser` in `psydac.api.ast.parser`;
   - method `_initialize` of class `LinearOperatorDot` in `psydac.api.ast.linalg`;
   - method `_initialize` of class `ExprKernel` in `psydac.api.ast.expr`;
   - method `_initialize` of class `GltKernel` in `psydac.api.ast.glt`.

Further changes
----------------
* Remove obsolete function `build_pyccel_types_decorator` (replaced by `build_pyccel_type_annotations`).
* Clean up method `_generate_code` of class `BasicCodeGen` in `psydac.api.basic`, and in particular remove from all the generated modules:
   - obsolete import `from pyccel.decorators import types`;
   - useless `@template` decorator and corresponding import.
* Do not force installation of Pyccel version 1.8.1, only require it as minimum version.
* Do not use old NumPy version during build process.