### PR TITLE
Conversion to PETSc with complex

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          python -m pip install wheel
+          python -m pip install wheel numpy
           PETSC_DIR=$(pwd) pip install --no-deps src/binding/petsc4py
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,8 +106,8 @@ jobs:
       - name: Alternative install of PETSc and petsc4py
         run: |
           export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
-          python -m pip install wheel
-          python -m pip install petsc
+          python -m pip install wheel numpy
+          python -m pip install petsc --verbose
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,7 +107,7 @@ jobs:
         run: |
           export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
           python -m pip install build numpy
-          python -m pip install petsc --verbose
+          python -m pip install petsc --verbose --no-binary=petsc
           python -m pip list
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py/setup.py
+          PETSC_ARCH=linux-gnu-complex-64 PETSC_DIR=~/petsc-main python -m pip install src/binding/petsc4py/setup.py
 #      - name: Alternative install of PETSc and petsc4py
 #        run: |
 #          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Alternative install of PETSc and petsc4py
         run: |
           export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
-          python -m pip install wheel numpy
+          python -m pip install build numpy
           python -m pip install petsc --verbose
           python -m pip list
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,11 +82,12 @@ jobs:
       - name: Determine directory of parallel HDF5 library
         run: |
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            export HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+            HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            export HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
+            HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi
           echo $HDF5_DIR
+          echo "HDF5_DIR=$HDF5_DIR" >> $GITHUB_ENV
 
       - name: Download a specific release of PETSc
         run: |
@@ -99,6 +100,8 @@ jobs:
           export PETSC_ARCH=petsc-cmplx
           ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
           make all check
+          echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
+          echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
 
       - name: Install petsc4py
         working-directory: ./petsc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,13 +100,19 @@ jobs:
         working-directory: ./petsc
         run: |
           ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-          make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug all check
+          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
+            export PETSC_ARCH=arch-linux-c-debug
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            export PETSC_ARCH=arch-darwin-c-debug
+          fi
+          echo $PETSC_ARCH          
+          make PETSC_DIR=$(pwd) $PETSC_ARCH all check
 
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
           python -m pip install wheel Cython numpy
-          PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug pip install src/binding/petsc4py
+          PETSC_DIR=$(pwd) PETSC_ARCH=$PETSC_ARCH pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
             export PETSC_ARCH=arch-darwin-c-debug
           fi
           echo $PETSC_ARCH          
-          make PETSC_DIR=$(pwd) $PETSC_ARCH all check
+          make PETSC_DIR=$(pwd) PETSC_ARCH=$PETSC_ARCH all check
 
       - name: Install petsc4py
         working-directory: ./petsc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,6 +104,7 @@ jobs:
 #          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 
       - name: Install petsc4py
+        working-directory: ./petsc
         run: |
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py
 #      - name: Alternative install of PETSc and petsc4py

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Alternative install of PETSc and petsc4py
         run: |
           export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
+          python -m pip install wheel
           python -m pip install petsc
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,21 +100,13 @@ jobs:
         working-directory: ./petsc
         run: |
           ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-          make all check
-#          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
+          make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug all check
 
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
           python -m pip install wheel Cython numpy
-          PETSC_DIR=$(pwd) PETSC_ARCH=linux-gnu-complex-64 pip install src/binding/petsc4py
-
-#      - name: Alternative install of PETSc and petsc4py
-#        run: |
-#          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
-#          python -m pip install build numpy
-#          python -m pip install petsc --verbose --no-binary=petsc
-#          python -m pip list
+          PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |
@@ -137,19 +129,19 @@ jobs:
           mkdir pytest
           cp mpi_tester.py pytest
 
-#      - name: Run single-process tests with Pytest
-#        working-directory: ./pytest
-#        run: |
-#          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-#          export OMP_NUM_THREADS=2
-#          python -m pytest -n auto --pyargs psydac -m "not parallel and not petsc"
+      - name: Run single-process tests with Pytest
+        working-directory: ./pytest
+        run: |
+          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+          export OMP_NUM_THREADS=2
+          python -m pytest -n auto --pyargs psydac -m "not parallel and not petsc"
 
-#      - name: Run MPI tests with Pytest
-#        working-directory: ./pytest
-#        run: |
-#          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-#          export OMP_NUM_THREADS=2
-#          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
+      - name: Run MPI tests with Pytest
+        working-directory: ./pytest
+        run: |
+          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+          export OMP_NUM_THREADS=2
+          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
 
       - name: Run single-process PETSc tests with Pytest
         working-directory: ./pytest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,9 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          PETSC_ARCH=linux-gnu-complex-64 PETSC_DIR=~/petsc-main python -m pip install src/binding/petsc4py/setup.py
+          python -m pip install wheel Cython numpy
+          PETSC_DIR=$(pwd) PETSC_ARCH=linux-gnu-complex-64 pip install src/binding/petsc4py
+
 #      - name: Alternative install of PETSc and petsc4py
 #        run: |
 #          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,27 +88,29 @@ jobs:
           fi
           echo $HDF5_DIR
 
-#      - name: Download a specific release of PETSc
-#        run: |
-#          PETSC_VERSION="v3.20.5"
-#          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
-#          unzip petsc-$PETSC_VERSION.zip
-#          rm petsc-$PETSC_VERSION.zip
-#          mv petsc-$PETSC_VERSION petsc
+      - name: Download a specific release of PETSc
+        run: |
+          PETSC_VERSION="v3.20.5"
+          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
+          unzip petsc-$PETSC_VERSION.zip
+          rm petsc-$PETSC_VERSION.zip
+          mv petsc-$PETSC_VERSION petsc
 
-#      - name: Install PETSc and petsc4py with complex support, and test it
-#        working-directory: ./petsc
-#        run: |
-#          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1
-#          make all check
+      - name: Install PETSc with complex support, and test it
+        working-directory: ./petsc
+        run: |
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
+          make all check
 #          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 
-      - name: Alternative install of PETSc and petsc4py
-        run: |
-          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
-          python -m pip install build numpy
-          python -m pip install petsc --verbose --no-binary=petsc
-          python -m pip list
+      - name: Install petsc4py
+v         PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py
+#      - name: Alternative install of PETSc and petsc4py
+#        run: |
+#          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
+#          python -m pip install build numpy
+#          python -m pip install petsc --verbose --no-binary=petsc
+#          python -m pip list
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,8 +105,8 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          python -m pip install wheel Cython numpy
-          PETSC_DIR=$(pwd) pip install src/binding/petsc4py
+          python -m pip install wheel
+          PETSC_DIR=$(pwd) pip install --no-deps src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -133,19 +133,19 @@ v         PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/pet
           mkdir pytest
           cp mpi_tester.py pytest
 
-      - name: Run single-process tests with Pytest
-        working-directory: ./pytest
-        run: |
-          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-          export OMP_NUM_THREADS=2
-          python -m pytest -n auto --pyargs psydac -m "not parallel and not petsc"
+#      - name: Run single-process tests with Pytest
+#        working-directory: ./pytest
+#        run: |
+#          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+#          export OMP_NUM_THREADS=2
+#          python -m pytest -n auto --pyargs psydac -m "not parallel and not petsc"
 
-      - name: Run MPI tests with Pytest
-        working-directory: ./pytest
-        run: |
-          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
-          export OMP_NUM_THREADS=2
-          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
+#      - name: Run MPI tests with Pytest
+#        working-directory: ./pytest
+#        run: |
+#          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+#          export OMP_NUM_THREADS=2
+#          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
 
       - name: Run single-process PETSc tests with Pytest
         working-directory: ./pytest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install PETSc and petsc4py with complex support, and test it
         working-directory: ./petsc
         run: |
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --with-petsc4py=1 --with-64-bit-indices=1
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1
           make all check
           python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,20 +88,25 @@ jobs:
           fi
           echo $HDF5_DIR
 
-      - name: Download a specific release of PETSc
-        run: |
-          PETSC_VERSION="v3.20.5"
-          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
-          unzip petsc-$PETSC_VERSION.zip
-          rm petsc-$PETSC_VERSION.zip
-          mv petsc-$PETSC_VERSION petsc
+#      - name: Download a specific release of PETSc
+#        run: |
+#          PETSC_VERSION="v3.20.5"
+#          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
+#          unzip petsc-$PETSC_VERSION.zip
+#          rm petsc-$PETSC_VERSION.zip
+#          mv petsc-$PETSC_VERSION petsc
 
-      - name: Install PETSc and petsc4py with complex support, and test it
-        working-directory: ./petsc
+#      - name: Install PETSc and petsc4py with complex support, and test it
+#        working-directory: ./petsc
+#        run: |
+#          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1
+#          make all check
+#          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
+
+      - name: Alternative install of PETSc and petsc4py
         run: |
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1
-          make all check
-          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
+          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
+          python -m pip install petsc
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,20 +95,18 @@ jobs:
       - name: Install PETSc with complex support, and test it
         working-directory: ./petsc
         run: |
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            export PETSC_ARCH=arch-linux-c-debug
-          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            export PETSC_ARCH=arch-darwin-c-debug
-          fi
-          echo $PETSC_ARCH          
-          make PETSC_DIR=$(pwd) PETSC_ARCH=$PETSC_ARCH all check
+          export PETSC_DIR=$(pwd)
+          export PETSC_ARCH=petsc-cmplx
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
+          make all check
 
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
+          echo PETSC_DIR  : $PETSC_DIR
+          echo PETSC_ARCH : $PETSC_ARCH 
           python -m pip install wheel Cython numpy
-          PETSC_DIR=$(pwd) PETSC_ARCH=$PETSC_ARCH pip install src/binding/petsc4py
+          pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
-          python -m pytest -n auto --pyargs psydac -m "not parallel"
+          python -m pytest -n auto --pyargs psydac -m "not parallel and not petsc"
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
@@ -142,6 +142,20 @@ jobs:
           export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
           export OMP_NUM_THREADS=2
           python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and not petsc"
+
+      - name: Run single-process PETSc tests with Pytest
+        working-directory: ./pytest
+        run: |
+          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+          export OMP_NUM_THREADS=2
+          python -m pytest -n auto --pyargs psydac -m "not parallel and petsc"
+
+      - name: Run MPI PETSc tests with Pytest
+        working-directory: ./pytest
+        run: |
+          export PSYDAC_MESH_DIR=$GITHUB_WORKSPACE/mesh
+          export OMP_NUM_THREADS=2
+          python mpi_tester.py --mpirun="mpiexec -n 4 ${MPI_OPTS}" --pyargs psydac -m "parallel and petsc"
 
       - name: Remove test directory
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,11 +105,9 @@ jobs:
 
       - name: Install petsc4py
         working-directory: ./petsc
-        run: |
-          echo PETSC_DIR  : $PETSC_DIR
-          echo PETSC_ARCH : $PETSC_ARCH 
+        run: | 
           python -m pip install wheel Cython numpy
-          pip install src/binding/petsc4py
+          python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |
@@ -120,7 +118,7 @@ jobs:
 
       - name: Check h5py installation
         run: |
-            python3 -c "from h5py import File; print(File)"
+            python -c "from h5py import File; print(File)"
 
       - name: Install project
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -104,7 +104,8 @@ jobs:
 #          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 
       - name: Install petsc4py
-v         PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py
+        run: |
+          PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py
 #      - name: Alternative install of PETSc and petsc4py
 #        run: |
 #          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -108,6 +108,7 @@ jobs:
           export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"
           python -m pip install wheel numpy
           python -m pip install petsc --verbose
+          python -m pip list
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py
+          PETSC_ARCH=linux-gnu-complex-64 python -m pip install /src/binding/petsc4py/setup.py
 #      - name: Alternative install of PETSc and petsc4py
 #        run: |
 #          export PETSC_CONFIGURE_OPTIONS="--with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 --with-petsc4py=1 --with-64-bit-indices=1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,11 +90,7 @@ jobs:
 
       - name: Download a specific release of PETSc
         run: |
-          PETSC_VERSION="v3.20.5"
-          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
-          unzip petsc-$PETSC_VERSION.zip
-          rm petsc-$PETSC_VERSION.zip
-          mv petsc-$PETSC_VERSION petsc
+          git clone --depth 1 --branch v3.20.5 https://gitlab.com/petsc/petsc.git
 
       - name: Install PETSc with complex support, and test it
         working-directory: ./petsc

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,17 +96,12 @@ jobs:
           rm petsc-$PETSC_VERSION.zip
           mv petsc-$PETSC_VERSION petsc
 
-      - name: Install PETSc with complex support, and test it
+      - name: Install PETSc and petsc4py with complex support, and test it
         working-directory: ./petsc
         run: |
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --with-petsc4py=1 --with-64-bit-indices=1
           make all check
-
-      - name: Install petsc4py
-        working-directory: ./petsc
-        run: |
-          python -m pip install wheel numpy
-          PETSC_DIR=$(pwd) pip install --no-deps src/binding/petsc4py
+          python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,6 +105,7 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
+          python -m pip install Cython
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,6 +96,7 @@ jobs:
           cd petsc-main
           ./configure --with-scalar-type=complex
           make all check
+          python -m pip install Cython
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,9 +105,8 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc
         run: |
-          python -m pip install Cython
-          export PETSC_DIR=$(pwd)
-          PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
+          python -m pip install wheel Cython numpy
+          PETSC_DIR=$(pwd) pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,8 +100,7 @@ jobs:
       - name: Install petsc4py
         working-directory: ./petsc-main
         run: |
-          python -m pip install Cython
-          PETSC_ARCH=linux-gnu-complex-64 python -m pip install --no-deps src/binding/petsc4py
+          PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,16 +88,22 @@ jobs:
           fi
           echo $HDF5_DIR
 
-      - name: Install PETSc with complex configuration
+      - name: Install PETSc with support for complex numbers
         run: |
           wget https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip
           unzip ./"petsc-main.zip"
           rm ./"petsc-main.zip"
           cd petsc-main
           ./configure --with-scalar-type=complex
-          make all check
+          make all
+
+      - name: Test PETSc installation 
+          make check
+
+      - name: Install petsc4py
           python -m pip install Cython
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install --no-deps src/binding/petsc4py
+          cd -
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,9 +96,7 @@ jobs:
           cd petsc-main
           ./configure --with-scalar-type=complex
           make all check
-          cd src/binding/petsc4py
-          PETSC_ARCH=linux-gnu-complex-64
-          pip3 install .
+          pip install petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Install PETSc with complex support, and test it
         run: |
           wget https://gitlab.com/petsc/petsc/-/archive/v3.20.5/petsc-v3.20.5.zip -O petsc.zip
-          unzip ./"petsc.zip" -j petsc
+          unzip ./"petsc.zip"
           rm ./"petsc.zip"
           cd petsc
           ./configure --with-scalar-type=complex --with-fortran-bindings=0

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,8 +96,7 @@ jobs:
           cd petsc-main
           ./configure --with-scalar-type=complex
           make all check
-          cd ..
-          pip install petsc4py
+          PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,18 @@ jobs:
           fi
           echo $HDF5_DIR
 
+      - name: Install PETSc with complex configuration
+        run: |
+          wget https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip
+          unzip ./"petsc-main.zip"
+          rm ./"petsc-main.zip"
+          cd petsc-main
+          ./configure --with-scalar-type=complex
+          make all check
+          cd src/binding/petsc4py
+          PETSC_ARCH=linux-gnu-complex-64
+          pip3 install .
+
       - name: Install Python dependencies
         run: |
           export CC="mpicc" HDF5_MPI="ON"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,7 +97,7 @@ jobs:
           ./configure --with-scalar-type=complex
           make all check
           python -m pip install Cython
-          PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
+          PETSC_ARCH=linux-gnu-complex-64 python -m pip install --no-deps src/binding/petsc4py
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,18 +88,14 @@ jobs:
           fi
           echo $HDF5_DIR
 
-      - name: Install PETSc with support for complex numbers
+      - name: Install PETSc with complex support, and test it
         run: |
           wget https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip
           unzip ./"petsc-main.zip"
           rm ./"petsc-main.zip"
           cd petsc-main
           ./configure --with-scalar-type=complex
-          make all
-
-      - name: Test PETSc installation
-        run: |
-          make check
+          make all check
 
       - name: Install petsc4py
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,10 +98,10 @@ jobs:
           make all check
 
       - name: Install petsc4py
+        working-directory: ./petsc-main
         run: |
           python -m pip install Cython
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install --no-deps src/binding/petsc4py
-          cd -
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -106,6 +106,7 @@ jobs:
         working-directory: ./petsc
         run: |
           python -m pip install Cython
+          export PETSC_DIR=$(pwd)
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -96,6 +96,7 @@ jobs:
           cd petsc-main
           ./configure --with-scalar-type=complex
           make all check
+          cd ..
           pip install petsc4py
 
       - name: Install Python dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -90,15 +90,15 @@ jobs:
 
       - name: Install PETSc with complex support, and test it
         run: |
-          wget https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip
-          unzip ./"petsc-main.zip"
-          rm ./"petsc-main.zip"
-          cd petsc-main
+          wget https://gitlab.com/petsc/petsc/-/archive/v3.20.5/petsc-v3.20.5.zip -O petsc.zip
+          unzip ./"petsc.zip" -j petsc
+          rm ./"petsc.zip"
+          cd petsc
           ./configure --with-scalar-type=complex --with-fortran-bindings=0
           make all check
 
       - name: Install petsc4py
-        working-directory: ./petsc-main
+        working-directory: ./petsc
         run: |
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install src/binding/petsc4py
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -94,7 +94,7 @@ jobs:
           unzip ./"petsc-main.zip"
           rm ./"petsc-main.zip"
           cd petsc-main
-          ./configure --with-scalar-type=complex
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0
           make all check
 
       - name: Install petsc4py

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,10 +97,12 @@ jobs:
           ./configure --with-scalar-type=complex
           make all
 
-      - name: Test PETSc installation 
+      - name: Test PETSc installation
+        run: |
           make check
 
       - name: Install petsc4py
+        run: |
           python -m pip install Cython
           PETSC_ARCH=linux-gnu-complex-64 python -m pip install --no-deps src/binding/petsc4py
           cd -

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,6 +98,7 @@ jobs:
 
       - name: Install PETSc with complex support, and test it
         working-directory: ./petsc
+        run: |
           ./configure --with-scalar-type=complex --with-fortran-bindings=0
           make all check
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,12 +88,16 @@ jobs:
           fi
           echo $HDF5_DIR
 
-      - name: Install PETSc with complex support, and test it
+      - name: Download a specific release of PETSc
         run: |
-          wget https://gitlab.com/petsc/petsc/-/archive/v3.20.5/petsc-v3.20.5.zip -O petsc.zip
-          unzip ./"petsc.zip"
-          rm ./"petsc.zip"
-          cd petsc
+          PETSC_VERSION="v3.20.5"
+          wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
+          unzip petsc-$PETSC_VERSION.zip
+          rm petsc-$PETSC_VERSION.zip
+          mv petsc-$PETSC_VERSION petsc
+
+      - name: Install PETSc with complex support, and test it
+        working-directory: ./petsc
           ./configure --with-scalar-type=complex --with-fortran-bindings=0
           make all check
 

--- a/README.md
+++ b/README.md
@@ -162,10 +162,18 @@ In the case of PETSc, it is sufficient to remove the cloned source directory giv
 
 ## Running tests
 
+Let `<PSYDAC-PATH>` be the installation directory of Psydac.
+In order to run all serial and parallel tests which do not use PETSc, just type:
 ```bash
-export PSYDAC_MESH_DIR=/path/to/psydac/mesh/
-python3 -m pytest --pyargs psydac -m "not parallel"
-python3 /path/to/psydac/mpi_tester.py --pyargs psydac -m "parallel"
+export PSYDAC_MESH_DIR=<PSYDAC-PATH>/mesh/
+python3 -m pytest --pyargs psydac -m "not parallel and not petsc"
+python3 <PSYDAC-PATH>/mpi_tester.py --pyargs psydac -m "parallel and not petsc"
+```
+
+If PETSc and petsc4py were installed, some additional tests can be run:
+```bash
+python3 -m pytest --pyargs psydac -m "not parallel and petsc"
+python3 <PSYDAC-PATH>/mpi_tester.py --pyargs psydac -m "parallel and petsc"
 ```
 
 ## Speeding up **Psydac**'s core

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 -   [Requirements](#requirements)
 -   [Python setup and project download](#python-setup-and-project-download)
 -   [Installing the library](#installing-the-library)
+-   [Optional PETSc installation](#optional-petsc-installation)
 -   [Uninstall](#uninstall)
 -   [Running tests](#running-tests)
 -   [Speeding up Psydac's core](#speeding-up-psydacs-core)
@@ -39,21 +40,6 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
-In order to install `PETSc`, download it from [source](https://gitlab.com/petsc/petsc) and specify a configuration for complex numbers:
-```sh
-PETSC_VERSION="v3.20.5"
-wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
-unzip petsc-$PETSC_VERSION.zip
-rm petsc-$PETSC_VERSION.zip
-mv petsc-$PETSC_VERSION petsc
-./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-make PETSC_DIR=$(pwd) PETSC_ARCH=arch-linux-c-debug all check
-```
-Once `PETSc` is installed, install the module `petsc4py` contained within the `PETSc` library:
-```sh
-python -m pip install wheel Cython numpy
-PETSC_DIR=$(pwd) PETSC_ARCH=arch-linux-c-debug pip install src/binding/petsc4py
-```
 
 ### macOS
 
@@ -67,21 +53,6 @@ brew install lapack
 brew install open-mpi
 brew install libomp
 brew install hdf5-mpi
-```
-In order to install `PETSc`, download it from [source](https://gitlab.com/petsc/petsc) and specify a configuration for complex numbers:
-```sh
-PETSC_VERSION="v3.20.5"
-wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
-unzip petsc-$PETSC_VERSION.zip
-rm petsc-$PETSC_VERSION.zip
-mv petsc-$PETSC_VERSION petsc
-./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-make PETSC_DIR=$(pwd) PETSC_ARCH=arch-darwin-c-debug all check
-```
-Once `PETSc` is installed, install the module `petsc4py` contained within the `PETSc` library:
-```sh
-python -m pip install wheel Cython numpy
-PETSC_DIR=$(pwd) PETSC_ARCH=arch-darwin-c-debug pip install src/binding/petsc4py
 ```
 
 ### Other operating systems
@@ -146,12 +117,48 @@ At this point the Psydac library may be installed in **standard mode**, which co
     python3 -m pip install --editable .
     ```
 
+## Optional PETSc installation
+
+Although Psydac provides several iterative linear solvers which work with our native matrices and vectors, it is often useful to access a dedicated library like [PETSc](https://petsc.org). To this end, our matrices and vectors have the method `topetsc()`, which converts them to the corresponding `petsc4py` objects.
+(`petsc4py` is a Python package which provides Python bindings to PETSc.) After solving the linear system with a PETSc solver, the function `petsc_to_psydac` allows converting the solution vector back to the Psydac format.
+
+In order to use these additional feature, PETSc and petsc4py must be installed as follows.
+First, we download the latest release of PETSc from its [official Git repository](https://gitlab.com/petsc/petsc):
+```sh
+git clone --depth 1 --branch v3.20.5 https://gitlab.com/petsc/petsc.git
+```
+Next, we specify a configuration for complex numbers, and install PETSc in a local directory:
+```sh
+cd petsc
+
+export PETSC_DIR=$(pwd)
+export PETSC_ARCH=petsc-cmplx
+
+./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1
+
+make all check
+
+cd -
+```
+Finally, we install the Python package `petsc4py` which is included in the `PETSc` source distribution:
+```sh
+python3 -m pip install wheel Cython numpy
+python3 -m pip install petsc/src/binding/petsc4py
+```
+
 ## Uninstall
 
 -   **Whichever the install mode**:
     ```bash
     python3 -m pip uninstall psydac
     ```
+-   **If PETSc was installed**:
+    ```bash
+    python3 -m pip uninstall petsc4py
+    ```
+
+The non-Python dependencies can be uninstalled manually using the package manager.
+In the case of PETSc, it is sufficient to remove the cloned source directory given that the installation has been performed locally.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -39,17 +39,21 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
-`PETSc` has to be installed from source with configuration for complex numbers:
+In order to install `PETSc`, download it from [source](https://gitlab.com/petsc/petsc) and specify a configuration for complex numbers:
 ```sh
+PETSC_VERSION="v3.20.5"
+wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
+unzip petsc-$PETSC_VERSION.zip
+rm petsc-$PETSC_VERSION.zip
+mv petsc-$PETSC_VERSION petsc
 ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
-make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug all check
+make PETSC_DIR=$(pwd) PETSC_ARCH=arch-linux-c-debug all check
 ```
-Lastly, `petsc4py` has to be installed:
+Once `PETSc` is installed, install the module `petsc4py` contained within the `PETSc` library:
 ```sh
 python -m pip install wheel Cython numpy
-PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug pip install src/binding/petsc4py
+PETSC_DIR=$(pwd) PETSC_ARCH=arch-linux-c-debug pip install src/binding/petsc4py
 ```
-This installation is also valid for macOS.
 
 ### macOS
 
@@ -63,6 +67,21 @@ brew install lapack
 brew install open-mpi
 brew install libomp
 brew install hdf5-mpi
+```
+In order to install `PETSc`, download it from [source](https://gitlab.com/petsc/petsc) and specify a configuration for complex numbers:
+```sh
+PETSC_VERSION="v3.20.5"
+wget https://gitlab.com/petsc/petsc/-/archive/$PETSC_VERSION/petsc-$PETSC_VERSION.zip
+unzip petsc-$PETSC_VERSION.zip
+rm petsc-$PETSC_VERSION.zip
+mv petsc-$PETSC_VERSION petsc
+./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
+make PETSC_DIR=$(pwd) PETSC_ARCH=arch-darwin-c-debug all check
+```
+Once `PETSc` is installed, install the module `petsc4py` contained within the `PETSc` library:
+```sh
+python -m pip install wheel Cython numpy
+PETSC_DIR=$(pwd) PETSC_ARCH=arch-darwin-c-debug pip install src/binding/petsc4py
 ```
 
 ### Other operating systems

--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
-To install `PETSc` with configuration for complex numbers and 64-bit indices, download [source code](https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip). After extracting the compressed file, move into folder and run:
+`PETSc` has to be installed from source with configuration for complex numbers:
 ```sh
-./configure --with-scalar-type=complex --with-fortran-bindings=0 --with-petsc4py=1 --with-64-bit-indices=1
-make all check
+./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1 
+make PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug all check
 ```
-Lastly, the installation path of `petsc4py` has to be added to `PYTHONPATH`:
+Lastly, `petsc4py` has to be installed:
 ```sh
-python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
+python -m pip install wheel Cython numpy
+PETSC_DIR=$(pwd) PETSC_ARCH=petsc-complex-c-debug pip install src/binding/petsc4py
 ```
+This installation is also valid for macOS.
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
-To install `PETSc` with configuration for complex numbers, download [source code](https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip). After extracting the compressed file, move into folder and run:
+To install `PETSc` with configuration for complex numbers and 64-bit indices, download [source code](https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip). After extracting the compressed file, move into folder and run:
 ```sh
-./configure --with-scalar-type=complex
+./configure --with-scalar-type=complex --with-fortran-bindings=0 --with-petsc4py=1 --with-64-bit-indices=1
 make all check
-PETSC_ARCH=linux-gnu-complex-64 PETSC_DIR=~/petsc-main pip install src/binding/petsc4py/setup.py
+```
+Lastly, the installation path of `petsc4py` has to be added to `PYTHONPATH`:
+```sh
+python3 -c "import sys, os; sys.path.append(os.getcwd() + '/arch-linux-c-debug/lib')"
 ```
 
 ### macOS

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
+To install `PETSc` with configuration for complex numbers, download [source code](https://gitlab.com/petsc/petsc). After extracting the compressed file, move into folder and run:
+```sh
+./configure --with-scalar-type=complex
+make all check
+cd src/binding/petsc4py
+PETSC_ARCH=linux-gnu-complex-64
+pip3 install .
+```
 
 ### macOS
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo apt install libopenmpi-dev openmpi-bin
 sudo apt install libomp-dev libomp5
 sudo apt install libhdf5-openmpi-dev
 ```
-To install `PETSc` with configuration for complex numbers, download [source code](https://gitlab.com/petsc/petsc). After extracting the compressed file, move into folder and run:
+To install `PETSc` with configuration for complex numbers, download [source code](https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip). After extracting the compressed file, move into folder and run:
 ```sh
 ./configure --with-scalar-type=complex
 make all check

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ To install `PETSc` with configuration for complex numbers, download [source code
 ```sh
 ./configure --with-scalar-type=complex
 make all check
-cd src/binding/petsc4py
-PETSC_ARCH=linux-gnu-complex-64
-pip3 install .
+PETSC_ARCH=linux-gnu-complex-64 PETSC_DIR=~/petsc-main pip install src/binding/petsc4py/setup.py
 ```
 
 ### macOS

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -284,13 +284,13 @@ def run_stokes_2d_dir_petsc(domain, f, ue, pe, *, homogeneous, ncells, degree):
         ksp.setOperators(A1)
         x1 = b1.duplicate()
         ksp.solve(b1, x1)
-        print('Boundary solution with petsc4py: success = {}'.format(ksp.converged))
+        print('Boundary solution with petsc4py: success = {}'.format(ksp.is_converged))
 
         ksp.setOperators(A0)
         b0 = b0 - A0*x1
         x0 = b0.duplicate()
         ksp.solve(b0, x0)
-        print('Interior solution with petsc4py: success = {}'.format(ksp.converged))
+        print('Interior solution with petsc4py: success = {}'.format(ksp.is_converged))
 
         # Solution is sum of boundary and interior contributions
         x = x0 + x1
@@ -300,7 +300,7 @@ def run_stokes_2d_dir_petsc(domain, f, ue, pe, *, homogeneous, ncells, degree):
         x = b0.duplicate()
         ksp.solve(b0, x)
 
-        print('Solution with petsc4py: success = {}'.format(ksp.converged))
+        print('Solution with petsc4py: success = {}'.format(ksp.is_converged))
 
 
     x = petsc_to_psydac(x, Xh.vector_space)

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -1233,7 +1233,7 @@ def test_block_linear_operator_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P
 
     W = BlockVectorSpace(V, V)
 
-    # Construct a BlockLinearOperator object containing M1, M2, M, using 3 ways
+    # Construct a BlockLinearOperator object containing M1, M2, M3: 
     #     |M1  M2|
     # L = |      |
     #     |M3  0 |
@@ -1242,6 +1242,7 @@ def test_block_linear_operator_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P
 
     L = BlockLinearOperator( W, W, blocks=dict_blocks )
 
+    print('hola')
     Lp = L.topetsc()
     indptr, indices, data = Lp.getValuesCSR()
     if dtype == float:
@@ -1250,6 +1251,7 @@ def test_block_linear_operator_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P
     L = L.tosparse().tocsr()
 
     assert (L-Lp).data.size == 0
+test_block_linear_operator_2d_parallel_topetsc(complex, 16,12,1,1,False,True)
 
 #===============================================================================
 @pytest.mark.parametrize( 'dtype', [float, complex] )

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -787,6 +787,7 @@ def test_block_2d_serial_array_to_psydac( dtype, n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'p2', [1, 3] )
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True] )
+@pytest.mark.petsc
 
 def test_block_vector_2d_serial_topetsc( dtype, n1, n2, p1, p2, P1, P2 ):
     #Define a factor for the data
@@ -844,6 +845,7 @@ def test_block_vector_2d_serial_topetsc( dtype, n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'p2', [1, 2] )
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True] )
+@pytest.mark.petsc
 
 def test_block_linear_operator_2d_serial_topetsc( dtype, n1, n2, p1, p2, P1, P2  ):
     # set seed for reproducibility
@@ -1130,6 +1132,7 @@ def test_block_linear_operator_parallel_dot( dtype, n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True] )
 @pytest.mark.parallel
+@pytest.mark.petsc
 
 def test_block_vector_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P2 ):
     #Define a factor for the data
@@ -1191,6 +1194,7 @@ def test_block_vector_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P2 ):
 @pytest.mark.parametrize( 'P1', [True, False] )
 @pytest.mark.parametrize( 'P2', [True] )
 @pytest.mark.parallel
+@pytest.mark.petsc
 
 def test_block_linear_operator_2d_parallel_topetsc( dtype, n1, n2, p1, p2, P1, P2):
     # set seed for reproducibility

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -24,9 +24,12 @@ def compute_global_starts_ends(domain_decomposition, npts, pads):
     global_starts = [None] * ndims
     global_ends = [None] * ndims
 
+    print('\ndomain_decomposition.global_element_starts', domain_decomposition.global_element_starts)
+    print('domain_decomposition.global_element_ends', domain_decomposition.global_element_ends)
+
     for axis in range(ndims):
         ee = domain_decomposition.global_element_ends[axis]
-
+        
         global_ends[axis] = ee.copy()
         global_ends[axis][-1] = npts[axis] - 1
         global_starts[axis] = np.array([0] + (global_ends[axis][:-1] + 1).tolist())
@@ -598,11 +601,12 @@ def test_stencil_matrix_2d_serial_topetsc( dtype, n1, n2, p1, p2, s1, s2, P1, P2
     indptr, indices, data = Mp.getValuesCSR()
     if dtype == float:
         data = data.real #PETSc with installation complex configuration only handles complex dtype
-    Mp = csr_matrix((data, indices, indptr), shape=Mp.size)
 
     M = M.tosparse().tocsr()
 
-    assert (M-Mp).data.size == 0
+    assert (indptr == M.indptr).all()
+    assert (indices == M.indices).all()
+    assert np.array_equal(data, M.data)
 
 # ===============================================================================
     
@@ -626,22 +630,24 @@ def test_mass_matrix_2d_serial_topetsc(n1, n2, p1, p2, P1, P2):
     u = element_of(V, name='u')
     v = element_of(V, name='v')    
 
-    a1 = BilinearForm((u, v), integral(domain, u * v))
+    a = BilinearForm((u, v), integral(domain, u * v))
     domain_h = discretize(domain, ncells=[n1,n2], periodic=[P1,P2])
-    Vh = discretize(V, domain_h, degree=[p1,p2])
-    a1h = discretize(a1, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
-    M1 = a1h.assemble()
+    V_h = discretize(V, domain_h, degree=[p1,p2])
+    a_h = discretize(a, domain_h, [V_h, V_h], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
+    M = a_h.assemble()
 
     # Convert stencil matrix to PETSc.Mat
-    Mp = M1.topetsc()
+    Mp = M.topetsc()
+
     # Convert PETSc.Mat to sparse CSR matrix   
     indptr, indices, data = Mp.getValuesCSR()
     data = data.real #PETSc with installation complex configuration only handles complex dtype
-    Mp = csr_matrix((data, indices, indptr), shape=Mp.size)
 
-    M1 = M1.tosparse().tocsr()
+    M = M.tosparse().tocsr()
 
-    assert (M1-Mp).data.size == 0
+    assert (indptr == M.indptr).all()
+    assert (indices == M.indices).all()
+    assert np.array_equal(data, M.data)
 
 # ===============================================================================
 
@@ -2719,49 +2725,127 @@ def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1,
             for k2 in range(-p2, p2 + 1):
                 nonzero_values[k1, k2] = 10 * k1 + k2 + 7
 
-    # Create domain decomposition
+    # Create domain decomposition: decomposes the coefficients
     D = DomainDecomposition([n1, n2], periods=[P1, P2], comm=MPI.COMM_WORLD)
 
-    # Partition the points
-    npts = [n1, n2]
+    # Partition the coefficients
+    npts = [n1, n2] #Number of coefficients
     global_starts, global_ends = compute_global_starts_ends(D, npts, [p1, p2])
+    print('\nglobal_starts', global_starts)
+    print('global_ends', global_ends)
 
     cart = CartDecomposition(D, npts, global_starts, global_ends, pads=[p1, p2], shifts=[sh1, sh2])
 
     # Create vector space and stencil matrix
     V = StencilVectorSpace(cart, dtype=dtype)
     M = StencilMatrix(V, V)
+    print('M.shape',M.shape)
 
     # Fill in stencil matrix values
     for k1 in range(-p1, p1 + 1):
         for k2 in range(-p2, p2 + 1):
             M[:, :, k1, k2] = nonzero_values[k1, k2]
+    #print('M._data.shape', M._data.shape)
+    #M[:,:,0,1]=1
+    #M[:,:,-1,0]=1
 
     # If any dimension is not periodic, set corresponding periodic corners to zero
     M.remove_spurious_entries()
+
+    print('M.shape', M.shape)
 
     # Convert stencil matrix to PETSc.Mat
     Mp = M.topetsc()
     # Convert PETSc.Mat to sparse CSR matrix   
     indptr, indices, data = Mp.getValuesCSR()
+    
     if dtype == float:
         data = data.real #PETSc with installation complex configuration only handles complex dtype
-    Mp = csr_matrix((data, indices, indptr), shape=Mp.size)
 
-    M = M.tosparse().tocsr()
+    print('Mp.getOwnershipIS()', Mp.getOwnershipIS()[0].array, Mp.getOwnershipIS()[1].array)
+    local_row_range = Mp.getOwnershipRange()
+    print('local_row_range', local_row_range)
+    
+    #print(list(range(local_row_range[0], local_row_range[1])))
+    #print('Mp.getValues()', Mp.getValues(list(range(local_row_range[0], local_row_range[1]+1)), list(range(M.shape[1]))).real)
+    
+    '''global_indptr = np.zeros((M.shape[0]+1,))
 
-    assert (M-Mp).data.size == 0
+    global_indptr[local_row_range[0]:local_row_range[1]+1] = indptr
+    for k in range(local_row_range[1]+1, global_indptr.size):
+        global_indptr[k] = indptr[-1]'''
 
+    ###########################################
+        
+    Marr = M.tosparse().toarray()
+        
+    local_row = [local_row_range[0],local_row_range[1]]
+    # The local row ranges are given s.t. the last and the first are repeated. 
+    # For example:
+    # Process 0: range is (0,5) (5 is included),
+    # Process 1: range is (5,9) (5 is not included). 
+
+    if local_row_range[0] != 0:
+        # If it is not the first row, start one below
+        local_row[0] = local_row_range[0] + 1
+    if local_row_range[1] != M.shape[0]:
+        # If it is not the last row, finish one after
+        local_row[1] = local_row_range[1] + 1
+
+    '''for k in range(local_row[0], local_row[1]):
+        print('Checking row', k)
+        #get the whole row with the global number of columns
+        Mp_row = Mp.getValues(k, list(range(M.shape[1])))
+        if dtype == float:
+            Mp_row = Mp_row.real
+        if np.array_equal(Mp_row, Marr[k,:]):
+            print('success')
+        else:
+            print('fail')
+
+        #assert np.array_equal(Mp_row, Marr[k,:])'''
+            
+    assert np.array_equal(Marr[Mp.getOwnershipIS()[0].array, Mp.getOwnershipIS()[1].array], Mp.getValues(Mp.getOwnershipIS()[0].array, Mp.getOwnershipIS()[1].array))
+        
+
+
+    ##################
+    # To create a sparse matrix from PETSc.Mat():
+    # Mp = csr_matrix((data, indices, indptr)) 
+    # The shape should not be passed, since M.shape is the global size and here it requires the local size
+    ##################   
+    
+    '''M = M.tosparse().tocsr()
+
+    print('M = ', M.toarray())
+
+    print('PETSc indptr', indptr)
+    print('PETSc global_indptr', global_indptr)
+    print('Psydac indptr', M.indptr)
+    print('PETSc indices', indices)
+    print('Psydac indices', M.indices)
+    print('PETSc data', data)
+    print('Psydac data', M.data)
+    print('-----------')
+    print('Mp.getOwnershipIS()', Mp.getOwnershipIS())
+    print('Mp.getOwnershipRange()', Mp.getOwnershipRange())
+    print('Mp.getOwnershipRangeColumn()', Mp.getOwnershipRangeColumn())
+    
+
+    assert (global_indptr == M.indptr).all()
+    assert (indices == M.indices).all()
+    assert np.array_equal(data, M.data)'''
+#test_stencil_matrix_2d_parallel_topetsc(float,3,3,1,1,1,1,True,True)
 # ===============================================================================
     
-@pytest.mark.parametrize('n1', [5])
-@pytest.mark.parametrize('n2', [7])
-@pytest.mark.parametrize('p1', [1, 3])
-@pytest.mark.parametrize('p2', [1, 2])
-@pytest.mark.parametrize('P1', [True, False])
-@pytest.mark.parametrize('P2', [True, False])
+@pytest.mark.parametrize('n1', [4])
+@pytest.mark.parametrize('n2', [4])
+@pytest.mark.parametrize('p1', [1])
+@pytest.mark.parametrize('p2', [1])
+@pytest.mark.parametrize('P1', [True])
+@pytest.mark.parametrize('P2', [True])
 @pytest.mark.parallel
-@pytest.mark.petsc
+#@pytest.mark.petsc
 
 def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     from sympde.topology import Square, ScalarFunctionSpace, element_of
@@ -2787,11 +2871,25 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     # Convert PETSc.Mat to sparse CSR matrix   
     indptr, indices, data = Mp.getValuesCSR()
     data = data.real #PETSc with installation complex configuration only handles complex dtype
-    Mp = csr_matrix((data, indices, indptr), shape=Mp.size)
 
     M1 = M1.tosparse().tocsr()
 
-    assert (M1-Mp).data.size == 0
+    print('M1 = ', M1.todense())
+    print()
+
+    print('PETSc indptr', indptr)
+    print('M1.indptr', M1.indptr)
+    print()
+    print('PETSc indices', indices)
+    print('M1.indices', M1.indices)
+
+    print('M1.shape', M1.shape)
+    print('M1.indptr.size', M1.indptr.size)
+
+    assert (indptr == M1.indptr).all()
+    assert (indices == M1.indices).all()
+    assert np.array_equal(data, M1.data)
+
 
 # ===============================================================================
 # PARALLEL BACKENDS TESTS

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -557,6 +557,8 @@ def test_stencil_matrix_2d_serial_toarray( dtype, n1, n2, p1, p2, s1, s2, P1, P2
 @pytest.mark.parametrize('s2', [1])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True, False])
+@pytest.mark.petsc
+
 def test_stencil_matrix_2d_serial_topetsc( dtype, n1, n2, p1, p2, s1, s2, P1, P2):
     # Select non-zero values based on diagonal index
     nonzero_values = dict()
@@ -610,6 +612,8 @@ def test_stencil_matrix_2d_serial_topetsc( dtype, n1, n2, p1, p2, s1, s2, P1, P2
 @pytest.mark.parametrize('p2', [1, 3])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True, False])
+@pytest.mark.petsc
+
 def test_mass_matrix_2d_serial_topetsc(n1, n2, p1, p2, P1, P2):
     from sympde.topology import Square, ScalarFunctionSpace, element_of
     from sympde.expr     import BilinearForm, integral
@@ -2700,6 +2704,8 @@ def test_stencil_matrix_2d_parallel_transpose(dtype, n1, n2, p1, p2, sh1, sh2, P
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True, False])
 @pytest.mark.parallel
+@pytest.mark.petsc
+
 def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1, P2):
     from mpi4py import MPI
     # Select non-zero values based on diagonal index
@@ -2755,6 +2761,8 @@ def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1,
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True, False])
 @pytest.mark.parallel
+@pytest.mark.petsc
+
 def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     from sympde.topology import Square, ScalarFunctionSpace, element_of
     from sympde.expr     import BilinearForm, integral

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -2715,7 +2715,7 @@ def test_stencil_matrix_2d_parallel_transpose(dtype, n1, n2, p1, p2, sh1, sh2, P
 
 def test_stencil_matrix_2d_parallel_topetsc(dtype, n1, n2, p1, p2, sh1, sh2, P1, P2):
     from mpi4py import MPI
-    np.set_printoptions(linewidth=300)
+
     # Select non-zero values based on diagonal index
     nonzero_values = dict()
     if dtype==complex:
@@ -2805,7 +2805,7 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     from psydac.api.settings            import PSYDAC_BACKENDS
     from psydac.api.discretization      import discretize
     from mpi4py import MPI
-    np.set_printoptions(linewidth=300, precision=3)
+
     domain = Square()
     V = ScalarFunctionSpace('V', domain)
 

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -416,6 +416,7 @@ def test_stencil_vector_2d_serial_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2,
 @pytest.mark.parametrize('s2', [1])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True])
+@pytest.mark.petsc
 def test_stencil_vector_2d_serial_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
     # Create domain decomposition
     D = DomainDecomposition([n1, n2], periods=[P1, P2])
@@ -599,6 +600,7 @@ def test_stencil_vector_2d_parallel_init(dtype, n1, n2, p1, p2, s1, s2, P1=True,
 @pytest.mark.parametrize('s2', [1])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True])
+@pytest.mark.petsc
 def test_stencil_vector_2d_parallel_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
     from mpi4py import MPI
     comm = MPI.COMM_WORLD

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -592,12 +592,12 @@ def test_stencil_vector_2d_parallel_init(dtype, n1, n2, p1, p2, s1, s2, P1=True,
 
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])
-@pytest.mark.parametrize('n1', [1, 7])
-@pytest.mark.parametrize('n2', [1, 5])
-@pytest.mark.parametrize('p1', [1, 2])
-@pytest.mark.parametrize('p2', [1])
+@pytest.mark.parametrize('n1', [20, 32])
+@pytest.mark.parametrize('n2', [24, 40])
+@pytest.mark.parametrize('p1', [1, 3])
+@pytest.mark.parametrize('p2', [2])
 @pytest.mark.parametrize('s1', [1, 2])
-@pytest.mark.parametrize('s2', [1])
+@pytest.mark.parametrize('s2', [2])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True])
 @pytest.mark.parallel
@@ -624,8 +624,10 @@ def test_stencil_vector_2d_parallel_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P
         f = lambda i1, i2: 10j * i1 + i2
     else:
         f = lambda i1, i2: 10 * i1 + i2
-    for i1 in range(n1):
-        for i2 in range(n2):
+
+    # Initialize distributed 2D stencil vector
+    for i1 in range(V.starts[0], V.ends[0] + 1):
+        for i2 in range(V.starts[1], V.ends[1] + 1):
             x[i1, i2] = f(i1,i2)
 
     # Convert vector to PETSc.Vec
@@ -634,14 +636,6 @@ def test_stencil_vector_2d_parallel_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P
     # Convert PETSc.Vec to StencilVector of V
     v = petsc_to_psydac(v, V)
 
-    # Test properties of v and data contained
-    assert v.space is V
-    assert v.dtype == dtype
-    assert v.starts == (0, 0)
-    assert v.ends == (n1 - 1, n2 - 1)
-    assert v.pads == (p1, p2)
-    assert v._data.shape == (n1 + 2 * p1 * s1, n2 + 2 * p2 * s2)
-    assert v._data.dtype == dtype
     assert np.array_equal(x.toarray(), v.toarray())
     
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -600,6 +600,7 @@ def test_stencil_vector_2d_parallel_init(dtype, n1, n2, p1, p2, s1, s2, P1=True,
 @pytest.mark.parametrize('s2', [1])
 @pytest.mark.parametrize('P1', [True, False])
 @pytest.mark.parametrize('P2', [True])
+@pytest.mark.parallel
 @pytest.mark.petsc
 def test_stencil_vector_2d_parallel_topetsc(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
     from mpi4py import MPI

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -82,10 +82,14 @@ def vec_topetsc( vec ):
     globalsize = vec.space.dimension
     indices, data = flatten_vec(vec)
     gvec  = PETSc.Vec().create(comm=comm)
+    # Set global size
     gvec.setSizes(globalsize)
     gvec.setFromOptions()
+    # Set values of the vector. They are stored in a cache, so the assembly is necessary to use the vector.
     gvec.setValues(indices, data)
-    gvec.assemble()
+
+    # Assemble vector
+    gvec.assemble() # Here PETSc exchanges global communication. The block corresponding to a certain process is not necessarily the same block in the Psydac StencilVector.
     return gvec
 
 def mat_topetsc( mat ):
@@ -130,87 +134,24 @@ def mat_topetsc( mat ):
 
     if comm:
         # Preallocate number of nonzeros
-        NNZ = comm.allreduce(data.size, op=MPI.SUM)
+        row_lengths = np.count_nonzero(rows[None,:] == np.unique(rows)[:,None], axis=1).max()
+        # NNZ is the number of non-zeros per row for the local portion of the matrix
+        NNZ = comm.allreduce(row_lengths, op=MPI.MAX)
         gmat.setPreallocationNNZ(NNZ)
 
     # Fill-in matrix values
     for i in range(rows.size):
         # The values have to be set in "addition mode", otherwise the default just takes the new value.
-        # This is here necessary, since the COO format can contain repeated entries and they must be added.
+        # This is here necessary, since the COO format can contain repeated entries.
         gmat.setValues(rows[i], cols[i], data[i], addv=PETSc.InsertMode.ADD_VALUES)
 
     # Process inserted matrix entries
+    ################################################
+    # Note 12.03.2024:
+    # In the assembly PETSc uses global communication to distribute the matrix in a different way than Psydac.
+    # For this reason, at the moment we cannot compare directly each distributed 'chunck' of the Psydac and the PETSc matrices.
+    # In the future we would like that PETSc uses the partition from Psydac, 
+    # which might involve passing a DM Object.
+    ################################################
     gmat.assemble()
     return gmat
-
-'''def mat_topetsc( mat ):
-    """ Convert operator from Psydac format to a PETSc.Mat object.
-
-    Parameters
-    ----------
-    mat : psydac.linalg.stencil.StencilMatrix | psydac.linalg.basic.LinearOperator | psydac.linalg.block.BlockLinearOperator
-      Psydac operator
-
-    Returns
-    -------
-    gmat : PETSc.Mat
-        PETSc Matrix
-    """
-    from petsc4py import PETSc
-
-    if isinstance(mat, StencilMatrix):
-        comm = mat.domain.cart.global_comm
-    elif isinstance(mat.domain.spaces[0], StencilVectorSpace):
-        comm = mat.domain.spaces[0].cart.global_comm
-    elif isinstance(mat.domain.spaces[0], BlockVectorSpace):
-        comm = mat.domain.spaces[0][0].cart.global_comm
-
-    mat_coo = mat.tosparse() #has the shape of the global operator
-    print('global shape', mat.shape)
-    print('dense matrix', mat_coo.todense())
-    print('mat_coo.row', mat_coo.row)
-    print('mat_coo.col', mat_coo.col)
-    mat_csr = mat_coo.tocsr()
-    print('mat_csr.indptr', mat_csr.indptr)
-    print('mat_csr.indices', mat_csr.indices)
-
-    gmat = PETSc.Mat().create(comm=comm)
-
-
- 
-    #gmat.setSizes(mat.shape)
-    #mat.setSizes([[nrl, nrg], [ncl, ncg]])
-    gmat.setSizes([[mat.shape[0]//2, mat.shape[0]], [mat.shape[1]//2, mat.shape[1]]])
-
-    #gmat.setSizes((nrows, ncols))
-
-    # Set sparse matrix type
-    gmat.setType("mpiaij")   
-    gmat.setFromOptions()
-
-    '''if comm:
-        # Preallocate number of nonzeros based on CSR structure
-        gmat.setPreallocationCSR((mat_csr.indptr, mat_csr.indices))
-        #NNZ = comm.allreduce(mat_csr.size, op=MPI.SUM)
-        #gmat.setPreallocationNNZ(NNZ)
-
-    # Fill-in matrix values from CSR data
-        #indptr: Stores accumulated number of non-zero entries
-        #indices: Stores column index of entries
-        #data: Stores non-zero entries
-
-    nrows = len(mat_csr.indptr)-1 #indptr always has a 0 in the first position to avoid void array
-    for r in range(nrows):
-        # get number of non zero entries to fill in row r
-        num_non_zero = mat_csr.indptr[r+1] - mat_csr.indptr[r]
-        for k in range(num_non_zero):
-            # set the value in correct column
-            gmat.setValues(r, mat_csr.indices[r+k], mat_csr.data[r+k])  
-        #cols = mat_csr.indices[mat_csr.indptr[i]:mat_csr.indptr[i+1]]
-        #col_data = mat_csr.data[mat_csr.indptr[i]:mat_csr.indptr[i+1]]
-        #gmat.setValues(i, cols, col_data)  
-   
-    # Process inserted matrix entries
-    gmat.assemble()
-    return gmat
-'''

--- a/psydac/linalg/topetsc.py
+++ b/psydac/linalg/topetsc.py
@@ -5,7 +5,6 @@ from psydac.linalg.stencil import StencilVectorSpace, StencilVector, StencilMatr
 from scipy.sparse import coo_matrix, bmat
 
 from mpi4py import MPI
-from petsc4py import PETSc
 
 __all__ = ('flatten_vec', 'vec_topetsc', 'mat_topetsc')
 
@@ -71,6 +70,7 @@ def vec_topetsc( vec ):
     gvec : PETSc.Vec
         PETSc vector
     """
+    from petsc4py import PETSc
 
     if isinstance(vec, StencilVector):
         comm = vec.space.cart.global_comm
@@ -101,6 +101,7 @@ def mat_topetsc( mat ):
     gmat : PETSc.Mat
         PETSc Matrix
     """
+    from petsc4py import PETSc
 
     if isinstance(mat, StencilMatrix):
         comm = mat.domain.cart.global_comm

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -80,7 +80,13 @@ def petsc_to_psydac(x, Xh):
             recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors
 
             if comm:
-                # gather the global array in all the procs
+                # Gather the global array in all the processors
+                ################################################
+                # Note 12.03.2024:
+                # This global communication is at the moment necessary since PETSc distributes matrices and vectors different than Psydac. 
+                # In order to avoid it, we would need that PETSc uses the partition from Psydac, 
+                # which might involve passing a DM Object.
+                ################################################
                 comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
             else:
                 recvbuf[:] = x.array
@@ -111,7 +117,8 @@ def petsc_to_psydac(x, Xh):
             recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors
 
             if comm:
-                # gather the global array in all the procs
+                # Gather the global array in all the procs
+                # TODO: Avoid this global communication with a DM Object (see note above).
                 comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
             else:
                 recvbuf[:] = x.array
@@ -142,7 +149,8 @@ def petsc_to_psydac(x, Xh):
         recvbuf    = np.empty(sum(sendcounts), dtype='complex') # PETSc installed with complex configuration only handles complex vectors 
 
         if comm:
-            # gather the global array in all the procs
+            # Gather the global array in all the procs
+            # TODO: Avoid this global communication with a DM Object (see note above).
             comm.Allgatherv(sendbuf=x.array, recvbuf=(recvbuf, sendcounts))
         else:
             recvbuf[:] = x.array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,6 @@ dependencies = [
 
     # IGAKIT - not on PyPI
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
-
-    # PETSc - needs source code for complex configuration
-    'petsc @ https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip'
-
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dependencies = [
 
     # IGAKIT - not on PyPI
     'igakit @ https://github.com/dalcinl/igakit/archive/refs/heads/master.zip'
+
+    # PETSc - needs source code for complex configuration
+    'petsc @ https://gitlab.com/petsc/petsc/-/archive/main/petsc-main.zip'
+
 ]
 
 [project.urls]


### PR DESCRIPTION
Fix the functions to cast Psydac format to PETSc format and back:

- Identify the correct installation procedure for PETSc and `petsc4py`;
- Make functions work on complex-valued vectors and matrices;
- Make functions work in the serial case (where `comm=None`);
- Add more extensive unit testing;
- Update unit test workflow;
- Update README file.

This allows the use of high-performance PETSc solvers:

- PETSc must be installed with the complex configuration (see the instructions in the README).
- `StencilVector`, `BlockVector`, `StencilMatrix` and `BlockLinearOperator` have a `topetsc()` method.
- The function `petsc_to_psydac` in `psydac.linalg.utilities.py` allows us to convert a `PETSc.Vec` object (for instance, the vector solution after solving a system with PETSc) back to Psydac `StencilVector` or `BlockVector` format.

How to use it: 
Let `A` be a `StencilMatrix` or `BlockLinearOperator` and b a `StencilVector`. We want to solve `Ax=b` with `PETSc` CG:

```
from psydac.linalg.utilities import petsc_to_psydac
from petsc4py import PETSC

Ap = A.topetsc() #converts operator to PETSc.Mat format

bp = b.topetsc() #converts vector to PETSc.Vec format

x = bp.duplicate() #x will be both the initial guess and where the solution is stored.
# If we have a particular initial guess in Psydac format, just convert it to PETSc.Vec format x = x.topetsc()

ksp = PETSc.KSP() # create Krylov solver type object
ksp.create(comm=Ap.comm) # pass communicator from PETSc.Mat object
opts = PETSc.Options() # create object to pass options to solver
opts["ksp_type"] = "cg" # set type of solver ("gmres" is default)
opts["pc_type"] = "none" # set preconditioner
opts["ksp_rtol"] = 1e-13
opts["ksp_atol"] = 1e-13
ksp.setFromOptions() # pass options to solver ksp
ksp.setOperators(Ap) # set system matrix. Preconditioner can also be passed here

ksp.solve(bp, x) # solve system

sol = petsc_to_psydac(x, V.vector_space) # convert solution to Psydac StencilVector format
```
Note: With this PR, the conversion from PETSC format to StencilVector format is not efficient, see [issue #389](https://github.com/pyccel/psydac/issues/389).