### PR TITLE
Fix GFortran compiler flags on ARM processors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.pyo
 .ipynb_checkpoints/
 *.so
+*.lock
 __psydac__/
+__*pyccel__/
 
 build
 *build*
@@ -18,12 +20,8 @@ doc/_static
 doc/_build
 doc/api-python
 
-
 psydac/core/bsp-f2py*
 psydac/core/bspmodule.c
-psydac/core/*.so
-psydac/core/*.lock
-__*pyccel__
 .env
 
 # pytest directories

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -13,7 +13,7 @@ PSYDAC_BACKEND_PYTHON = {'name': 'python', 'tag':'python', 'openmp':False}
 
 PSYDAC_BACKEND_GPYCCEL  = {'name': 'pyccel',
                        'compiler': 'GNU',
-                       'flags'   : '-O3 -march=native -mtune=native -ffast-math -ffree-line-length-none',
+                       'flags'   : '-O3 -march=native -mtune=native -ffast-math',
                        'folder'  : '__gpyccel__',
                        'tag'     : 'gpyccel',
                        'openmp'  : False}

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -2,6 +2,10 @@
 import platform
 
 
+__all__ = {'PSYDAC_DEFAULT_FOLDER', 'PSYDAC_BACKENDS'}
+
+#==============================================================================
+
 PSYDAC_DEFAULT_FOLDER = {'name':'__psydac__'}
 
 # ... defining PSYDAC backends
@@ -23,9 +27,16 @@ PSYDAC_BACKEND_IPYCCEL  = {'name': 'pyccel',
 
 PSYDAC_BACKEND_PGPYCCEL = {'name': 'pyccel',
                        'compiler': 'PGI',
-                       'flags'   : '-O3',
+                       'flags'   : '-O3 -Munroll',
                        'folder'  : '__pgpyccel__',
                        'tag'     : 'pgpyccel',
+                       'openmp'  : False}
+
+PSYDAC_BACKEND_NVPYCCEL = {'name': 'pyccel',
+                       'compiler': 'nvidia',
+                       'flags'   : '-O3 -Munroll',
+                       'folder'  : '__nvpyccel__',
+                       'tag'     : 'nvpyccel',
                        'openmp'  : False}
 # ...
 
@@ -33,10 +44,13 @@ PSYDAC_BACKEND_PGPYCCEL = {'name': 'pyccel',
 if platform.machine() == 'x86_64':
     PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mavx'
 
+#==============================================================================
+
 # List of all available backends for accelerating Python code
 PSYDAC_BACKENDS = {
-    'python'      : PSYDAC_BACKEND_PYTHON,
-    'pyccel-gcc'  : PSYDAC_BACKEND_GPYCCEL,
-    'pyccel-intel': PSYDAC_BACKEND_IPYCCEL,
-    'pyccel-pgi'  : PSYDAC_BACKEND_PGPYCCEL,
+    'python'       : PSYDAC_BACKEND_PYTHON,
+    'pyccel-gcc'   : PSYDAC_BACKEND_GPYCCEL,
+    'pyccel-intel' : PSYDAC_BACKEND_IPYCCEL,
+    'pyccel-pgi'   : PSYDAC_BACKEND_PGPYCCEL,
+    'pyccel-nvidia': PSYDAC_BACKEND_NVPYCCEL,
 }

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -2,7 +2,7 @@
 import platform
 
 
-__all__ = {'PSYDAC_DEFAULT_FOLDER', 'PSYDAC_BACKENDS'}
+__all__ = ('PSYDAC_DEFAULT_FOLDER', 'PSYDAC_BACKENDS')
 
 #==============================================================================
 

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -1,10 +1,5 @@
 # coding: utf-8
-
-# ... Determine Pyccel version: compiler names changed with version 1.3.0
-import pyccel
-pyccel_version = tuple(map(int, pyccel.__version__.split('.')))
-pyccel_legacy  = pyccel_version < (1, 3, 0)
-# ...
+import platform
 
 
 PSYDAC_DEFAULT_FOLDER = {'name':'__psydac__'}
@@ -12,27 +7,31 @@ PSYDAC_DEFAULT_FOLDER = {'name':'__psydac__'}
 # ... defining PSYDAC backends
 PSYDAC_BACKEND_PYTHON = {'name': 'python', 'tag':'python', 'openmp':False}
 
-PSYDAC_BACKEND_GPYCCEL = {'name':     'pyccel',
-                      'compiler': 'gfortran' if pyccel_legacy else 'GNU',
-                      'flags':    '-O3 -march=native -mtune=native  -mavx -ffast-math -ffree-line-length-none',
-                      'folder': '__gpyccel__',
-                      'tag':'gpyccel',
-                      'openmp':False}
+PSYDAC_BACKEND_GPYCCEL  = {'name': 'pyccel',
+                       'compiler': 'GNU',
+                       'flags'   : '-O3 -march=native -mtune=native -ffast-math -ffree-line-length-none',
+                       'folder'  : '__gpyccel__',
+                       'tag'     : 'gpyccel',
+                       'openmp'  : False}
 
-PSYDAC_BACKEND_IPYCCEL = {'name':     'pyccel',
-                      'compiler': 'ifort' if pyccel_legacy else 'intel',
-                      'flags':    '-O3',
-                      'folder': '__ipyccel__',
-                      'tag':'ipyccel',
-                      'openmp':False}
+PSYDAC_BACKEND_IPYCCEL  = {'name': 'pyccel',
+                       'compiler': 'intel',
+                       'flags'   : '-O3',
+                       'folder'  : '__ipyccel__',
+                       'tag'     :'ipyccel',
+                       'openmp'  : False}
 
-PSYDAC_BACKEND_PGPYCCEL = {'name':     'pyccel',
-                      'compiler': 'pgfortran' if pyccel_legacy else 'PGI',
-                      'flags':    '-O3',
-                      'folder': '__pgpyccel__',
-                       'tag':'pgpyccel',
-                       'openmp':False}
+PSYDAC_BACKEND_PGPYCCEL = {'name': 'pyccel',
+                       'compiler': 'PGI',
+                       'flags'   : '-O3',
+                       'folder'  : '__pgpyccel__',
+                       'tag'     : 'pgpyccel',
+                       'openmp'  : False}
 # ...
+
+# Platform-dependent flags
+if platform.machine() == 'x86_64':
+    PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mavx'
 
 # List of all available backends for accelerating Python code
 PSYDAC_BACKENDS = {

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -5,13 +5,17 @@ import numpy as np
 from random import random
 
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatrix
-from psydac.api.settings import *
+from psydac.api.settings import PSYDAC_BACKENDS
 from psydac.ddm.cart import DomainDecomposition, CartDecomposition
+
+
+# Backends
+PSYDAC_BACKEND_PYTHON  = PSYDAC_BACKENDS['python']     # Pure Python
+PSYDAC_BACKEND_GPYCCEL = PSYDAC_BACKENDS['pyccel-gcc'] # Pyccel w/ Fortran and GCC
 
 # backend to activate multi threading
 PSYDAC_BACKEND_GPYCCEL_WITH_OPENMP           = PSYDAC_BACKEND_GPYCCEL.copy()
 PSYDAC_BACKEND_GPYCCEL_WITH_OPENMP['openmp'] = True
-
 
 # ===============================================================================
 def compute_global_starts_ends(domain_decomposition, npts, pads):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
     # Our packages from PyPi
     'sympde == 0.18.1',
-    'pyccel >= 1.9.2',
+    'pyccel >= 1.11',
     'gelato == 0.12',
 
     # In addition, we depend on mpi4py and h5py (MPI version).


### PR DESCRIPTION
- Give the flag `-mavx` to the GFortran compiler only if the processor's architecture is `x86_64`.
- Clean up the backends settings in `psydac.api.settings`.
- Update `.gitignore`.