### PR TITLE
Speed up Pyccelization of built-in kernels

### DIFF
--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -1955,13 +1955,12 @@ def eval_jac_det_irregular_2d_weights(np1: int, np2: int, f_p1: int, f_p2: int,
 # -----------------------------------------------------------------------------
 # 1: Regular tensor grid without weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_3d(nc1: int, nc2: int, nc3: int, f_p1: int, f_p2: int, f_p3: int,
                       k1: int, k2: int, k3: int, global_basis_1: 'float[:,:,:,:]', global_basis_2: 'float[:,:,:,:]',
                       global_basis_3: 'float[:,:,:,:]', global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                      global_spans_3: 'int[:]', global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
-                      global_arr_coeff_z: 'T', jacobians: 'T_jac'):
+                      global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]', global_arr_coeff_y: 'T[:,:,:]',
+                      global_arr_coeff_z: 'T[:,:,:]', jacobians: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -2114,12 +2113,11 @@ def eval_jacobians_3d(nc1: int, nc2: int, nc3: int, f_p1: int, f_p2: int, f_p3: 
                                                         [z_x1, z_x2, z_x3]])
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_2d(nc1: int, nc2: int, f_p1: int, f_p2: int, k1: int, k2: int,
                       global_basis_1: 'float[:,:,:,:]', global_basis_2: 'float[:,:,:,:]', global_spans_1: 'int[:]',
-                      global_spans_2: 'int[:]', global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
-                      jacobians: 'T_jac'):
+                      global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]', global_arr_coeff_y: 'T[:,:]',
+                      jacobians: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -2221,15 +2219,14 @@ def eval_jacobians_2d(nc1: int, nc2: int, f_p1: int, f_p2: int, k1: int, k2: int
 # -----------------------------------------------------------------------------
 # 2: Irregular tensor grid without weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_irregular_3d(np1: int, np2: int, np3: int, f_p1: int, f_p2: int,
                                 f_p3: int, cell_index_1: 'int[:]', cell_index_2: 'int[:]', cell_index_3 : 'int[:]',
                                 global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                 global_basis_3: 'float[:,:,:]', global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                global_spans_3: 'int[:]', global_arr_coeff_x: 'T',
-                                global_arr_coeff_y: 'T', global_arr_coeff_z: 'T',
-                                jacobians: 'T_jac'):
+                                global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]',
+                                global_arr_coeff_y: 'T[:,:,:]', global_arr_coeff_z: 'T[:,:,:]',
+                                jacobians: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -2368,12 +2365,11 @@ def eval_jacobians_irregular_3d(np1: int, np2: int, np3: int, f_p1: int, f_p2: i
                                                                  [temp_z_x1, temp_z_x2, temp_z_x3]])
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_irregular_2d(np1: int, np2: int, f_p1: int, f_p2: int, cell_index_1: 'int[:]',
                                 cell_index_2: 'int[:]', global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
-                                global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T',
-                                global_arr_coeff_y: 'T', jacobians: 'T_jac'):
+                                global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]',
+                                global_arr_coeff_y: 'T[:,:]', jacobians: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -2466,15 +2462,14 @@ def eval_jacobians_irregular_2d(np1: int, np2: int, f_p1: int, f_p2: int, cell_i
 # -----------------------------------------------------------------------------
 # 3: Regular tensor grid with weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_3d_weights(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2: int,
                               f_p3: int, k1: int, k2: int, k3: int, global_basis_1: 'float[:,:,:,:]',
                               global_basis_2: 'float[:,:,:,:]', global_basis_3: 'float[:,:,:,:]',
                               global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_spans_3: 'int[:]',
-                              global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
-                              global_arr_coeff_z: 'T', global_arr_coeff_weights: 'float[:,:,:]',
-                              jacobians: 'T_jac'):
+                              global_arr_coeff_x: 'T[:,:,:]', global_arr_coeff_y: 'T[:,:,:]',
+                              global_arr_coeff_z: 'T[:,:,:]', global_arr_coeff_weights: 'float[:,:,:]',
+                              jacobians: 'T[:,:,:,:,:]'):
 
     """
     Parameters
@@ -2694,13 +2689,12 @@ def eval_jacobians_3d_weights(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2: in
                                                         [z_x1, z_x2, z_x3]])
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_2d_weights(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1: int, k2: int,
                               global_basis_1: 'float[:,:,:,:]', global_basis_2: 'float[:,:,:,:]',
-                              global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T',
-                              global_arr_coeff_y: 'T', global_arr_coeff_weights: 'float[:,:]',
-                              jacobians: 'T_jac'):
+                              global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]',
+                              global_arr_coeff_y: 'T[:,:]', global_arr_coeff_weights: 'float[:,:]',
+                              jacobians: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -2852,15 +2846,14 @@ def eval_jacobians_2d_weights(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1: int
 # -----------------------------------------------------------------------------
 # 4: Irregular tensor grid with weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_irregular_3d_weights(np1: int, np2: int, np3: int, f_p1: int, f_p2: int,
                                         f_p3: int, cell_index_1: 'int[:]', cell_index_2: 'int[:]', cell_index_3 : 'int[:]',
                                         global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                         global_basis_3: 'float[:,:,:]', global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                        global_spans_3: 'int[:]', global_arr_coeff_x: 'T',
-                                        global_arr_coeff_y: 'T', global_arr_coeff_z: 'T',
-                                        global_arr_coeff_weights: 'float[:,:, :]', jacobians: 'T_jac'):
+                                        global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]',
+                                        global_arr_coeff_y: 'T[:,:,:]', global_arr_coeff_z: 'T[:,:,:]',
+                                        global_arr_coeff_weights: 'float[:,:, :]', jacobians: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -3050,15 +3043,14 @@ def eval_jacobians_irregular_3d_weights(np1: int, np2: int, np3: int, f_p1: int,
                                                                  [z_x1, z_x2, z_x3]])
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_irregular_2d_weights(np1: int, np2: int, f_p1: int, f_p2: int,
                                         cell_index_1: 'int[:]', cell_index_2: 'int[:]',
                                         global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                         global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                        global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
+                                        global_arr_coeff_x: 'T[:,:]', global_arr_coeff_y: 'T[:,:]',
                                         global_arr_coeff_weights: 'float[:,:]',
-                                        jacobians: 'T_jac'):
+                                        jacobians: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -3193,14 +3185,13 @@ def eval_jacobians_irregular_2d_weights(np1: int, np2: int, f_p1: int, f_p2: int
 # -----------------------------------------------------------------------------
 # 1: Regular tensor grid without weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_3d(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2: int,
                           f_p3: int, k1: int, k2: int, k3: int, global_basis_1: 'float[:,:,:,:]',
                           global_basis_2: 'float[:,:,:,:]', global_basis_3: 'float[:,:,:,:]', global_spans_1: 'int[:]',
-                          global_spans_2: 'int[:]', global_spans_3: 'int[:]', global_arr_coeff_x: 'T',
-                          global_arr_coeff_y: 'T', global_arr_coeff_z: 'T',
-                          jacobians_inv: 'T_jac'):
+                          global_spans_2: 'int[:]', global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]',
+                          global_arr_coeff_y: 'T[:,:,:]', global_arr_coeff_z: 'T[:,:,:]',
+                          jacobians_inv: 'T[:,:,:,:,:]'):
 
     """
     Parameters
@@ -3369,12 +3360,11 @@ def eval_jacobians_inv_3d(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2: int,
                                                             [a_13, a_23, a_33]]) / det
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_2d(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1: int, k2: int,
                           global_basis_1: 'float[:,:,:,:]', global_basis_2: 'float[:,:,:,:]', global_spans_1: 'int[:]',
-                          global_spans_2: 'int[:]', global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
-                          jacobians_inv: 'T_jac'):
+                          global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]', global_arr_coeff_y: 'T[:,:]',
+                          jacobians_inv: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -3478,15 +3468,14 @@ def eval_jacobians_inv_2d(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1: int, k2
 # -----------------------------------------------------------------------------
 # 2: Irregular tensor grid without weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_irregular_3d(np1: int, np2: int, np3: int, f_p1: int, f_p2: int,
                                    f_p3: int, cell_index_1: 'int[:]', cell_index_2: 'int[:]', cell_index_3 : 'int[:]',
                                    global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                    global_basis_3: 'float[:,:,:]', global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                   global_spans_3: 'int[:]', global_arr_coeff_x: 'T',
-                                   global_arr_coeff_y: 'T', global_arr_coeff_z: 'T',
-                                   jacobians_inv: 'T_jac'):
+                                   global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]',
+                                   global_arr_coeff_y: 'T[:,:,:]', global_arr_coeff_z: 'T[:,:,:]',
+                                   jacobians_inv: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -3647,12 +3636,11 @@ def eval_jacobians_inv_irregular_3d(np1: int, np2: int, np3: int, f_p1: int, f_p
                                                   [a_13, a_23, a_33]]) / det
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_irregular_2d(np1: int, np2: int, f_p1: int, f_p2: int, cell_index_1: 'int[:]',
                                     cell_index_2: 'int[:]', global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
-                                    global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T',
-                                    global_arr_coeff_y: 'T', jacobians_inv: 'T_jac'):
+                                    global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]',
+                                    global_arr_coeff_y: 'T[:,:]', jacobians_inv: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -3748,15 +3736,14 @@ def eval_jacobians_inv_irregular_2d(np1: int, np2: int, f_p1: int, f_p2: int, ce
 # -----------------------------------------------------------------------------
 # 3: Regular tensor grid with weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_3d_weights(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2: int,
                                   f_p3: int, k1: int, k2: int, k3: int, global_basis_1: 'float[:,:,:,:]',
                                   global_basis_2: 'float[:,:,:,:]', global_basis_3: 'float[:,:,:,:]',
                                   global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_spans_3: 'int[:]',
-                                  global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
-                                  global_arr_coeff_z: 'T', global_arr_coeff_weigths: 'float[:,:,:]',
-                                  jacobians_inv: 'T_jac'):
+                                  global_arr_coeff_x: 'T[:,:,:]', global_arr_coeff_y: 'T[:,:,:]',
+                                  global_arr_coeff_z: 'T[:,:,:]', global_arr_coeff_weigths: 'float[:,:,:]',
+                                  jacobians_inv: 'T[:,:,:,:,:]'):
 
     """
     Parameters
@@ -3991,13 +3978,12 @@ def eval_jacobians_inv_3d_weights(nc1: int, nc2: int, nc3: int,  f_p1: int, f_p2
                                                             [a_13, a_23, a_33]]) / det
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_2d_weights(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1: int, k2: int,
                                   global_basis_1: 'float[:,:,:,:]', global_basis_2: 'float[:,:,:,:]',
-                                  global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T',
-                                  global_arr_coeff_y: 'T', global_arr_coeff_weights: 'float[:,:]',
-                                  jacobians_inv: 'T_jac'):
+                                  global_spans_1: 'int[:]', global_spans_2: 'int[:]', global_arr_coeff_x: 'T[:,:]',
+                                  global_arr_coeff_y: 'T[:,:]', global_arr_coeff_weights: 'float[:,:]',
+                                  jacobians_inv: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4151,15 +4137,14 @@ def eval_jacobians_inv_2d_weights(nc1: int, nc2: int,  f_p1: int, f_p2: int, k1:
 # -----------------------------------------------------------------------------
 # 4: Irregular tensor grid with weights
 # -----------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_irregular_3d_weights(np1: int, np2: int, np3: int, f_p1: int, f_p2: int,
                                             f_p3: int, cell_index_1: 'int[:]', cell_index_2: 'int[:]', cell_index_3 : 'int[:]',
                                             global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                             global_basis_3: 'float[:,:,:]', global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                            global_spans_3: 'int[:]', global_arr_coeff_x: 'T',
-                                            global_arr_coeff_y: 'T', global_arr_coeff_z: 'T',
-                                            global_arr_coeff_weights: 'float[:,:, :]', jacobians_inv: 'T_jac'):
+                                            global_spans_3: 'int[:]', global_arr_coeff_x: 'T[:,:,:]',
+                                            global_arr_coeff_y: 'T[:,:,:]', global_arr_coeff_z: 'T[:,:,:]',
+                                            global_arr_coeff_weights: 'float[:,:,:]', jacobians_inv: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4367,15 +4352,14 @@ def eval_jacobians_inv_irregular_3d_weights(np1: int, np2: int, np3: int, f_p1: 
                                                 [a_13, a_23, a_33]]) / det
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T_jac', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
+@template(name='T', types=[float, complex])
 def eval_jacobians_inv_irregular_2d_weights(np1: int, np2: int, f_p1: int, f_p2: int,
                                             cell_index_1: 'int[:]', cell_index_2: 'int[:]',
                                             global_basis_1: 'float[:,:,:]', global_basis_2: 'float[:,:,:]',
                                             global_spans_1: 'int[:]', global_spans_2: 'int[:]',
-                                            global_arr_coeff_x: 'T', global_arr_coeff_y: 'T',
+                                            global_arr_coeff_x: 'T[:,:]', global_arr_coeff_y: 'T[:,:]',
                                             global_arr_coeff_weights: 'float[:,:]',
-                                            jacobians_inv: 'T_jac'):
+                                            jacobians_inv: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4511,8 +4495,9 @@ def eval_jacobians_inv_irregular_2d_weights(np1: int, np2: int, f_p1: int, f_p2:
 # --------------------------------------------------------------------------
 # 1: L2 Push-forward
 # --------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-def pushforward_2d_l2(fields_to_push: 'T', sqrt_met_dets: 'float[:,:]', pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_2d_l2(fields_to_push: 'T[:,:,:]', sqrt_met_dets: 'float[:,:]',
+                       pushed_fields: 'T[:,:,:]'):
     """
     Parameters
     ----------
@@ -4533,8 +4518,8 @@ def pushforward_2d_l2(fields_to_push: 'T', sqrt_met_dets: 'float[:,:]', pushed_f
         pushed_fields[:, :, i_f] = fields_to_push[:, :, i_f] / sqrt_met_dets[:, :]
 
 
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def pushforward_3d_l2(fields_to_push: 'T', sqrt_met_dets: 'float[:,:,:]', pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_3d_l2(fields_to_push: 'T[:,:,:,:]', sqrt_met_dets: 'float[:,:,:]', pushed_fields: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4559,9 +4544,9 @@ def pushforward_3d_l2(fields_to_push: 'T', sqrt_met_dets: 'float[:,:,:]', pushed
 # --------------------------------------------------------------------------
 # 2: Hcurl Push-forward
 # --------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def pushforward_2d_hcurl(fields_to_push: 'T', inv_jac_mats: 'float[:,:,:,:]',
-                         pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_2d_hcurl(fields_to_push: 'T[:,:,:,:]', inv_jac_mats: 'float[:,:,:,:]',
+                          pushed_fields: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4587,9 +4572,9 @@ def pushforward_2d_hcurl(fields_to_push: 'T', inv_jac_mats: 'float[:,:,:,:]',
                                        + inv_jac_mats[:, :, 1, 1] * fields_to_push[1, :, :, i_f])
 
 
-@template(name='T', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
-def pushforward_3d_hcurl(fields_to_push: 'T', inv_jac_mats: 'float[:,:,:,:,:]',
-                         pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_3d_hcurl(fields_to_push: 'T[:,:,:,:,:]', inv_jac_mats: 'float[:,:,:,:,:]',
+                          pushed_fields: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4629,9 +4614,9 @@ def pushforward_3d_hcurl(fields_to_push: 'T', inv_jac_mats: 'float[:,:,:,:,:]',
 # --------------------------------------------------------------------------
 # 1: Hdiv Push-forward
 # --------------------------------------------------------------------------
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def pushforward_2d_hdiv(fields_to_push: 'T', jac_mats: 'float[:,:,:,:]',
-                        sqrt_met_dets: 'float[:, :]', pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_2d_hdiv(fields_to_push: 'T[:,:,:,:]', jac_mats: 'float[:,:,:,:]',
+                        sqrt_met_dets: 'float[:,:]', pushed_fields: 'T[:,:,:,:]'):
     """
     Parameters
     ----------
@@ -4661,9 +4646,9 @@ def pushforward_2d_hdiv(fields_to_push: 'T', jac_mats: 'float[:,:,:,:]',
                                        + jac_mats[:, :, 1, 1] * fields_to_push[1, :, :, i_f]) / sqrt_met_dets[:, :]
 
 
-@template(name='T', types=['float[:,:,:,:,:]', 'complex[:,:,:,:,:]'])
-def pushforward_3d_hdiv(fields_to_push: 'T', jac_mats: 'float[:,:,:,:,:]',
-                        sqrt_met_dets: 'float[:, :, :]', pushed_fields: 'T'):
+@template(name='T', types=[float, complex])
+def pushforward_3d_hdiv(fields_to_push: 'T[:,:,:,:,:]', jac_mats: 'float[:,:,:,:,:]',
+                        sqrt_met_dets: 'float[:,:,:]', pushed_fields: 'T[:,:,:,:,:]'):
     """
     Parameters
     ----------

--- a/psydac/linalg/kernels/axpy_kernels.py
+++ b/psydac/linalg/kernels/axpy_kernels.py
@@ -1,9 +1,8 @@
 from pyccel.decorators import template
 
 #========================================================================================================
-@template(name='Tarray', types=['float[:]', 'complex[:]'])
-@template(name='T', types=['float', 'complex'])
-def axpy_1d(alpha: 'T', x: "Tarray", y: "Tarray"):
+@template(name='T', types=[float, complex])
+def axpy_1d(alpha: 'T', x: 'T[:]', y: 'T[:]'):
     """
     Kernel for computing y = alpha * x + y.
 
@@ -20,9 +19,8 @@ def axpy_1d(alpha: 'T', x: "Tarray", y: "Tarray"):
         y[i1] += alpha * x[i1]
 
 #========================================================================================================
-@template(name='Tarray', types=['float[:,:]', 'complex[:,:]'])
-@template(name='T', types=['float', 'complex'])
-def axpy_2d(alpha: 'T', x: "Tarray", y: "Tarray"):
+@template(name='T', types=[float, complex])
+def axpy_2d(alpha: 'T', x: 'T[:,:]', y: 'T[:,:]'):
     """
     Kernel for computing y = alpha * x + y.
 
@@ -40,9 +38,8 @@ def axpy_2d(alpha: 'T', x: "Tarray", y: "Tarray"):
             y[i1, i2] += alpha * x[i1, i2]
 
 #========================================================================================================
-@template(name='Tarray', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='T', types=['float', 'complex'])
-def axpy_3d(alpha: 'T', x: "Tarray", y: "Tarray"):
+@template(name='T', types=[float, complex])
+def axpy_3d(alpha: 'T', x: 'T[:,:,:]', y: 'T[:,:,:]'):
     """
     Kernel for computing y = alpha * x + y.
 

--- a/psydac/linalg/kernels/inner_kernels.py
+++ b/psydac/linalg/kernels/inner_kernels.py
@@ -7,8 +7,8 @@ from pyccel.decorators import template
 #!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!#
 
 #==============================================================================
-@template(name='T', types=['float[:]', 'complex[:]'])
-def inner_1d(v1: 'T', v2: 'T', nghost0: 'int64'):
+@template(name='T', types=[float, complex])
+def inner_1d(v1: 'T[:]', v2: 'T[:]', nghost0: 'int64'):
     """
     Kernel for computing the inner product (case of two 1D vectors).
 
@@ -34,8 +34,8 @@ def inner_1d(v1: 'T', v2: 'T', nghost0: 'int64'):
     return res
 
 #==============================================================================
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-def inner_2d(v1: 'T', v2: 'T', nghost0: 'int64', nghost1: 'int64'):
+@template(name='T', types=[float, complex])
+def inner_2d(v1: 'T[:,:]', v2: 'T[:,:]', nghost0: 'int64', nghost1: 'int64'):
     """
     Kernel for computing the inner product (case of two 2D vectors).
 
@@ -65,8 +65,8 @@ def inner_2d(v1: 'T', v2: 'T', nghost0: 'int64', nghost1: 'int64'):
     return res
 
 #==============================================================================
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-def inner_3d(v1: 'T', v2: 'T', nghost0: 'int64', nghost1: 'int64', nghost2: 'int64'):
+@template(name='T', types=[float, complex])
+def inner_3d(v1: 'T[:,:,:]', v2: 'T[:,:,:]', nghost0: 'int64', nghost1: 'int64', nghost2: 'int64'):
     """
     Kernel for computing the inner product (case of two 3D vectors).
 

--- a/psydac/linalg/kernels/matvec_kernels.py
+++ b/psydac/linalg/kernels/matvec_kernels.py
@@ -1,9 +1,8 @@
 from pyccel.decorators import template
 
 
-@template(name='T', types=['float[:]', 'complex[:]'])
-@template(name='Tarray', types=['float[:,:]', 'complex[:,:]'])
-def matvec_1d(mat00:'Tarray', x0:'T', out0:'T', starts: 'int64[:]', nrows: 'int64[:]', nrows_extra: 'int64[:]',
+@template(name='T', types=[float, complex])
+def matvec_1d(mat00:'T[:,:]', x0:'T[:]', out0:'T[:]', starts: 'int64[:]', nrows: 'int64[:]', nrows_extra: 'int64[:]',
                   dm:'int64[:]', cm:'int64[:]', pad_imp:'int64[:]', ndiags:'int64[:]', gpads: 'int64[:]'):
 
     nrows1   = nrows[0]
@@ -38,9 +37,9 @@ def matvec_1d(mat00:'Tarray', x0:'T', out0:'T', starts: 'int64[:]', nrows: 'int6
             out0[pxm1 + i1] = v00
 
 
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='Tarray', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def matvec_2d(mat00:'Tarray', x0:'T', out0:'T', starts:'int64[:]', nrows:'int64[:]', nrows_extra:'int64[:]',
+
+@template(name='T', types=[float, complex])
+def matvec_2d(mat00:'T[:,:,:,:]', x0:'T[:,:]', out0:'T[:,:]', starts:'int64[:]', nrows:'int64[:]', nrows_extra:'int64[:]',
                   dm:'int64[:]', cm:'int64[:]', pad_imp:'int64[:]', ndiags:'int64[:]', gpads: 'int64[:]'):
 
     nrows1   = nrows[0]
@@ -105,9 +104,8 @@ def matvec_2d(mat00:'Tarray', x0:'T', out0:'T', starts:'int64[:]', nrows:'int64[
                 out0[pxm1 + i1, pxm2 + i2] = v00
 
 
-@template(name='T', types=['float[:,:,:]', 'complex[:,:,:]'])
-@template(name='Tarray', types=['float[:,:,:,:,:,:]', 'complex[:,:,:,:,:,:]'])
-def matvec_3d(mat00:'Tarray', x0:'T', out0:'T', starts:'int64[:]', nrows:'int64[:]', nrows_extra:'int64[:]',
+@template(name='T', types=[float, complex])
+def matvec_3d(mat00:'T[:,:,:,:,:,:]', x0:'T[:,:,:]', out0:'T[:,:,:]', starts:'int64[:]', nrows:'int64[:]', nrows_extra:'int64[:]',
                   dm:'int64[:]', cm:'int64[:]', pad_imp:'int64[:]', ndiags:'int64[:]', gpads: 'int64[:]'):
 
     nrows1   = nrows[0]

--- a/psydac/linalg/kernels/stencil2coo_kernels.py
+++ b/psydac/linalg/kernels/stencil2coo_kernels.py
@@ -1,16 +1,16 @@
 # coding: utf-8
 from pyccel.decorators import template
 
-#========================================================================================================
+#!!!!!!!!!!!!!
+#TODO avoid using The expensive modulo operator % in the non periodic case to make the methods faster
+#!!!!!!!!!!!!!
+
 
 #__all__ = ['stencil2coo_1d_C','stencil2coo_1d_F','stencil2coo_2d_C','stencil2coo_2d_F', 'stencil2coo_3d_C', 'stencil2coo_3d_F']
 
-# If we can create an array of a pyccel template, we should only create one template
-#       @template(name='T', types=['float', 'complex'])
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-#TODO avoid using The expensive modulo operator % in the non periodic case to make the methods faster
-def stencil2coo_1d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]', nrl1:'int64', ncl1:'int64',
+#========================================================================================================
+@template(name='T', types=[float, complex])
+def stencil2coo_1d_C(A:'T[:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]', nrl1:'int64', ncl1:'int64',
                      s1:'int64', nr1:'int64', nc1:'int64', dm1:'int64', cm1:'int64', p1:'int64', dp1:'int64'):
     nnz = 0
     pp1 = cm1*p1
@@ -27,11 +27,10 @@ def stencil2coo_1d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]', nrl1:
 
     return nnz
 
-
 #========================================================================================================
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-def stencil2coo_1d_F(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]', nrl1:'int64', ncl1:'int64', s1:'int64', nr1:'int64', nc1:'int64', dm1:'int64', cm1:'int64', p1:'int64', dp1:'int64'):
+@template(name='T', types=[float, complex])
+def stencil2coo_1d_F(A:'T[:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]', nrl1:'int64', ncl1:'int64',
+                     s1:'int64', nr1:'int64', nc1:'int64', dm1:'int64', cm1:'int64', p1:'int64', dp1:'int64'):
     nnz = 0
     pp1 = cm1*p1
     for i1 in range(nrl1):
@@ -47,11 +46,9 @@ def stencil2coo_1d_F(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]', nrl1:
 
     return nnz
 
-
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-def stencil2coo_2d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
+@template(name='T', types=[float, complex])
+def stencil2coo_2d_C(A:'T[:,:,:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]',
                      nrl1:'int64', nrl2:'int64', ncl1:'int64', ncl2:'int64',
                      s1:'int64', s2:'int64', nr1:'int64', nr2:'int64',
                      nc1:'int64', nc2:'int64', dm1:'int64', dm2:'int64',
@@ -80,11 +77,9 @@ def stencil2coo_2d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
                     nnz += 1
     return nnz
 
-
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-def stencil2coo_2d_F(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
+@template(name='T', types=[float, complex])
+def stencil2coo_2d_F(A:'T[:,:,:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]',
                      nrl1:'int64', nrl2:'int64', ncl1:'int64', ncl2:'int64',
                      s1:'int64', s2:'int64', nr1:'int64', nr2:'int64',
                      nc1:'int64', nc2:'int64', dm1:'int64', dm2:'int64',
@@ -113,11 +108,9 @@ def stencil2coo_2d_F(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
                     nnz += 1
     return nnz
 
-
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:,:,:]', 'complex[:,:,:,:,:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-def stencil2coo_3d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
+@template(name='T', types=[float, complex])
+def stencil2coo_3d_C(A:'T[:,:,:,:,:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]',
                      nrl1:'int64', nrl2:'int64', nrl3:'int64', ncl1:'int64', ncl2:'int64', ncl3:'int64',
                      s1:'int64', s2:'int64', s3:'int64', nr1:'int64', nr2:'int64', nr3:'int64',
                      nc1:'int64', nc2:'int64', nc3:'int64', dm1:'int64', dm2:'int64', dm3:'int64',
@@ -154,9 +147,8 @@ def stencil2coo_3d_C(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
 
 
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:,:,:]', 'complex[:,:,:,:,:,:]'])
-@template(name='data', types=['float[:]', 'complex[:]'])
-def stencil2coo_3d_F(A:'T', data:'data', rows:'int64[:]', cols:'int64[:]',
+@template(name='T', types=[float, complex])
+def stencil2coo_3d_F(A:'T[:,:,:,:,:,:]', data:'T[:]', rows:'int64[:]', cols:'int64[:]',
                      nrl1:'int64', nrl2:'int64', nrl3:'int64', ncl1:'int64', ncl2:'int64', ncl3:'int64',
                      s1:'int64', s2:'int64', s3:'int64', nr1:'int64', nr2:'int64', nr3:'int64',
                      nc1:'int64', nc2:'int64', nc3:'int64', dm1:'int64', dm2:'int64', dm3:'int64',

--- a/psydac/linalg/kernels/transpose_kernels.py
+++ b/psydac/linalg/kernels/transpose_kernels.py
@@ -1,19 +1,20 @@
 from pyccel.decorators import template
 
 #========================================================================================================
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-def transpose_1d( M:'T', Mt:'T',
-                 n:"int64[:]",
-                 nc:"int64[:]",
-                 gp:"int64[:]",
-                 p:"int64[:]",
-                 dm:"int64[:]",
-                 cm:"int64[:]",
-                 nd:"int64[:]",
-                 ndT:"int64[:]",
-                 si:"int64[:]",
-                 sk:"int64[:]",
-                 sl:"int64[:]"):
+@template(name='T', types=[float, complex])
+def transpose_1d(M  : "T[:,:]",
+                 Mt : "T[:,:]",
+                 n  : "int64[:]",
+                 nc : "int64[:]",
+                 gp : "int64[:]",
+                 p  : "int64[:]",
+                 dm : "int64[:]",
+                 cm : "int64[:]",
+                 nd : "int64[:]",
+                 ndT: "int64[:]",
+                 si : "int64[:]",
+                 sk : "int64[:]",
+                 sl : "int64[:]"):
 
     #$omp parallel default(private) shared(Mt,M) firstprivate( n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
     d1 = gp[0] - p[0]
@@ -34,25 +35,28 @@ def transpose_1d( M:'T', Mt:'T',
     return
 
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def transpose_2d( M:'T', Mt:'T',
-                 n:"int64[:]",
-                 nc:"int64[:]",
-                 gp:"int64[:]",
-                 p:"int64[:]",
-                 dm:"int64[:]",
-                 cm:"int64[:]",
-                 nd:"int64[:]",
-                 ndT:"int64[:]",
-                 si:"int64[:]",
-                 sk:"int64[:]",
-                 sl:"int64[:]"):
+@template(name='T', types=[float, complex])
+def transpose_2d(M  : "T[:,:,:,:]",
+                 Mt : "T[:,:,:,:]",
+                 n  : "int64[:]",
+                 nc : "int64[:]",
+                 gp : "int64[:]",
+                 p  : "int64[:]",
+                 dm : "int64[:]",
+                 cm : "int64[:]",
+                 nd : "int64[:]",
+                 ndT: "int64[:]",
+                 si : "int64[:]",
+                 sk : "int64[:]",
+                 sl : "int64[:]"):
 
     #$omp parallel default(private) shared(Mt,M) firstprivate( n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
-    d1 = gp[0]-p[0]
-    d2 = gp[1]-p[1]
+    d1 = gp[0] - p[0]
+    d2 = gp[1] - p[1]
+
     e1 = nd[0] - sl[0]
     e2 = nd[1] - sl[1]
+
     #$omp for schedule(static) collapse(2)
     for x1 in range(n[0]):
         for x2 in range(n[1]):
@@ -73,28 +77,32 @@ def transpose_2d( M:'T', Mt:'T',
                         Mt[j1,j2, l1 + sl[0],l2 + sl[1]] = M[i1,i2, k1,k2]
     #$omp end parallel
     return
-#========================================================================================================
-@template(name='T', types=['float[:,:,:,:,:,:]', 'complex[:,:,:,:,:,:]'])
-def transpose_3d(M:'T', Mt:'T',
-                 n:"int64[:]",
-                 nc:"int64[:]",
-                 gp:"int64[:]",
-                 p:"int64[:]",
-                 dm:"int64[:]",
-                 cm:"int64[:]",
-                 nd:"int64[:]",
-                 ndT:"int64[:]",
-                 si:"int64[:]",
-                 sk:"int64[:]",
-                 sl:"int64[:]"):
 
-    #$omp parallel default(private) shared(Mt,M) firstprivate( n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
-    d1 = gp[0]-p[0]
-    d2 = gp[1]-p[1]
-    d3 = gp[2]-p[2]
+#========================================================================================================
+@template(name='T', types=[float, complex])
+def transpose_3d(M  : "T[:,:,:,:,:,:]",
+                 Mt : "T[:,:,:,:,:,:]",
+                 n  : "int64[:]",
+                 nc : "int64[:]",
+                 gp : "int64[:]",
+                 p  : "int64[:]",
+                 dm : "int64[:]",
+                 cm : "int64[:]",
+                 nd : "int64[:]",
+                 ndT: "int64[:]",
+                 si : "int64[:]",
+                 sk : "int64[:]",
+                 sl : "int64[:]"):
+
+    #$omp parallel default(private) shared(Mt,M) firstprivate(n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
+    d1 = gp[0] - p[0]
+    d2 = gp[1] - p[1]
+    d3 = gp[2] - p[2]
+
     e1 = nd[0] - sl[0]
     e2 = nd[1] - sl[1]
     e3 = nd[2] - sl[2]
+
     #$omp for schedule(static) collapse(3)
     for x1 in range(n[0]):
         for x2 in range(n[1]):
@@ -123,22 +131,23 @@ def transpose_3d(M:'T', Mt:'T',
     return
 
 #========================================================================================================
-@template(name='T', types=['float[:,:]', 'complex[:,:]'])
-def interface_transpose_1d( M:'T', Mt:'T',
-                            n:"int64[:]",
-                            nc:"int64[:]",
-                            gp:"int64[:]",
-                            p:"int64[:]",
-                            dm:"int64[:]",
-                            cm:"int64[:]",
-                            nd:"int64[:]",
-                            ndT:"int64[:]",
-                            si:"int64[:]",
-                            sk:"int64[:]",
-                            sl:"int64[:]"):
+@template(name='T', types=[float, complex])
+def interface_transpose_1d(M  : "T[:,:]",
+                           Mt : "T[:,:]",
+                           n  : "int64[:]",
+                           nc : "int64[:]",
+                           gp : "int64[:]",
+                           p  : "int64[:]",
+                           dm : "int64[:]",
+                           cm : "int64[:]",
+                           nd : "int64[:]",
+                           ndT: "int64[:]",
+                           si : "int64[:]",
+                           sk : "int64[:]",
+                           sl : "int64[:]"):
 
     #$ omp parallel default(private) shared(Mt,M) firstprivate(n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
-    d1 = gp[0]-p[0]
+    d1 = gp[0] - p [0]
     e1 = nd[0] - sl[0]
 
     #$ omp for schedule(static) collapse(1)
@@ -159,23 +168,25 @@ def interface_transpose_1d( M:'T', Mt:'T',
     return
 
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:]', 'complex[:,:,:,:]'])
-def interface_transpose_2d( M:'T', Mt:'T',
-                            n:"int64[:]",
-                            nc:"int64[:]",
-                            gp:"int64[:]",
-                            p:"int64[:]",
-                            dm:"int64[:]",
-                            cm:"int64[:]",
-                            nd:"int64[:]",
-                            ndT:"int64[:]",
-                            si:"int64[:]",
-                            sk:"int64[:]",
-                            sl:"int64[:]"):
+@template(name='T', types=[float, complex])
+def interface_transpose_2d(M  : "T[:,:,:,:]",
+                           Mt : "T[:,:,:,:]",
+                           n  : "int64[:]",
+                           nc : "int64[:]",
+                           gp : "int64[:]",
+                           p  : "int64[:]",
+                           dm : "int64[:]",
+                           cm : "int64[:]",
+                           nd : "int64[:]",
+                           ndT: "int64[:]",
+                           si : "int64[:]",
+                           sk : "int64[:]",
+                           sl : "int64[:]"):
 
     #$ omp parallel default(private) shared(Mt,M) firstprivate(n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
-    d1 = gp[0]-p[0]
-    d2 = gp[1]-p[1]
+    d1 = gp[0] - p[0]
+    d2 = gp[1] - p[1]
+
     e1 = nd[0] - sl[0]
     e2 = nd[1] - sl[1]
 
@@ -203,24 +214,26 @@ def interface_transpose_2d( M:'T', Mt:'T',
     return
 
 #========================================================================================================
-@template(name='T', types=['float[:,:,:,:,:,:]', 'complex[:,:,:,:,:,:]'])
-def interface_transpose_3d( M:'T', Mt:'T',
-                            n:"int64[:]",
-                            nc:"int64[:]",
-                            gp:"int64[:]",
-                            p:"int64[:]",
-                            dm:"int64[:]",
-                            cm:"int64[:]",
-                            nd:"int64[:]",
-                            ndT:"int64[:]",
-                            si:"int64[:]",
-                            sk:"int64[:]",
-                            sl:"int64[:]"):
+@template(name='T', types=[float, complex])
+def interface_transpose_3d(M  : "T[:,:,:,:,:,:]",
+                           Mt : "T[:,:,:,:,:,:]",
+                           n  : "int64[:]",
+                           nc : "int64[:]",
+                           gp : "int64[:]",
+                           p  : "int64[:]",
+                           dm : "int64[:]",
+                           cm : "int64[:]",
+                           nd : "int64[:]",
+                           ndT: "int64[:]",
+                           si : "int64[:]",
+                           sk : "int64[:]",
+                           sl : "int64[:]"):
 
     #$ omp parallel default(private) shared(Mt,M) firstprivate(n,nc,gp,p,dm,cm,nd,ndT,si,sk,sl)
-    d1 = gp[0]-p[0]
-    d2 = gp[1]-p[1]
-    d3 = gp[2]-p[2]
+    d1 = gp[0] - p[0]
+    d2 = gp[1] - p[1]
+    d3 = gp[2] - p[2]
+
     e1 = nd[0] - sl[0]
     e2 = nd[1] - sl[1]
     e3 = nd[2] - sl[2]

--- a/psydac_accelerate.py
+++ b/psydac_accelerate.py
@@ -23,7 +23,7 @@ parser.add_argument('--language',
                     choices=['fortran', 'c'],
                     action='store',
                     dest='language',
-                    help='Language used to pyccelise all the _kernels files'
+                    help='Language used to pyccelize all the _kernels files'
                     )
 
 # Add flag --openmp at the pyccel command
@@ -40,7 +40,7 @@ args = parser.parse_args()
 # get the absolute path to the psydac directory
 psydac_path = os.path.dirname(os.path.abspath(__file__))+'/psydac'
 
-print("\n This script should only be used if psydac was installed in editable mode.\n")
+print("\nNOTE: This script should only be used if Psydac was installed in editable mode.\n")
 
 # Define all the parameters of the command in the parameters array
 parameters = ['--language', args.language]
@@ -53,8 +53,6 @@ if args.openmp:
 for path, subdirs, files in os.walk(psydac_path):
     for name in files:
         if name.endswith('_kernels.py'):
-            print('Pyccelise file :' + os.path.join(path, name))
+            print('  Pyccelize file: ' + os.path.join(path, name))
             sub_run([shutil.which('pyccel'), os.path.join(path, name), *parameters], shell=False)
-            print('\n')
-
-
+print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
     # Our packages from PyPi
     'sympde == 0.18.1',
-    'pyccel >= 1.11',
+    'pyccel >= 1.11.2',
     'gelato == 0.12',
 
     # In addition, we depend on mpi4py and h5py (MPI version).


### PR DESCRIPTION
Use partial templates to generate the minimum possible number of functions.
Fixes #383.

- Use partial types in templates
- Require Pyccel version 1.11.2 or newer, as it contains a necessary bugfix
- Improve printing to terminal of script psydac_accelerate.py