### PR TITLE
Speed up unit tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,14 +114,14 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python -m pytest --pyargs psydac -m "not parallel"
+          python -m pytest -n auto --pyargs psydac -m "not parallel"
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" -n auto --pyargs psydac -m "parallel and not petsc"
+          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
           - { isMerge: false, python-version: '3.10' }
         include:
           - os: macos-latest
-            python-version: 3.10
+            python-version: '3.11'
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python -m pytest -n auto --pyargs psydac -m "not parallel"
+          python -m pytest -n 2 --pyargs psydac -m "not parallel"
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
           - { isMerge: false, python-version: '3.10' }
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: 3.11
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
@@ -114,7 +114,7 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python -m pytest -n 2 --pyargs psydac -m "not parallel"
+          python -m pytest -n auto --pyargs psydac -m "not parallel"
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,7 +115,7 @@ jobs:
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
           python -m pytest --pyargs psydac -m "not parallel"
-          python mpi_tester.py --pyargs psydac -m "parallel and not petsc"
+          python mpi_tester.py -n auto --pyargs psydac -m "parallel and not petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,15 +24,15 @@ jobs:
           - { isMerge: false, python-version: '3.10' }
         include:
           - os: macos-latest
-            python-version: '3.11'
+            python-version: '3.10'
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,7 +24,7 @@ jobs:
           - { isMerge: false, python-version: '3.10' }
         include:
           - os: macos-latest
-            python-version: 3.11
+            python-version: 3.10
 
     name: ${{ matrix.os }} / Python ${{ matrix.python-version }}
 

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -17,6 +17,11 @@ from psydac.core.bsplines import (find_span,
                                   basis_integrals,
                                   basis_ders_on_quad_grid)
 
+# The pytest-xdist plugin requires that every worker sees the same parameters
+# in the unit tests. As in this module random parameters are used, here we set
+# the same random seed for all workers.
+np.random.seed(0)
+
 ###############################################################################
 # "True" Functions
 ###############################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     'sympy >= 1.5',
     'matplotlib',
     'pytest >= 4.5',
+    'pytest-xdist >= 1.16',
     'pyyaml >= 5.1',
     'packaging',
     'pyevtk',


### PR DESCRIPTION
- Use all available cores to run our unit tests.
- Distribute single-process tests across cores using the `xdist` plugin of Pytest.
- Fix random seed to make sure that all `xdist` workers see the same random parameters.
- Use Python 3.10 on macOS instead of 3.9