### PR TITLE
 Fix parallel bug in `simplify` method of `SumLinearOperator`

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -654,7 +654,7 @@ class SumLinearOperator(LinearOperator):
     @staticmethod
     def simplifiy(addends):
         class_list = [addends[i].__class__.__name__ for i in range(len(addends))]
-        unique_list = list(set(class_list))
+        unique_list = list(set(class_list)).sort()
         if len(unique_list) == 1:
             return addends
         out = ()

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -603,7 +603,7 @@ class SumLinearOperator(LinearOperator):
             else:
                 addends = (*addends, a)
 
-        addends = SumLinearOperator.simplifiy(addends)
+        addends = SumLinearOperator.simplify(addends)
 
         self._domain = domain
         self._codomain = codomain
@@ -652,10 +652,9 @@ class SumLinearOperator(LinearOperator):
         return SumLinearOperator(self._codomain, self._domain, *t_addends)
 
     @staticmethod
-    def simplifiy(addends):
-        class_list = [addends[i].__class__.__name__ for i in range(len(addends))]
-        unique_list = list(set(class_list))
-        unique_list.sort()
+    def simplify(addends):
+        class_list  = [a.__class__ for a in addends]
+        unique_list = [*{c: a for c, a in zip(class_list, addends}]
         if len(unique_list) == 1:
             return addends
         out = ()

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -654,7 +654,8 @@ class SumLinearOperator(LinearOperator):
     @staticmethod
     def simplifiy(addends):
         class_list = [addends[i].__class__.__name__ for i in range(len(addends))]
-        unique_list = list(set(class_list)).sort()
+        unique_list = list(set(class_list))
+        unique_list.sort()
         if len(unique_list) == 1:
             return addends
         out = ()

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -654,7 +654,7 @@ class SumLinearOperator(LinearOperator):
     @staticmethod
     def simplify(addends):
         class_list  = [a.__class__ for a in addends]
-        unique_list = [*{c: a for c, a in zip(class_list, addends}]
+        unique_list = [*{c: a for c, a in zip(class_list, addends)}]
         if len(unique_list) == 1:
             return addends
         out = ()


### PR DESCRIPTION
Maintain the original order of the addends in the method `simplify` of class `SumLinearOperator`. This is achieved by using `dict` (which preserves the insertion order as part of the language specification as of Python 3.7) in place of `set` (which does not keep an order). As a consequence of the deterministic ordering, every process in a parallel run now has the same identical addends. Earlier this was not always the case, which resulted in random errors.

A minimal reproducible example is not included because the bug appears to be system- and configuration-dependent.