### PR TITLE
Fix several errors in `cell_index_p`

### DIFF
--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -910,6 +910,8 @@ def cell_index(breaks, i_grid, tol=1e-15, out=None):
     status = cell_index_p(breaks, i_grid, tol, out)
     if status == -1:
         raise ValueError("Encountered a point that was outside of the domain")
+    elif status == -2:
+        raise ValueError("Loop too long in cell search: a point might be slightly outside of the domain")
     return out
 
 #==============================================================================

--- a/psydac/core/bsplines_kernels.py
+++ b/psydac/core/bsplines_kernels.py
@@ -1097,7 +1097,6 @@ def cell_index_p(breaks: 'float[:]', i_grid: 'float[:]', tol: float, out: 'int[:
             i_cell = (low + high)//2
             it += 1
         if it >= max_it:
-            print("Warning: binary search loop is too long in cell_index_p -- aborted")
             return -2
         
         # Check were we landed with the binary search

--- a/psydac/core/bsplines_kernels.py
+++ b/psydac/core/bsplines_kernels.py
@@ -1077,8 +1077,8 @@ def cell_index_p(breaks: 'float[:]', i_grid: 'float[:]', tol: float, out: 'int[:
     nbk = len(breaks)
 
     # Check if there are points outside the domain
-    if np.min(i_grid) < breaks[0] - tol/2: return 1
-    if np.max(i_grid) > breaks[nbk - 1] + tol/2: return 1
+    if np.min(i_grid) < breaks[0] - tol/2: return -1
+    if np.max(i_grid) > breaks[nbk - 1] + tol/2: return -1
 
     current_index = 0
     while current_index < nx:
@@ -1087,13 +1087,19 @@ def cell_index_p(breaks: 'float[:]', i_grid: 'float[:]', tol: float, out: 'int[:
         # Binary search
         low, high = 0, nbk - 1
         i_cell = (low + high)//2
-        while  x < breaks[i_cell] - tol or x >= breaks[i_cell + 1] + tol:
+        it = 0
+        max_it = 2*(high-low) # this number of iterations should not be reached
+        while it < max_it and (x < breaks[i_cell] - tol or x >= breaks[i_cell + 1] + tol):
             if x < breaks[i_cell]:
                 high = i_cell
             else:
                 low = i_cell
             i_cell = (low + high)//2
-
+            it += 1
+        if it >= max_it:
+            print("Warning: binary search loop is too long in cell_index_p -- aborted")
+            return -1
+        
         # Check were we landed with the binary search
         # Case 1: x is the left breakpoint
         if abs(x - breaks[i_cell]) < tol:

--- a/psydac/core/bsplines_kernels.py
+++ b/psydac/core/bsplines_kernels.py
@@ -1077,8 +1077,8 @@ def cell_index_p(breaks: 'float[:]', i_grid: 'float[:]', tol: float, out: 'int[:
     nbk = len(breaks)
 
     # Check if there are points outside the domain
-    if np.min(i_grid) < breaks[0] - tol: return 1
-    if np.max(i_grid) > breaks[nbk - 1] + tol: return 1
+    if np.min(i_grid) < breaks[0] - tol/2: return 1
+    if np.max(i_grid) > breaks[nbk - 1] + tol/2: return 1
 
     current_index = 0
     while current_index < nx:

--- a/psydac/core/bsplines_kernels.py
+++ b/psydac/core/bsplines_kernels.py
@@ -1098,7 +1098,7 @@ def cell_index_p(breaks: 'float[:]', i_grid: 'float[:]', tol: float, out: 'int[:
             it += 1
         if it >= max_it:
             print("Warning: binary search loop is too long in cell_index_p -- aborted")
-            return -1
+            return -2
         
         # Check were we landed with the binary search
         # Case 1: x is the left breakpoint

--- a/psydac/core/tests/test_bsplines_kernel.py
+++ b/psydac/core/tests/test_bsplines_kernel.py
@@ -8,7 +8,6 @@ from psydac.core.bsplines_kernels import cell_index_p
 
 def test_cell_index_p():
     breaks = np.array([0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.])
-    # i_grid = np.asarray(i_grid)
     breaks = np.ascontiguousarray(breaks, dtype=float)
     out = np.zeros_like(breaks, dtype=np.int64)
     tol = 1e-15
@@ -25,4 +24,12 @@ def test_cell_index_p():
         i_grid[:] += offset
         status = cell_index_p(breaks, i_grid, tol, out)
         assert status == expected_status
+
+    # checking that the values match those of searchsorted (-1) for arbitrary grid points
+    i_grid = np.random.random(30)
+    out = np.zeros_like(i_grid, dtype=np.int64)
+    status = cell_index_p(breaks, i_grid, tol, out)
+    assert status == 0
+    nps = np.searchsorted(breaks, i_grid)-1
+    assert np.allclose(out, nps)
 

--- a/psydac/core/tests/test_bsplines_kernel.py
+++ b/psydac/core/tests/test_bsplines_kernel.py
@@ -13,6 +13,12 @@ def test_cell_index_p():
     out = np.zeros_like(breaks, dtype=np.int64)
     tol = 1e-15
 
+    # limit case: code should decide wether point is in or out, not fall in infinite loop
+    i_grid = breaks.copy()
+    i_grid[:] += tol
+    status = cell_index_p(breaks, i_grid, tol, out)
+    assert status in [0,-1]
+
     # usual cases: points inside or outside domain
     for offset, expected_status in [(0, 0), (tol/2, 0), (2*tol, -1)]:
         i_grid = breaks.copy()
@@ -20,8 +26,3 @@ def test_cell_index_p():
         status = cell_index_p(breaks, i_grid, tol, out)
         assert status == expected_status
 
-    # limit case: code should decide wether point is in or out, not fall in infinite loop
-    i_grid = breaks.copy()
-    i_grid[:] += tol
-    status = cell_index_p(breaks, i_grid, tol, out)
-    assert status in [0,-1]

--- a/psydac/core/tests/test_bsplines_kernel.py
+++ b/psydac/core/tests/test_bsplines_kernel.py
@@ -1,0 +1,27 @@
+#coding: utf-8
+
+import pytest
+import numpy as np
+
+
+from psydac.core.bsplines_kernels import cell_index_p
+
+def test_cell_index_p():
+    breaks = np.array([0. , 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.])
+    # i_grid = np.asarray(i_grid)
+    breaks = np.ascontiguousarray(breaks, dtype=float)
+    out = np.zeros_like(breaks, dtype=np.int64)
+    tol = 1e-15
+
+    # usual cases: points inside or outside domain
+    for offset, expected_status in [(0, 0), (tol/2, 0), (2*tol, -1)]:
+        i_grid = breaks.copy()
+        i_grid[:] += offset
+        status = cell_index_p(breaks, i_grid, tol, out)
+        assert status == expected_status
+
+    # limit case: code should decide wether point is in or out, not fall in infinite loop
+    i_grid = breaks.copy()
+    i_grid[:] += tol
+    status = cell_index_p(breaks, i_grid, tol, out)
+    assert status in [0,-1]

--- a/psydac/core/tests/test_bsplines_kernel.py
+++ b/psydac/core/tests/test_bsplines_kernel.py
@@ -26,7 +26,12 @@ def test_cell_index_p():
         assert status == expected_status
 
     # checking that the values match those of searchsorted (-1) for arbitrary grid points
-    i_grid = np.random.random(30)
+    i_grid = np.array([0.14320482, 0.86569833, 0.77775327, 0.00895956, 0.074629  ,
+       0.45682646, 0.5384352 , 0.20915311, 0.73121977, 0.01057414,
+       0.33756086, 0.17839759, 0.14023414, 0.09846206, 0.79970392,
+       0.65330406, 0.82716552, 0.24185731, 0.24054685, 0.72466651,
+       0.69125033, 0.3136558 , 0.64794089, 0.47975527, 0.99802844,
+       0.64402598, 0.41263526, 0.28178414, 0.57274384, 0.73218562])
     out = np.zeros_like(i_grid, dtype=np.int64)
     status = cell_index_p(breaks, i_grid, tol, out)
     assert status == 0


### PR DESCRIPTION
In `cell_index_p` we look for cells containing points. If a point is outside the domain exactly at `tol` distance from the bounds, then the search loop will be stuck in infinite recursion. One way to fix this is to lower the tolerance when checking if the points are within the domain (before actually entering the loop).

**Edit (21.03.2024):**

in this PR I also fix the `status` value returned by the cell search in `cell_index_p`, so that it is:
- 0 if all points are in domain
- -1 if some points are outside domain as expected by calling `cell_index` (was 1 before)
- -2 if search can't decide

in the third case the previous code was actually caught in an infinite loop. To avoid this behaviour I added a max number of iterations in `cell_index_p`

(and a unit test)
