### PR TITLE
Moved _check_options() and transpose() to the base class `InverseLinearOperator`

### DIFF
--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -44,7 +44,7 @@ def inverse(A, solver, **kwargs):
 
     """
     # Check solver input
-    solvers = ('cg', 'pcg', 'bicg', 'bicgstab', 'minres', 'lsmr', 'gmres')
+    solvers = ('cg', 'pcg', 'bicg', 'bicgstab', 'pbicgstab', 'minres', 'lsmr', 'gmres')
     if solver not in solvers:
         raise ValueError(f"Required solver '{solver}' not understood.")
 
@@ -65,6 +65,8 @@ def inverse(A, solver, **kwargs):
         obj = BiConjugateGradient(A, **kwargs)
     elif solver == 'bicgstab':
         obj = BiConjugateGradientStabilized(A, **kwargs)
+    elif solver == 'pbicgstab':
+        obj = PBiConjugateGradientStabilized(A, **kwargs)
     elif solver == 'minres':
         obj = MinimumResidual(A, **kwargs)
     elif solver == 'lsmr':
@@ -268,7 +270,7 @@ class PConjugateGradient(InverseLinearOperator):
     The .dot (and also the .solve) function are based on a preconditioned conjugate gradient method.
 
     Preconditioned Conjugate Gradient (PCG) solves the symetric positive definte
-    system Ax = b. It assumes that pc(r) returns the solution to Ps = r,
+    system Ax = b. It assumes that pc.dot(r) returns the solution to Ps = r,
     where P is positive definite.
 
     Parameters
@@ -276,14 +278,8 @@ class PConjugateGradient(InverseLinearOperator):
     A : psydac.linalg.stencil.StencilMatrix
         Left-hand-side matrix A of linear system
 
-    pc: str
-        Preconditioner for A, it should approximate the inverse of A.
-        Can currently only be:
-        * The strings 'jacobi' or 'weighted_jacobi'. (rather obsolete, supply a callable instead, if possible)(14.02.: test weighted_jacobi)
-        The following should also be possible
-        * None, i.e. not pre-conditioning (this calls the standard `cg` method)
-        * A LinearSolver object (in which case the out parameter is used)
-        * A callable with two parameters (A, r), where A is the LinearOperator from above, and r is the residual.
+    pc: psydac.linalg.basic.LinearOperator
+        Preconditioner for A, it should approximate the inverse of A (can be None).
 
     x0 : psydac.linalg.basic.Vector
         First guess of solution for iterative solver (optional).
@@ -301,7 +297,7 @@ class PConjugateGradient(InverseLinearOperator):
         Stores a copy of the output in x0 to speed up consecutive calculations of slightly altered linear systems
 
     """
-    def __init__(self, A, *, pc='jacobi', x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
+    def __init__(self, A, *, pc=None, x0=None, tol=1e-6, maxiter=1000, verbose=False, recycle=False):
 
         assert isinstance(A, LinearOperator)
         assert A.domain.dimension == A.codomain.dimension
@@ -318,6 +314,8 @@ class PConjugateGradient(InverseLinearOperator):
         self._domain = domain
         self._codomain = codomain
         self._solver = 'pcg'
+        if pc is None:
+            pc = IdentityOperator(self._domain)
         self._options = {"x0":x0, "pc":pc, "tol":tol, "maxiter":maxiter, "verbose":verbose, "recycle":recycle}
         self._check_options(**self._options)
         tmps_codomain = {key: codomain.zeros() for key in ("p", "s")}
@@ -329,8 +327,7 @@ class PConjugateGradient(InverseLinearOperator):
         for key, value in kwargs.items():
 
             if key == 'pc':
-                assert value is not None, "pc may not be None"
-                assert value == 'jacobi', "unsupported preconditioner"
+                assert isinstance(value, LinearOperator)
             elif key == 'x0':
                 if value is not None:
                     assert isinstance(value, Vector), "x0 must be a Vector or None"
@@ -357,7 +354,7 @@ class PConjugateGradient(InverseLinearOperator):
     def solve(self, b, out=None):
         """
         Preconditioned Conjugate Gradient (PCG) solves the symetric positive definte
-        system Ax = b. It assumes that pc(r) returns the solution to Ps = r,
+        system Ax = b. It assumes that pc.dot(r) returns the solution to Ps = r,
         where P is positive definite.
         Info can be accessed using get_info(), see :func:~`basic.InverseLinearOperator.get_info`.
 
@@ -390,6 +387,8 @@ class PConjugateGradient(InverseLinearOperator):
 
         assert isinstance(b, Vector)
         assert b.space is domain
+    
+        assert isinstance(pc, LinearOperator)
 
         # First guess of solution
         if out is not None:
@@ -397,22 +396,6 @@ class PConjugateGradient(InverseLinearOperator):
             assert out.space is codomain
 
         x = x0.copy(out=out)
-
-        # Preconditioner
-        assert pc is not None
-        if pc == 'jacobi':
-            psolve = lambda r, out: InverseLinearOperator.jacobi(A, r, out)
-        #elif pc == 'weighted_jacobi':
-        #    psolve = lambda r, out: InverseLinearOperator.weighted_jacobi(A, r, out) # allows for further specification not callable like this!
-        #elif isinstance(pc, str):
-        #    pcfun = getattr(InverseLinearOperator, str)
-        #    #pcfun = globals()[pc]
-        #    psolve = lambda r: pcfun(A, r)
-        #elif isinstance(pc, LinearSolver):
-        #    s = b.space.zeros()
-        #    psolve = lambda r: pc.solve(r, out=s)
-        #elif hasattr(pc, '__call__'):
-        #    psolve = lambda r: pc(A, r)
 
         # Extract local storage
         v = self._tmps["v"]
@@ -425,7 +408,7 @@ class PConjugateGradient(InverseLinearOperator):
         b.copy(out=r)
         r       -= v
         nrmr_sqr = r.dot(r).real
-        psolve(r, out=s)
+        pc.dot(r, out=s)
         am       = s.dot(r)
         s.copy(out=p)
 
@@ -453,7 +436,7 @@ class PConjugateGradient(InverseLinearOperator):
             r.mul_iadd(-l, v) # this is r -= l*v
 
             nrmr_sqr = r.dot(r).real
-            psolve(r, out=s)
+            pc.dot(r, out=s)
 
             am1 = s.dot(r)
 
@@ -702,6 +685,268 @@ class BiConjugateGradient(InverseLinearOperator):
 
         if recycle:
             x.copy(out=self._options["x0"])
+
+        return x
+
+    def dot(self, b, out=None):
+        return self.solve(b, out=out)
+
+#===============================================================================
+class PBiConjugateGradientStabilized(InverseLinearOperator):
+    """
+    A LinearOperator subclass. Objects of this class are meant to be created using :func:~`solvers.inverse`.
+    The .dot (and also the .solve) function are based on the
+    preconditioned Biconjugate gradient Stabilized (PBCGSTAB) algorithm for solving linear system Ax=b.
+    Implementation from [1], page 251.
+    Parameters
+    ----------
+    A : psydac.linalg.basic.LinearOperator
+        Left-hand-side matrix A of linear system; individual entries A[i,j]
+        can't be accessed, but A has 'shape' attribute and provides 'dot(p)'
+        function (i.e. matrix-vector product A*p).
+    pc: psydac.linalg.basic.LinearOperator
+        Preconditioner for A, it should approximate the inverse of A (can be None).
+    x0 : psydac.linalg.basic.Vector
+        First guess of solution for iterative solver (optional).
+    tol : float
+        Absolute tolerance for 2-norm of residual r = A*x - b.
+    maxiter: int
+        Maximum number of iterations.
+    verbose : bool
+        If True, 2-norm of residual r is printed at each iteration.
+    References
+    ----------
+    [1] A. Maister, Numerik linearer Gleichungssysteme, Springer ed. 2015.
+    """
+    def __init__(self, A, *, pc=None, x0=None, tol=1e-6, maxiter=1000, verbose=False):
+
+        assert isinstance(A, LinearOperator)
+        assert A.domain.dimension == A.codomain.dimension
+        domain = A.codomain
+        codomain = A.domain
+
+        if x0 is not None:
+            assert isinstance(x0, Vector)
+            assert x0.space is codomain
+        else:
+            x0 = codomain.zeros()
+
+        self._A = A
+        self._domain = domain
+        self._codomain = codomain
+        self._solver = 'pbicgstab'
+        if pc is None:
+            pc = IdentityOperator(self._domain)
+        self._options = { "pc": pc, "x0": x0, "tol": tol, "maxiter": maxiter, "verbose": verbose}
+        self._check_options(**self._options)
+        self._tmps = {key: domain.zeros() for key in ("v", "r", "s", "t", 
+                                                      "vp", "rp", "sp", "tp",
+                                                      "pp", "av", "app", "osp", 
+                                                      "rp0")}
+        self._info = None
+
+    def _check_options(self, **kwargs):
+        keys = ('pc', 'x0', 'tol', 'maxiter', 'verbose')
+        for key, value in kwargs.items():
+            idx = [key == keys[i] for i in range(len(keys))]
+            assert any(idx), "key not supported, check options"
+            true_idx = idx.index(True)
+            if true_idx == 0:
+                assert isinstance(value, LinearOperator)
+            elif true_idx == 1:
+                if value is not None:
+                    assert isinstance(value, Vector), "x0 must be a Vector or None"
+                    assert value.space == self._codomain, "x0 belongs to the wrong VectorSpace"
+            elif true_idx == 2:
+                assert is_real(value), "tol must be a real number"
+                assert value > 0, "tol must be positive"
+            elif true_idx == 3:
+                assert isinstance(value, int), "maxiter must be an int"
+                assert value > 0, "maxiter must be positive"
+            elif true_idx == 4:
+                assert isinstance(value, bool), "verbose must be a bool"
+
+    def _update_options( self ):
+        self._options = {"pc": self._pc, "x0":self._x0, "tol":self._tol, "maxiter": self._maxiter, "verbose": self._verbose}
+
+    def transpose(self, conjugate=False):
+        At = self._A.transpose(conjugate=conjugate)
+        solver = self._solver
+        options = self._options
+        return inverse(At, solver, **options)
+
+    def solve(self, b, out=None):
+        """
+        Preconditioned biconjugate gradient stabilized method (PBCGSTAB) algorithm for solving linear system Ax=b.
+        Implementation from [1], page 251.
+        Parameters
+        ----------
+        b : psydac.linalg.basic.Vector
+            Right-hand-side vector of linear system. Individual entries b[i] need
+            not be accessed, but b has 'shape' attribute and provides 'copy()' and
+            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            scalar multiplication and sum operations are available.
+        out : psydac.linalg.basic.Vector | NoneType
+            The output vector, or None (optional).
+        Returns
+        -------
+        x : psydac.linalg.basic.Vector
+            Numerical solution of linear system. To check the convergence of the solver,
+            use the method InverseLinearOperator.get_info().
+        
+        info : dict
+            Dictionary containing convergence information:
+              - 'niter'    = (int) number of iterations
+              - 'success'  = (boolean) whether convergence criteria have been met
+              - 'res_norm' = (float) 2-norm of residual vector r = A*x - b.
+        References
+        ----------
+        [1] A. Maister, Numerik linearer Gleichungssysteme, Springer ed. 2015.
+        """
+
+        A = self._A
+        domain = self._domain
+        codomain = self._codomain
+        options = self._options
+        pc = options["pc"]
+        x0 = options["x0"]
+        tol = options["tol"]
+        maxiter = options["maxiter"]
+        verbose = options["verbose"]
+
+        assert isinstance(b, Vector)
+        assert b.space is domain
+
+        assert isinstance(pc, LinearOperator)
+
+        # first guess of solution
+        if out is not None:
+            assert isinstance(out, Vector)
+            assert out.space == codomain
+            out *= 0
+            if x0 is None:
+                x = out
+            else:
+                assert x0.shape == (A.shape[0],)
+                out += x0
+                x = out
+        else:
+            if x0 is None:
+                x = b.copy()
+                x *= 0.0
+            else:
+                assert x0.shape == (A.shape[0],)
+                x = x0.copy()
+
+        # preconditioner (must have a .solve method)
+        assert isinstance(pc, LinearOperator)
+
+        # extract temporary vectors
+        v = self._tmps['v']
+        r = self._tmps['r']
+        s = self._tmps['s']
+        t = self._tmps['t']
+
+        vp = self._tmps['vp']
+        rp = self._tmps['rp']
+        pp = self._tmps['pp']
+        sp = self._tmps['sp']
+        tp = self._tmps['tp']
+
+        av = self._tmps['av']
+
+        app = self._tmps['app']
+        osp = self._tmps['osp']
+
+        # first values: r = b - A @ x, rp = pp = PC @ r, rhop = |rp|^2
+        A.dot(x, out=v)
+        b.copy(out=r)
+        r -= v
+
+        pc.dot(r, out=rp)
+        rp.copy(out=pp)
+
+        rhop = rp.dot(rp)
+
+        # save initial residual vector rp0
+        rp0 = self._tmps['rp0']
+        rp.copy(out=rp0)
+
+        # squared residual norm and squared tolerance
+        res_sqr = r.dot(r)
+        tol_sqr = tol**2
+
+        if verbose:
+            print("Pre-conditioned BICGSTAB solver:")
+            print("+---------+---------------------+")
+            print("+ Iter. # | L2-norm of residual |")
+            print("+---------+---------------------+")
+            template = "| {:7d} | {:19.2e} |"
+
+        # iterate to convergence or maximum number of iterations
+        niter = 0
+
+        while res_sqr > tol_sqr and niter < maxiter:
+
+            # v = A @ pp, vp = PC @ v, alphap = rhop/(vp.rp0)
+            A.dot(pp, out=v)
+            pc.dot(v, out=vp)
+            alphap = rhop / vp.dot(rp0)
+
+            # s = r - alphap*v, sp = PC @ s
+            r.copy(out=s)
+            v.copy(out=av)
+            av *= alphap
+            s -= av
+            pc.dot(s, out=sp)
+
+            # t = A @ sp, tp = PC @ t, omegap = (tp.sp)/(tp.tp)
+            A.dot(sp, out=t)
+            pc.dot(t, out=tp)
+            omegap = tp.dot(sp) / tp.dot(tp)
+
+            # x = x + alphap*pp + omegap*sp
+            pp.copy(out=app)
+            sp.copy(out=osp)
+            app *= alphap
+            osp *= omegap
+            x += app
+            x += osp
+
+            # r = s - omegap*t, rp = sp - omegap*tp
+            s.copy(out=r)
+            t *= omegap
+            r -= t
+
+            sp.copy(out=rp)
+            tp *= omegap
+            rp -= tp
+
+            # rhop_new = rp.rp0, betap = (alphap*rhop_new)/(omegap*rhop)
+            rhop_new = rp.dot(rp0)
+            betap = (alphap*rhop_new) / (omegap*rhop)
+            rhop = 1*rhop_new
+
+            # pp = rp + betap*(pp - omegap*vp)
+            vp *= omegap
+            pp -= vp
+            pp *= betap
+            pp += rp
+
+            # new residual norm
+            res_sqr = r.dot(r)
+
+            niter += 1
+
+            if verbose:
+                print(template.format(niter, sqrt(res_sqr)))
+
+        if verbose:
+            print("+---------+---------------------+")
+
+        # convergence information
+        self._info = {'niter': niter, 'success': res_sqr <
+                tol_sqr, 'res_norm': sqrt(res_sqr)}
 
         return x
 


### PR DESCRIPTION
All solvers are sub-classes of `InverseLinearOperator`. As such, they now call now `super().__init__` which takes the base arguments for any iterative solver. Additional arguments must be checked in the individual solvers.
    
The base class now has the setter method for `linop`, which allows to change the matrix A of the solver.
Moreover, there is the abstract property `solver` which is the name string of the solver.

Moreover, changed the handling of preconditioners in inverse LinearOperators.
    
The option `pc` must now take as value a `LinearOperator`, which is the preconditioner.
 If `pc=None`, an `IdentityOperator` of the domain space is created automatically.
 The class `InverseLinearOperators` could be deprecated, since the Jacobi preconditiner should be implemented as a `LinearOperator`.
    
 The new solver `PBiConjugateGradientStabilized` (preconditioned) has been added from Struphy.
    
 `test_solvers.py` has been updated. The Jacobi preconditioner is not tested at the moment.

Solves #343