### PR TITLE
Fix `None` value in `Pushforward`

### DIFF
--- a/psydac/feec/pushforward.py
+++ b/psydac/feec/pushforward.py
@@ -100,7 +100,10 @@ class Pushforward:
         self.npts_per_cell = npts_per_cell
         self.cell_indexes = cell_indexes
         self.grid_type=grid_type
-        grid_local=grid_local
+        if grid_local is None:
+            grid_local=grid
+        else:
+            grid_local=grid_local
 
         if isinstance(mapping, Mapping):
             self._mesh_grids = np.meshgrid(*grid_local, indexing='ij', sparse=True)

--- a/psydac/feec/pushforward.py
+++ b/psydac/feec/pushforward.py
@@ -102,8 +102,6 @@ class Pushforward:
         self.grid_type=grid_type
         if grid_local is None:
             grid_local=grid
-        else:
-            grid_local=grid_local
 
         if isinstance(mapping, Mapping):
             self._mesh_grids = np.meshgrid(*grid_local, indexing='ij', sparse=True)

--- a/psydac/feec/tests/test_pushforward.py
+++ b/psydac/feec/tests/test_pushforward.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from psydac.api.discretization  import discretize
+from sympde.topology            import ScalarFunctionSpace
+from sympde.topology            import Square
+from sympde.topology            import Mapping
+from psydac.mapping.discrete    import SplineMapping
+from psydac.feec.pushforward    import Pushforward
+
+def test_basic_call():
+
+    logical_domain = Square('Omega')
+
+    ncells = [2**4, 2**4]
+    degree = [2, 2]
+
+    # Mapping and physical domain
+    class CollelaMapping2D(Mapping):
+
+        _ldim = 2
+        _pdim = 2
+        _expressions = {'x': 'a * (x1 + eps / (2*pi) * sin(2*pi*x1) * sin(2*pi*x2))',
+                        'y': 'b * (x2 + eps / (2*pi) * sin(2*pi*x1) * sin(2*pi*x2))'}
+
+    mapping = CollelaMapping2D('M', a=1, b=1, eps=.2)
+    domain  = mapping(logical_domain)
+
+    hat_V0 = ScalarFunctionSpace('hat V0', logical_domain)
+    domain_h = discretize(logical_domain, ncells = ncells, periodic = [False, True])
+    hat_V0_h = discretize(hat_V0, domain_h, degree = degree)
+    
+    grid_x1 = hat_V0_h.breaks[0]
+    grid_x2 = hat_V0_h.breaks[1]
+
+    F = SplineMapping.from_mapping(hat_V0_h, mapping.get_callable_mapping())    
+    Pushforward(grid=(grid_x1, grid_x2), mapping=F, grid_type=0)
+
+    F = mapping   
+    Pushforward(grid=(grid_x1, grid_x2), mapping=F, grid_type=0)

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -1326,7 +1326,7 @@ def test_stencil_matrix_2d_serial_vdot(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
     ya_exact = np.dot(np.conjugate(Ma), xa)
     # Check data in 1D array
     assert y.dtype == dtype
-    assert np.allclose(ya, ya_exact, rtol=1e-13, atol=1e-13)
+    assert np.allclose(ya, ya_exact, rtol=1e-12, atol=1e-12)
 
 # TODO: verify for s>1
 # ===============================================================================


### PR DESCRIPTION
there was a small bug in the Pushforward function, when no `grid_local` was passed for a mapping of `Mapping` type

I also added a unit test