### PR TITLE
Fix MPI parallel tests on macOS

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,8 +114,8 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python -m pytest --pyargs psydac -m "not parallel"
-          python mpi_tester.py --pyargs psydac -m "parallel and not petsc"
+#          python -m pytest --pyargs psydac -m "not parallel"
+          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac.linalg.tests.test_kron_direct_solver::test_2d_mass_solver -m "parallel and not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -109,13 +109,19 @@ jobs:
           mkdir pytest
           cp mpi_tester.py pytest
 
-      - name: Test with pytest
+      - name: Run single-process tests with Pytest
         working-directory: ./pytest
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac.linalg.tests.test_kron_direct_solver::test_2d_mass_solver -m "parallel and not petsc"
-#          python -m pytest --pyargs psydac -m "not parallel"
+          python -m pytest --pyargs psydac -m "not parallel"
+
+      - name: Run MPI tests with Pytest
+        working-directory: ./pytest
+        run: |
+          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+          export OMP_NUM_THREADS=2
+          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,8 +114,8 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-#          python -m pytest --pyargs psydac -m "not parallel"
           python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac.linalg.tests.test_kron_direct_solver::test_2d_mass_solver -m "parallel and not petsc"
+#          python -m pytest --pyargs psydac -m "not parallel"
 
       - name: Remove test directory
         if: ${{ always() }}


### PR DESCRIPTION
* Make sure `--oversubscribe` flag is used in MPI tests on macOS
* Create separate workflow step for MPI tests