### PR TITLE
fix some LinearOperator class functions 

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -263,7 +263,7 @@ class LinearOperator(ABC):
     # Magic methods
     #-------------------------------------
     def __neg__(self):
-        return ScaledLinearOperator(self._domain, self._codomain, -1.0, self)
+        return ScaledLinearOperator(self.domain, self.codomain, -1.0, self)
 
     def __mul__(self, c):
         """
@@ -273,11 +273,11 @@ class LinearOperator(ABC):
         """
         assert np.isscalar(c)
         if c==0:
-            return ZeroOperator(self._domain, self._codomain)
+            return ZeroOperator(self.domain, self.codomain)
         elif c == 1:
             return self
         else:
-            return ScaledLinearOperator(self._domain, self._codomain, c, self)
+            return ScaledLinearOperator(self.domain, self.codomain, c, self)
 
     def __rmul__(self, c):
         """ Calls :ref:`__mul__ <mul>` instead. """
@@ -287,13 +287,13 @@ class LinearOperator(ABC):
         """ Creates an object of class :ref:`ComposedLinearOperator <composedlinearoperator>`. """
         assert isinstance(B, (LinearOperator, Vector))
         if isinstance(B, LinearOperator):
-            assert self._domain == B.codomain
+            assert self.domain == B.codomain
             if isinstance(B, ZeroOperator):
-                return ZeroOperator(B.domain, self._codomain)
+                return ZeroOperator(B.domain, self.codomain)
             elif isinstance(B, IdentityOperator):
                 return self
             else:
-                return ComposedLinearOperator(B.domain, self._codomain, self, B)
+                return ComposedLinearOperator(B.domain, self.codomain, self, B)
         else:
             return self.dot(B)
 
@@ -303,18 +303,18 @@ class LinearOperator(ABC):
         if isinstance(B, ZeroOperator):
             return self
         else:
-            return SumLinearOperator(self._domain, self._codomain, self, B)
+            return SumLinearOperator(self.domain, self.codomain, self, B)
 
     def __sub__(self, m):
         assert isinstance(m, LinearOperator)
         if isinstance(m, ZeroOperator):
             return self
         else:
-            return SumLinearOperator(self._domain, self._codomain, self, -m)
+            return SumLinearOperator(self.domain, self.codomain, self, -m)
 
     def __pow__(self, n):
         """ Creates an object of class :ref:`PowerLinearOperator <powerlinearoperator>`. """
-        return PowerLinearOperator(self._domain, self._codomain, self, n)
+        return PowerLinearOperator(self.domain, self.codomain, self, n)
 
     def __truediv__(self, c):
         """ Divide by scalar. """
@@ -393,7 +393,7 @@ class ZeroOperator(LinearOperator):
         return None
 
     def copy(self):
-        return ZeroOperator(self._domain, self._codomain)
+        return ZeroOperator(self.domain, self.codomain)
 
     def toarray(self):
         return np.zeros(self.shape, dtype=self.dtype) 
@@ -403,17 +403,17 @@ class ZeroOperator(LinearOperator):
         return csr_matrix(self.shape, dtype=self.dtype)
 
     def transpose(self, conjugate=False):
-        return ZeroOperator(domain=self._codomain, codomain=self._domain)
+        return ZeroOperator(domain=self.codomain, codomain=self.domain)
 
     def dot(self, v, out=None):
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
             out *= 0
         else:
-            out = self._codomain.zeros()
+            out = self.codomain.zeros()
         return out
 
     def __neg__(self):
@@ -421,14 +421,14 @@ class ZeroOperator(LinearOperator):
 
     def __add__(self, B):
         assert isinstance(B, LinearOperator)
-        assert self._domain == B.domain
-        assert self._codomain == B.codomain
+        assert self.domain == B.domain
+        assert self.codomain == B.codomain
         return B
 
     def __sub__(self, B):
         assert isinstance(B, LinearOperator)
-        assert self._domain == B.domain
-        assert self._codomain == B.codomain
+        assert self.domain == B.domain
+        assert self.codomain == B.codomain
         return -B
 
     def __mul__(self, c):
@@ -438,8 +438,8 @@ class ZeroOperator(LinearOperator):
     def __matmul__(self, B):
         assert isinstance(B, (LinearOperator, Vector))
         if isinstance(B, LinearOperator):
-            assert self._domain == B.codomain
-            return ZeroOperator(domain=B.domain, codomain=self._codomain)
+            assert self.domain == B.codomain
+            return ZeroOperator(domain=B.domain, codomain=self.codomain)
         else:
             return self.dot(B)
 
@@ -481,25 +481,25 @@ class IdentityOperator(LinearOperator):
         return None
 
     def copy(self):
-        return IdentityOperator(self._domain, self._codomain)
+        return IdentityOperator(self.domain, self.codomain)
 
     def toarray(self):
-        return np.diag(np.ones(self._domain.dimension , dtype=self.dtype)) 
+        return np.diag(np.ones(self.domain.dimension , dtype=self.dtype)) 
 
     def tosparse(self):
         from scipy.sparse import identity
-        return identity(self._domain.dimension, dtype=self.dtype, format="csr")
+        return identity(self.domain.dimension, dtype=self.dtype, format="csr")
 
     def transpose(self, conjugate=False):
         """ Could return self, but by convention returns new object. """
-        return IdentityOperator(self._domain, self._codomain)
+        return IdentityOperator(self.domain, self.codomain)
 
     def dot(self, v, out=None):
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
             out *= 0
             out += v
             return out
@@ -509,7 +509,7 @@ class IdentityOperator(LinearOperator):
     def __matmul__(self, B):
         assert isinstance(B, (LinearOperator, Vector))
         if isinstance(B, LinearOperator):
-            assert self._domain == B.codomain
+            assert self.domain == B.codomain
             return B
         else:
             return self.dot(B)
@@ -566,17 +566,17 @@ class ScaledLinearOperator(LinearOperator):
         return self._scalar*csr_matrix(self._operator.toarray())
 
     def transpose(self, conjugate=False):
-        return ScaledLinearOperator(domain=self._codomain, codomain=self._domain, c=self._scalar, A=self._operator.transpose(conjugate=conjugate))
+        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=self._scalar, A=self._operator.transpose(conjugate=conjugate))
 
     def __neg__(self):
-        return ScaledLinearOperator(domain=self._domain, codomain=self._codomain, c=-1*self._scalar, A=self._operator)
+        return ScaledLinearOperator(domain=self.domain, codomain=self.codomain, c=-1*self._scalar, A=self._operator)
 
     def dot(self, v, out=None):
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
             self._operator.dot(v, out = out)
             out *= self._scalar
             return out
@@ -662,7 +662,7 @@ class SumLinearOperator(LinearOperator):
         t_addends = ()
         for a in self._addends:
             t_addends = (*t_addends, a.transpose(conjugate=conjugate))
-        return SumLinearOperator(self._codomain, self._domain, *t_addends)
+        return SumLinearOperator(self.codomain, self.domain, *t_addends)
 
     @staticmethod
     def simplify(addends):
@@ -688,16 +688,16 @@ class SumLinearOperator(LinearOperator):
     def dot(self, v, out=None):
         """ Evaluates SumLinearOperator object at a vector v element of domain. """
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
             out *= 0
             for a in self._addends:
                 a.idot(v, out)
             return out
         else:
-            out = self._codomain.zeros()
+            out = self.codomain.zeros()
             for a in self._addends:
                 a.idot(v, out=out)
             return out
@@ -775,18 +775,18 @@ class ComposedLinearOperator(LinearOperator):
         t_multiplicants = ()
         for a in self._multiplicants:
             t_multiplicants = (a.transpose(conjugate=conjugate), *t_multiplicants)
-        new_dom = self._codomain
-        new_cod = self._domain
+        new_dom = self.codomain
+        new_cod = self.domain
         assert isinstance(new_dom, VectorSpace)
         assert isinstance(new_cod, VectorSpace)
-        return ComposedLinearOperator(self._codomain, self._domain, *t_multiplicants)
+        return ComposedLinearOperator(self.codomain, self.domain, *t_multiplicants)
 
     def dot(self, v, out=None):
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
 
         x = v
         for i in range(len(self._tmp_vectors)):
@@ -869,14 +869,14 @@ class PowerLinearOperator(LinearOperator):
         raise NotImplementedError('tosparse() is not defined for PowerLinearOperators.')
 
     def transpose(self, conjugate=False):
-        return PowerLinearOperator(domain=self._codomain, codomain=self._domain, A=self._operator.transpose(conjugate=conjugate), n=self._factorial)
+        return PowerLinearOperator(domain=self.codomain, codomain=self.domain, A=self._operator.transpose(conjugate=conjugate), n=self._factorial)
 
     def dot(self, v, out=None):
         assert isinstance(v, Vector)
-        assert v.space == self._domain
+        assert v.space == self.domain
         if out is not None:
             assert isinstance(out, Vector)
-            assert out.space == self._codomain
+            assert out.space == self.codomain
             for i in range(self._factorial):
                 self._operator.dot(v, out=out)
                 v = out.copy()


### PR DESCRIPTION
The functions should use abstract properties `domain` and `codomain` rather than corresponding private attributes `_domain` and `_codomain` (which may not exist for some child classes).