### PR TITLE
Improve developers' documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,11 +29,7 @@ jobs:
         sudo apt install graphviz
     - name: Install Python dependencies
       run: |
-        python -m pip install -U sphinx
-        python -m pip install pydata_sphinx_theme
-        python -m pip install numpydoc
-        python -m pip install tomli
-        python -m pip install sphinx-math-dollar
+        python -m pip install -r docs_requirements.txt
     - name: Make the sphinx doc
       run: |
         rm -rf docs/source/modules/STUBDIR

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,6 +33,7 @@ jobs:
         python -m pip install pydata_sphinx_theme
         python -m pip install numpydoc
         python -m pip install tomli
+        python -m pip install sphinx-math-dollar
     - name: Make the sphinx doc
       run: |
         rm -rf docs/source/modules/STUBDIR

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,20 @@ extensions = [
 'sphinx.ext.autodoc',
 'sphinx.ext.autosummary',
 'sphinx.ext.githubpages',
+'sphinx_math_dollar',
+'sphinx.ext.mathjax',
 ]
+
+from docutils.nodes import FixedTextElement, literal,math
+from docutils.nodes import  comment, doctest_block, image, literal_block, math_block, paragraph, pending, raw, rubric, substitution_definition, target
+math_dollar_node_blacklist = (literal,math,doctest_block, image, literal_block,  math_block,  pending,  raw,rubric, substitution_definition,target)
+
+mathjax3_config = {
+  "tex": {
+    "inlineMath": [['\\(', '\\)']],
+    "displayMath": [["\\[", "\\]"]],
+  }
+}
 
 #numpydoc_class_members_toctree = False, nothing changed using this
 numpydoc_show_class_members = False

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Contents
    
    modules
    examples
+   maintenance
 
 .. _note:
 .. note::

--- a/docs/source/maintenance.rst
+++ b/docs/source/maintenance.rst
@@ -1,0 +1,43 @@
+Contributing to the Docs
+========================
+
+We highly encourage anyone working with Psydac to contribute to the library
+by adding new or by improving already existing docstrings.
+
+Psydac's documentation is built using Sphinx and the `numpydoc` extension.
+In particular, this means that this documentation is automatically generated from the library's docstrings, 
+and hence is only as good as the docstrings themselves.
+
+Contributing is as simple as adding docstrings and creating a pull request. 
+Alternatively, you can add your docstring suggestions to an already existing "Improve docstrings CWxx" PR.
+
+This documentation supports the math-dollar-sign in docstrings, which means that you can use LaTeX to write mathematical expressions.
+We have started using this feature in the `linalg.basic` module, and we encourage you to use it as well.
+
+Building the Docs
+-----------------
+
+In order to verify whether your docstrings are correctly formatted, you can build the documentation locally.
+To do so, execute the following commands from the root directory of the repository:
+
+.. code-block::
+
+   # go to psydac/
+   # if on Linux
+   >>> sudo apt install graphviz
+   # if on macOS
+   >>> brew install graphviz
+
+   >>> python -m pip install -r docs_requirements.txt
+
+   # go to psydac/docs/
+   >>> rm -rf source/modules/STUBDIR
+   >>> make clean
+   >>> make html
+
+   # go to psydac/
+   # this script cannot be executed properly from within psydac/docs/
+   >>> python docs/update_links.py
+
+   # Open the documentation on your browser with 
+   >>> open docs/build/html/index.html

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,5 @@
+sphinx
+pydata_sphinx_theme
+numpydoc
+tomli
+sphinx-math-dollar

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -548,7 +548,7 @@ class IdentityOperator(LinearOperator):
 #===============================================================================
 class ScaledLinearOperator(LinearOperator):
     """
-    A linear operator :math:`A` scalar multiplied by a real constant :math:`c`. 
+    A linear operator $A$ scalar multiplied by a real constant $c$. 
     
     """
 
@@ -626,7 +626,7 @@ class ScaledLinearOperator(LinearOperator):
 #===============================================================================
 class SumLinearOperator(LinearOperator):
     """
-    Sum :math:`\sum_{i=1}^n A_i` of linear operators :math:`A_1,\dots,A_n` acting between the same vector spaces V (domain) and W (codomain).
+    Sum $\sum_{i=1}^n A_i$ of linear operators $A_1,\dots,A_n$ acting between the same vector spaces V (domain) and W (codomain).
 
     """
     def __new__(cls, domain, codomain, *args):
@@ -740,7 +740,7 @@ class SumLinearOperator(LinearOperator):
 #===============================================================================
 class ComposedLinearOperator(LinearOperator):
     """
-    Composition :math:`A_n\circ\dots\circ A_1` of two or more linear operators :math:`A_1,\dots,A_n`.
+    Composition $A_n\circ\dots\circ A_1$ of two or more linear operators $A_1,\dots,A_n$.
     
     """
 
@@ -800,8 +800,8 @@ class ComposedLinearOperator(LinearOperator):
     @property
     def multiplicants(self):
         """
-        A tuple :math:`(A_1,\dots,A_n)` containing the multiplicants of the linear operator 
-        :math:`self = A_n\circ\dots\circ A_1`.
+        A tuple $(A_1,\dots,A_n)$ containing the multiplicants of the linear operator 
+        $self = A_n\circ\dots\circ A_1$.
         
         """
         return self._multiplicants
@@ -863,7 +863,7 @@ class ComposedLinearOperator(LinearOperator):
 #===============================================================================
 class PowerLinearOperator(LinearOperator):
     """
-    Power :math:`A^n` of a linear operator :math:`A` for some integer :math:`n\geq 0`.
+    Power $A^n$ of a linear operator $A$ for some integer $n\geq 0$.
     
     """
 
@@ -944,8 +944,8 @@ class PowerLinearOperator(LinearOperator):
 #===============================================================================
 class InverseLinearOperator(LinearOperator):
     """
-    Abstract base class for the (approximate) inverse :math:`A^{-1}` of a
-    square matrix :math:`A`. The result of A_inv.dot(b) is the (approximate) solution x
+    Abstract base class for the (approximate) inverse $A^{-1}$ of a
+    square matrix $A$. The result of A_inv.dot(b) is the (approximate) solution x
     of the linear system A x = b, where x and b belong to the same vector space V.
 
     We assume that the linear system is solved by an iterative method, which
@@ -1004,20 +1004,20 @@ class InverseLinearOperator(LinearOperator):
     @property
     def linop(self):
         """
-        The linear operator :math:`A` of which this object is the inverse :math:`A^{-1}`.
+        The linear operator $A$ of which this object is the inverse $A^{-1}$.
 
-        The linear operator :math:`A` can be modified in place, or replaced entirely
+        The linear operator $A$ can be modified in place, or replaced entirely
         through the setter. A substitution should only be made in cases where
         no other options are viable, as it breaks the one-to-one map between
-        the original linear operator :math:`A` (passed to the constructor) and the
-        current `InverseLinearOperator` object :math:`A^{-1}`. Use with extreme care!
+        the original linear operator $A$ (passed to the constructor) and the
+        current `InverseLinearOperator` object $A^{-1}$. Use with extreme care!
 
         """
         return self._A
     
     @linop.setter
     def linop(self, a):
-        """ Set the linear operator :math:`A` of which this object is the inverse :math:`A^{-1}`. """
+        """ Set the linear operator $A$ of which this object is the inverse $A^{-1}$. """
         assert isinstance(a, LinearOperator)
         assert a.domain is self.domain
         assert a.codomain is self.codomain

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -2,6 +2,10 @@
 #
 # Copyright 2018 Yaman Güçlü, Jalal Lakhlili
 # Copyright 2022 Yaman Güçlü, Said Hadjout, Julian Owezarek
+"""
+provides the fundamental classes for linear algebra operations.
+
+"""
 
 from abc import ABC, abstractmethod
 
@@ -88,7 +92,7 @@ class VectorSpace(ABC):
 #===============================================================================
 class Vector(ABC):
     """
-    Element of a (normed) vector space V.
+    Element of a vector space V.
 
     """
     @property
@@ -206,7 +210,7 @@ class Vector(ABC):
 #===============================================================================
 class LinearOperator(ABC):
     """
-    Linear operator acting between two (normed) vector spaces V (domain)
+    Abstract base class for all linear operators acting between two vector spaces V (domain)
     and W (codomain).
 
     """
@@ -351,6 +355,10 @@ class LinearOperator(ABC):
 
 #===============================================================================
 class ZeroOperator(LinearOperator):
+    """
+    Zero operator mapping any vector from its domain V to the zero vector of its codomain W.
+    
+    """
 
     def __new__(cls, domain, codomain=None):
 
@@ -445,6 +453,11 @@ class ZeroOperator(LinearOperator):
 
 #===============================================================================
 class IdentityOperator(LinearOperator):
+    """
+    Identity operator acting between a vector space V and itself.
+    Useful for example in custom linear operator classes together with the apply_essential_bc method to create projection operators.
+    
+    """
 
     def __new__(cls, domain, codomain=None):
 
@@ -516,12 +529,17 @@ class IdentityOperator(LinearOperator):
 
 #===============================================================================
 class ScaledLinearOperator(LinearOperator):
+    """
+    A linear operator :math:`A` scalar multiplied by a real constant :math:`c`. 
+    
+    """
 
     def __init__(self, domain, codomain, c, A):
 
         assert isinstance(domain, VectorSpace)
         assert isinstance(codomain, VectorSpace)
         assert np.isscalar(c)
+        assert np.isreal(c)
         assert isinstance(A, LinearOperator)
         assert domain   == A.domain
         assert codomain == A.codomain
@@ -588,7 +606,7 @@ class ScaledLinearOperator(LinearOperator):
 #===============================================================================
 class SumLinearOperator(LinearOperator):
     """
-    A sum of linear operatos acting between the same (normed) vector spaces V (domain) and W (codomain).
+    Sum :math:`\sum_{i=1}^n A_i` of linear operators :math:`A_1,\dots,A_n` acting between the same vector spaces V (domain) and W (codomain).
 
     """
     def __new__(cls, domain, codomain, *args):
@@ -704,6 +722,10 @@ class SumLinearOperator(LinearOperator):
 
 #===============================================================================
 class ComposedLinearOperator(LinearOperator):
+    """
+    Composition :math:`A_n\circ\dots\circ A_1` of two or more linear operators :math:`A_1,\dots,A_n`.
+    
+    """
 
     def __init__(self, domain, codomain, *args):
 
@@ -813,6 +835,10 @@ class ComposedLinearOperator(LinearOperator):
 
 #===============================================================================
 class PowerLinearOperator(LinearOperator):
+    """
+    Power :math:`A^n` of a linear operator :math:`A` for some integer :math:`n\geq 0`.
+    
+    """
 
     def __new__(cls, domain, codomain, A, n):
 
@@ -889,10 +915,9 @@ class PowerLinearOperator(LinearOperator):
 #===============================================================================
 class InverseLinearOperator(LinearOperator):
     """
-    Abstract base class for the (approximate) inverse A_inv := A^{-1} of a
-    square matrix A. The result of A_inv.dot(b) is the (approximate) solution x
-    of the linear system A x = b, where x and b belong to the same (normed)
-    vector space V.
+    Abstract base class for the (approximate) inverse :math:`A^{-1}` of a
+    square matrix :math:`A`. The result of A_inv.dot(b) is the (approximate) solution x
+    of the linear system A x = b, where x and b belong to the same vector space V.
 
     We assume that the linear system is solved by an iterative method, which
     needs a first guess `x0` and an exit condition based on `tol` and `maxiter`.
@@ -1029,8 +1054,7 @@ class InverseLinearOperator(LinearOperator):
 #===============================================================================
 class LinearSolver(ABC):
     """
-    Solver for square linear system Ax=b, where x and b belong to (normed)
-    vector space V.
+    Solver for the square linear system Ax=b, where x and b belong to the same vector space V.
 
     """
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,15 @@ dependencies = [
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
 ]
 
+[project.optional-dependencies]
+docs = [
+    'sphinx',
+    'pydata_sphinx_theme',
+    'numpydoc',
+    'tomli',
+    'sphinx-math-dollar'
+]
+
 [project.urls]
 Homepage      = "https://github.com/pyccel/psydac"
 Documentation = "https://pyccel.github.io/psydac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,15 +53,6 @@ dependencies = [
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
 ]
 
-[project.optional-dependencies]
-docs = [
-    'sphinx',
-    'pydata_sphinx_theme',
-    'numpydoc',
-    'tomli',
-    'sphinx-math-dollar'
-]
-
 [project.urls]
 Homepage      = "https://github.com/pyccel/psydac"
 Documentation = "https://pyccel.github.io/psydac"


### PR DESCRIPTION
**The first of potentially weekly(?) PRs improving Psydac's docstrings - any contribution is welcome @pyccel/psydac-dev !**

Files updated so far in this PR:

- `linalg.basic`

**Note:** I have started using :math:\`[insert standard latex code]\` in the docstrings of `linalg.basic` inspired by STRUPHY. Do we want to use this math-mode everywhere?

**To locally view your changes:**

- If not already done, now is a good time to create a venv
- If not already done: (let me know if these are not enough)
   - `sudo apt install graphviz` (Linux) or `brew install graphviz` (macOS)
   - `python -m pip install -r docs_requirements.txt`
- Go to `psydac/docs/`
- Execute `make html` *)
- Open the documentation on your browser with `open build/html/index.html`

*) While not necessary, instead of `make html` only, I like to execute 
- `rm -rf source/modules/STUBDIR`
- `make  clean`
- `make  html`
- `cd ..`
- `python docs/update_links.py` (this file cannot be executed from within `psydac/docs`)
