### PR TITLE
Add 1D field evaluation kernels

### DIFF
--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -316,6 +316,51 @@ def eval_fields_2d_irregular_no_weights(np1: int, np2: int, f_p1: int, f_p2: int
                     out_fields[i_p_1, i_p_2, :] += spline * coeff_fields
 
 
+@template(name='T', types=['float[:,:]', 'complex[:,:]'])
+def eval_fields_1d_irregular_no_weights(np1: int, f_p1: int,
+                                        cell_index_1: 'int[:]',
+                                        global_basis_1: 'float[:,:,:]',
+                                        global_spans_1: 'int[:]', 
+                                        glob_arr_coeff: 'T',
+                                        out_fields: 'T'):
+    """
+    Parameters
+    ----------
+    np1: int
+        Number of points in the X1 direction
+
+    f_p1: int
+        Degree in the X1 direction
+
+    cell_index_1 : ndarray of ints
+        Index of the cells in the X1 direction
+
+    global_basis_1: ndarray of floats
+        Basis functions values at each point in the X1 direction
+
+    global_spans_1: ndarray of ints
+        Spans in the X1 direction
+
+    glob_arr_coeff: ndarray of floats
+        Coefficients of the fields in the X1 direction
+
+    out_fields: ndarray of floats
+        Evaluated fields, filled with the correct values by the function
+    """
+    arr_coeff_fields = np.zeros_like(glob_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
+
+    for i_p_1 in range(np1):
+        i_cell_1 = cell_index_1[i_p_1]
+        span_1 = global_spans_1[i_cell_1]
+
+        arr_coeff_fields[:, :] = glob_arr_coeff[span_1 - f_p1:1 + span_1, :]
+
+        for i_basis_1 in range(1 + f_p1):
+            spline_1 = global_basis_1[i_p_1, i_basis_1, 0]
+            coeff_fields = arr_coeff_fields[i_basis_1, :]
+
+            out_fields[i_p_1, :] += spline_1 * coeff_fields
+
 # -----------------------------------------------------------------------------
 # 3: Regular tensor grid with weights
 # -----------------------------------------------------------------------------

--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -638,7 +638,7 @@ def eval_fields_1d_weighted(nc1: int, f_p1: int, k1: int,
     out_fields: ndarray of float
         Evaluated fields, filled with the correct values by the function
     """
-    arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[2]))
+    arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
     arr_coeff_weights = np.zeros(1 + f_p1)
 
     arr_fields = np.zeros_like(global_arr_coeff, shape=(k1, out_fields.shape[1]))

--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -200,7 +200,7 @@ def eval_fields_1d_no_weights(nc1: int, f_p1: int, k1: int,
             coeff_fields = arr_coeff_fields[i_basis_1, :]
             for i_quad_1 in range(k1):
                 spline = global_basis_1[i_cell_1, i_basis_1, 0, i_quad_1]
-                out_fields[i_cell_1 * k1 + i_quad_1:] += spline * coeff_fields
+                out_fields[i_cell_1 * k1 + i_quad_1, :] += spline * coeff_fields
 
 # -----------------------------------------------------------------------------
 # 2: Irregular tensor grid without weights
@@ -639,10 +639,10 @@ def eval_fields_1d_weighted(nc1: int, f_p1: int, k1: int,
         Evaluated fields, filled with the correct values by the function
     """
     arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
-    arr_coeff_weights = np.zeros(1 + f_p1)
+    arr_coeff_weights = np.zeros((1 + f_p1))
 
     arr_fields = np.zeros_like(global_arr_coeff, shape=(k1, out_fields.shape[1]))
-    arr_weights = np.zeros(k1)
+    arr_weights = np.zeros((k1))
 
     for i_cell_1 in range(nc1):
         span_1 = global_spans_1[i_cell_1]
@@ -668,7 +668,7 @@ def eval_fields_1d_weighted(nc1: int, f_p1: int, k1: int,
             fields = arr_fields[i_quad_1, :]
             weight = arr_weights[i_quad_1]
 
-            out_fields[i_cell_1 * k1 + i_quad_1,:] += fields / weight
+            out_fields[i_cell_1 * k1 + i_quad_1, :] += fields / weight
 
 
 # -----------------------------------------------------------------------------
@@ -869,7 +869,7 @@ def eval_fields_2d_irregular_weighted(np1: int, np2: int, f_p1: int, f_p2: int,
 def eval_fields_1d_irregular_weighted(np1: int, f_p1: int, 
                                       cell_index_1: 'int[:]', global_basis_1: 'float[:,:,:]',
                                       global_spans_1: 'int[:]', 
-                                      global_arr_coeff: 'T', global_arr_weights: 'float[:,:]',
+                                      global_arr_coeff: 'T', global_arr_weights: 'float[:]',
                                       out_fields: 'T'):
     """
     Parameters
@@ -898,18 +898,11 @@ def eval_fields_1d_irregular_weighted(np1: int, f_p1: int,
     out_fields : ndarray of floats
         Evaluated fields, filled with the correct values by the function
     """
-    arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
-    arr_coeff_weights = np.zeros(1 + f_p1)
-
     temp_fields = np.zeros_like(global_arr_coeff, shape=out_fields.shape[1])
 
     for i_p_1 in range(np1):
         i_cell_1 = cell_index_1[i_p_1]
         span_1 = global_spans_1[i_cell_1]
-
-        arr_coeff_fields[:, :] = global_arr_coeff[span_1 - f_p1:1 + span_1, :]
-
-        arr_coeff_weights[:] = global_arr_weights[span_1 - f_p1:1 + span_1]
 
         temp_fields[:] = 0.0
         temp_weight    = 0.0
@@ -917,9 +910,9 @@ def eval_fields_1d_irregular_weighted(np1: int, f_p1: int,
         for i_basis_1 in range(1 + f_p1):
             spline = global_basis_1[i_p_1, i_basis_1, 0]
 
-            coeff_fields = arr_coeff_fields[i_basis_1, :]
+            coeff_fields = global_arr_coeff[span_1 - f_p1 + i_basis_1, :]
 
-            coeff_weight = arr_coeff_weights[i_basis_1]
+            coeff_weight = global_arr_weights[span_1 - f_p1 + i_basis_1]
 
             temp_fields[:] += spline * coeff_fields * coeff_weight
 

--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -161,6 +161,47 @@ def eval_fields_2d_no_weights(nc1: int, nc2: int, f_p1: int, f_p2: int, k1: int,
                                        :] += spline * coeff_fields
 
 
+@template(name='T', types=['float[:,:]', 'complex[:,:]'])
+def eval_fields_1d_no_weights(nc1: int, f_p1: int, k1: int,
+                              global_basis_1: 'float[:,:,:,:]',
+                              global_spans_1: 'int[:]', 
+                              glob_arr_coeff: 'T',
+                              out_fields: 'T'):
+    """
+    Parameters
+    ----------
+    nc1: int
+        Number of cells in the X1 direction
+
+    f_p1: int
+        Degree in the X1 direction
+
+    k1: int
+        Number of evaluation points in the X1 direction
+
+    global_basis_1: ndarray of floats
+        Basis functions values at each cell and quadrature points in the X1 direction
+
+    global_spans_1: ndarray of ints
+        Spans in the X1 direction
+
+    glob_arr_coeff: ndarray of floats
+        Coefficients of the fields in the X1 and X2 directions
+
+    out_fields: ndarray of floats
+        Evaluated fields, filled with the correct values by the function
+    """
+    arr_coeff_fields = np.zeros_like(glob_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
+
+    for i_cell_1 in range(nc1):
+        span_1 = global_spans_1[i_cell_1]
+        arr_coeff_fields[:, :] = glob_arr_coeff[span_1 - f_p1:1 + span_1, :]
+        for i_basis_1 in range(1 + f_p1):
+            coeff_fields = arr_coeff_fields[i_basis_1, :]
+            for i_quad_1 in range(k1):
+                spline = global_basis_1[i_cell_1, i_basis_1, 0, i_quad_1]
+                out_fields[i_cell_1 * k1 + i_quad_1:] += spline * coeff_fields
+
 # -----------------------------------------------------------------------------
 # 2: Irregular tensor grid without weights
 # -----------------------------------------------------------------------------
@@ -565,6 +606,71 @@ def eval_fields_2d_weighted(nc1: int, nc2: int, f_p1: int, f_p2: int, k1: int, k
                                :] += fields / weight
 
 
+@template(name='T', types=['float[:,:]', 'complex[:,:]'])
+def eval_fields_1d_weighted(nc1: int, f_p1: int, k1: int, 
+                            global_basis_1: 'float[:,:,:,:]',
+                            global_spans_1: 'int[:]', global_arr_coeff: 'T',
+                            global_arr_weights: 'float[:]', out_fields: 'T'):
+    """
+    Parameters
+    ----------
+    nc1: int
+        Number of cells in the X1 direction
+
+    f_p1: int
+        Degree in the X1 direction
+
+    k1: int
+        Number of evaluation points in the X1 direction
+
+    global_basis_1: ndarray of float
+        Basis functions values at each cell and quadrature points in the X1 direction
+
+    global_spans_1: ndarray of int
+        Spans in the X1 direction
+
+    global_arr_coeff: ndarray of float
+        Coefficients of the fields in the X1 direction
+
+    global_arr_weights: ndarray of float
+        Coefficients of the weight field in the X1 direction
+
+    out_fields: ndarray of float
+        Evaluated fields, filled with the correct values by the function
+    """
+    arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[2]))
+    arr_coeff_weights = np.zeros(1 + f_p1)
+
+    arr_fields = np.zeros_like(global_arr_coeff, shape=(k1, out_fields.shape[1]))
+    arr_weights = np.zeros(k1)
+
+    for i_cell_1 in range(nc1):
+        span_1 = global_spans_1[i_cell_1]
+
+        arr_coeff_fields[:, :] = global_arr_coeff[span_1 - f_p1:1 + span_1, :]
+
+        arr_coeff_weights[:] = global_arr_weights[span_1 - f_p1:1 + span_1]
+
+        arr_fields[:, :] = 0.0
+        arr_weights[:] = 0.0
+
+        for i_quad_1 in range(k1):
+            for i_basis_1 in range(1 + f_p1):
+                spline = global_basis_1[i_cell_1, i_basis_1, 0, i_quad_1]
+
+                coeff_fields = arr_coeff_fields[i_basis_1, :]
+                coeff_weight = arr_coeff_weights[i_basis_1]
+
+                arr_fields[i_quad_1, :] += spline * coeff_fields * coeff_weight
+
+                arr_weights[i_quad_1] += spline * coeff_weight
+
+            fields = arr_fields[i_quad_1, :]
+            weight = arr_weights[i_quad_1]
+
+            out_fields[i_cell_1 * k1 + i_quad_1,:] += fields / weight
+
+
 # -----------------------------------------------------------------------------
 # 4: Iregular tensor grid with weights
 # -----------------------------------------------------------------------------
@@ -757,6 +863,69 @@ def eval_fields_2d_irregular_weighted(np1: int, np2: int, f_p1: int, f_p2: int,
                     temp_weight += spline * coeff_weight
 
             out_fields[i_p_1, i_p_2, :] += temp_fields / temp_weight
+
+
+@template(name='T', types=['float[:,:]', 'complex[:,:]'])
+def eval_fields_1d_irregular_weighted(np1: int, f_p1: int, 
+                                      cell_index_1: 'int[:]', global_basis_1: 'float[:,:,:]',
+                                      global_spans_1: 'int[:]', 
+                                      global_arr_coeff: 'T', global_arr_weights: 'float[:,:]',
+                                      out_fields: 'T'):
+    """
+    Parameters
+    ----------
+    np1 : int
+        Number of points in the X1 direction
+
+    f_p1: int
+        Degree in the X1 direction
+
+    cell_index_1 : ndarray of ints
+        Index of the cells in the X1 direction
+
+    global_basis_1 : ndarray of floats
+        Basis functions values at each point in the X1 direction
+
+    global_spans_1 : ndarray of ints
+        Spans in the X1 direction
+
+    global_arr_coeff : ndarray of floats
+        Coefficients of the fields in the X1 direction
+
+    global_arr_weights: ndarray of float
+        Coefficients of the weight field in the X1 direction
+
+    out_fields : ndarray of floats
+        Evaluated fields, filled with the correct values by the function
+    """
+    arr_coeff_fields = np.zeros_like(global_arr_coeff, shape=(1 + f_p1, out_fields.shape[1]))
+    arr_coeff_weights = np.zeros(1 + f_p1)
+
+    temp_fields = np.zeros_like(global_arr_coeff, shape=out_fields.shape[1])
+
+    for i_p_1 in range(np1):
+        i_cell_1 = cell_index_1[i_p_1]
+        span_1 = global_spans_1[i_cell_1]
+
+        arr_coeff_fields[:, :] = global_arr_coeff[span_1 - f_p1:1 + span_1, :]
+
+        arr_coeff_weights[:] = global_arr_weights[span_1 - f_p1:1 + span_1]
+
+        temp_fields[:] = 0.0
+        temp_weight    = 0.0
+
+        for i_basis_1 in range(1 + f_p1):
+            spline = global_basis_1[i_p_1, i_basis_1, 0]
+
+            coeff_fields = arr_coeff_fields[i_basis_1, :]
+
+            coeff_weight = arr_coeff_weights[i_basis_1]
+
+            temp_fields[:] += spline * coeff_fields * coeff_weight
+
+            temp_weight += spline * coeff_weight
+
+        out_fields[i_p_1, :] += temp_fields / temp_weight
 
 
 # =============================================================================

--- a/psydac/core/field_evaluation_kernels.py
+++ b/psydac/core/field_evaluation_kernels.py
@@ -186,7 +186,9 @@ def eval_fields_1d_no_weights(nc1: int, f_p1: int, k1: int,
         Spans in the X1 direction
 
     glob_arr_coeff: ndarray of floats
-        Coefficients of the fields in the X1 and X2 directions
+        Coefficients of the 1D fields, stored in a 2D array.
+        The first dimension loops over the coefficients, and
+        the second dimension over the different fields.
 
     out_fields: ndarray of floats
         Evaluated fields, filled with the correct values by the function
@@ -383,7 +385,9 @@ def eval_fields_1d_irregular_no_weights(np1: int, f_p1: int,
         Spans in the X1 direction
 
     glob_arr_coeff: ndarray of floats
-        Coefficients of the fields in the X1 direction
+        Coefficients of the scalar 1D fields, stored in a 2D array.
+        The first dimension loops over the coefficients, and the
+        second dimension over the different fields.
 
     out_fields: ndarray of floats
         Evaluated fields, filled with the correct values by the function
@@ -630,10 +634,12 @@ def eval_fields_1d_weighted(nc1: int, f_p1: int, k1: int,
         Spans in the X1 direction
 
     global_arr_coeff: ndarray of float
-        Coefficients of the fields in the X1 direction
+        Coefficients of the scalar 1D fields, stored in a 2D array.
+        The first dimension loops over the coefficients, and the
+        second dimension over the different fields.
 
     global_arr_weights: ndarray of float
-        Coefficients of the weight field in the X1 direction
+        Coefficients of the 1D scalar weight field.
 
     out_fields: ndarray of float
         Evaluated fields, filled with the correct values by the function
@@ -890,10 +896,12 @@ def eval_fields_1d_irregular_weighted(np1: int, f_p1: int,
         Spans in the X1 direction
 
     global_arr_coeff : ndarray of floats
-        Coefficients of the fields in the X1 direction
+        Coefficients of the scalar 1D fields, stored in a 2D array.
+        The first dimension loops over the coefficients, and the
+        second dimension over the different fields.
 
     global_arr_weights: ndarray of float
-        Coefficients of the weight field in the X1 direction
+        Coefficients of the 1D scalar weight field.
 
     out_fields : ndarray of floats
         Evaluated fields, filled with the correct values by the function

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -31,7 +31,8 @@ from psydac.core.bsplines  import (find_span,
                                    cell_index,
                                    basis_ders_on_irregular_grid)
 
-from psydac.core.field_evaluation_kernels import (eval_fields_2d_no_weights,
+from psydac.core.field_evaluation_kernels import (eval_fields_1d_irregular_no_weights,
+                                                  eval_fields_2d_no_weights,
                                                   eval_fields_2d_irregular_no_weights,
                                                   eval_fields_2d_weighted,
                                                   eval_fields_2d_irregular_weighted,
@@ -539,7 +540,12 @@ class TensorFemSpace( FemSpace ):
                                         global_spans[1], global_spans[2], glob_arr_coeffs, global_weight_coeff,
                                         out_fields)
         else:
-            raise NotImplementedError("1D not Implemented")
+            if weights is None:
+                eval_fields_1d_no_weights(ncells[0], degree[0],
+                                          n_eval_points[0], global_basis[0],
+                                          global_spans[0], glob_arr_coeffs, out_fields)
+            else:
+                raise NotImplementedError("1D with weights not Implemented")
 
         return out_fields
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -507,7 +507,7 @@ class TensorFemSpace( FemSpace ):
         n_eval_points = [local_shape[i][1] for i in range(self.ldim)]
         out_fields = np.zeros((*(tuple(ncells[i] * n_eval_points[i] for i in range(self.ldim))), len(fields)), dtype=self.dtype)
 
-        glob_arr_coeffs = np.zeros(shape=(*fields[0].coeffs._data.shape, len(fields)), dtype=self.dtype)
+        global_arr_coeffs = np.zeros(shape=(*fields[0].coeffs._data.shape, len(fields)), dtype=self.dtype)
 
         for i in range(len(fields)):
             glob_arr_coeffs[..., i] = fields[i].coeffs._data
@@ -520,8 +520,8 @@ class TensorFemSpace( FemSpace ):
             else:
                 raise NotImplementedError(f"eval_fields_{self.ldim}d_no_weights not implemented")
         else:
-            global_weight_coeff = weights.coeffs._data
-            args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeff, out_fields)
+            global_weight_coeffs = weights.coeffs._data
+            args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeffs, out_fields)
             if   self.ldim == 1:  eval_fields_1d_weighted(*args)
             elif self.ldim == 2:  eval_fields_2d_weighted(*args)
             elif self.ldim == 3:  eval_fields_3d_weighted(*args)
@@ -560,12 +560,12 @@ class TensorFemSpace( FemSpace ):
             self.preprocess_irregular_tensor_grid(grid, overlap=overlap)
         out_fields = np.zeros(tuple(local_shape) + (len(fields),), dtype=self.dtype)
 
-        glob_arr_coeffs = np.zeros(shape=(*fields[0].coeffs._data.shape, len(fields)), dtype=self.dtype)
+        global_arr_coeffs = np.zeros(shape=(*fields[0].coeffs._data.shape, len(fields)), dtype=self.dtype)
 
         npoints = local_shape
 
         for i in range(len(fields)):
-            glob_arr_coeffs[..., i] = fields[i].coeffs._data
+            global_arr_coeffs[..., i] = fields[i].coeffs._data
 
         if weights is None:
             args = (*npoints, *degree, *cell_indexes, *global_basis, *global_spans, global_arr_coeffs, out_fields)
@@ -575,8 +575,8 @@ class TensorFemSpace( FemSpace ):
             else:
                 raise NotImplementedError(f"eval_fields_{self.ldim}d_irregular_no_weights not implemented")
         else:
-            global_weight_coeff = weights.coeffs._data
-            args = (*npoints, *degree, *cell_indexes, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeff, out_fields)
+            global_weight_coeffs = weights.coeffs._data
+            args = (*npoints, *degree, *cell_indexes, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeffs, out_fields)
             if   self.ldim == 1:  eval_fields_1d_irregular_weighted(*args)
             elif self.ldim == 2:  eval_fields_2d_irregular_weighted(*args)
             elif self.ldim == 3:  eval_fields_3d_irregular_weighted(*args)

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -31,7 +31,10 @@ from psydac.core.bsplines  import (find_span,
                                    cell_index,
                                    basis_ders_on_irregular_grid)
 
-from psydac.core.field_evaluation_kernels import (eval_fields_1d_irregular_no_weights,
+from psydac.core.field_evaluation_kernels import (eval_fields_1d_no_weights,
+                                                  eval_fields_1d_irregular_no_weights,
+                                                  eval_fields_1d_weighted,
+                                                  eval_fields_1d_irregular_weighted,
                                                   eval_fields_2d_no_weights,
                                                   eval_fields_2d_irregular_no_weights,
                                                   eval_fields_2d_weighted,
@@ -545,7 +548,12 @@ class TensorFemSpace( FemSpace ):
                                           n_eval_points[0], global_basis[0],
                                           global_spans[0], glob_arr_coeffs, out_fields)
             else:
-                raise NotImplementedError("1D with weights not Implemented")
+                global_weight_coeff = weights.coeffs._data
+
+                eval_fields_1d_weighted(ncells[0], degree[0], 
+                                        n_eval_points[0], global_basis[0], 
+                                        global_spans[0], glob_arr_coeffs, global_weight_coeff,
+                                        out_fields)
 
         return out_fields
 
@@ -609,7 +617,14 @@ class TensorFemSpace( FemSpace ):
                 eval_fields_3d_irregular_weighted(*npoints, *degree, *cell_indexes, *global_basis,
                                                   *global_spans, glob_arr_coeffs, global_weight_coeff, out_fields)
         else:
-            raise NotImplementedError("1D not Implemented")
+            if weights is None:
+                eval_fields_1d_irregular_no_weights(*npoints, *degree, *cell_indexes, *global_basis,
+                                                    *global_spans, glob_arr_coeffs, out_fields)
+            else:
+                global_weight_coeff = weights.coeffs._data
+
+                eval_fields_1d_irregular_weighted(*npoints, *degree, *cell_indexes, *global_basis,
+                                                  *global_spans, glob_arr_coeffs, global_weight_coeff, out_fields)
 
         return out_fields
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -133,6 +133,7 @@ class TensorFemSpace( FemSpace ):
         self._global_element_ends   = domain_decomposition.global_element_ends
 
         self.set_refined_space(self.ncells, self)
+
     #--------------------------------------------------------------------------
     # Abstract interface: read-only attributes
     #--------------------------------------------------------------------------
@@ -511,49 +512,21 @@ class TensorFemSpace( FemSpace ):
         for i in range(len(fields)):
             glob_arr_coeffs[..., i] = fields[i].coeffs._data
 
-        if self.ldim == 2:
-            if weights is None:
-                eval_fields_2d_no_weights(ncells[0], ncells[1], degree[0], degree[1],
-                                          n_eval_points[0], n_eval_points[1], global_basis[0], global_basis[1],
-                                          global_spans[0], global_spans[1], glob_arr_coeffs, out_fields)
+        if weights is None:
+            args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, out_fields)
+            if   self.ldim == 1:  eval_fields_1d_no_weights(*args)
+            elif self.ldim == 2:  eval_fields_2d_no_weights(*args)
+            elif self.ldim == 3:  eval_fields_3d_no_weights(*args)
             else:
-
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_2d_weighted(ncells[0], ncells[1], degree[0], degree[1],
-                                        n_eval_points[0], n_eval_points[1], global_basis[0], global_basis[1],
-                                        global_spans[0], global_spans[1], glob_arr_coeffs, global_weight_coeff,
-                                        out_fields)
-
-        elif self.ldim == 3:
-            if weights is None:
-
-                eval_fields_3d_no_weights(ncells[0], ncells[1], ncells[2], degree[0],
-                                          degree[1], degree[2], n_eval_points[0], n_eval_points[1],
-                                          n_eval_points[2], global_basis[0], global_basis[1], global_basis[2],
-                                          global_spans[0], global_spans[1], global_spans[2], glob_arr_coeffs,
-                                          out_fields)
-
-            else:
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_3d_weighted(ncells[0], ncells[1], ncells[2], degree[0],
-                                        degree[1], degree[2], n_eval_points[0], n_eval_points[1], n_eval_points[2],
-                                        global_basis[0], global_basis[1], global_basis[2], global_spans[0],
-                                        global_spans[1], global_spans[2], glob_arr_coeffs, global_weight_coeff,
-                                        out_fields)
+              raise NotImplementedError(f"eval_fields_{self.ldim}d_no_weights not implemented")
         else:
-            if weights is None:
-                eval_fields_1d_no_weights(ncells[0], degree[0],
-                                          n_eval_points[0], global_basis[0],
-                                          global_spans[0], glob_arr_coeffs, out_fields)
+            global_weight_coeff = weights.coeffs._data
+            args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeff, out_fields)
+            if   self.ldim == 1:  eval_fields_1d_weighted(*args)
+            elif self.ldim == 2:  eval_fields_2d_weighted(*args)
+            elif self.ldim == 3:  eval_fields_3d_weighted(*args)
             else:
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_1d_weighted(ncells[0], degree[0], 
-                                        n_eval_points[0], global_basis[0], 
-                                        global_spans[0], glob_arr_coeffs, global_weight_coeff,
-                                        out_fields)
+              raise NotImplementedError(f"eval_fields_{self.ldim}d_weighted not implemented")
 
         return out_fields
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -510,7 +510,7 @@ class TensorFemSpace( FemSpace ):
         global_arr_coeffs = np.zeros(shape=(*fields[0].coeffs._data.shape, len(fields)), dtype=self.dtype)
 
         for i in range(len(fields)):
-            glob_arr_coeffs[..., i] = fields[i].coeffs._data
+            global_arr_coeffs[..., i] = fields[i].coeffs._data
 
         if weights is None:
             args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, out_fields)

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -518,7 +518,7 @@ class TensorFemSpace( FemSpace ):
             elif self.ldim == 2:  eval_fields_2d_no_weights(*args)
             elif self.ldim == 3:  eval_fields_3d_no_weights(*args)
             else:
-              raise NotImplementedError(f"eval_fields_{self.ldim}d_no_weights not implemented")
+                raise NotImplementedError(f"eval_fields_{self.ldim}d_no_weights not implemented")
         else:
             global_weight_coeff = weights.coeffs._data
             args = (*ncells, *degree, *n_eval_points, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeff, out_fields)
@@ -526,11 +526,11 @@ class TensorFemSpace( FemSpace ):
             elif self.ldim == 2:  eval_fields_2d_weighted(*args)
             elif self.ldim == 3:  eval_fields_3d_weighted(*args)
             else:
-              raise NotImplementedError(f"eval_fields_{self.ldim}d_weighted not implemented")
+                raise NotImplementedError(f"eval_fields_{self.ldim}d_weighted not implemented")
 
         return out_fields
 
-# ...
+    # ...
     def eval_fields_irregular_tensor_grid(self, grid, *fields, weights=None, overlap=0):
         """Evaluate fields on a regular tensor grid
 
@@ -567,46 +567,30 @@ class TensorFemSpace( FemSpace ):
         for i in range(len(fields)):
             glob_arr_coeffs[..., i] = fields[i].coeffs._data
 
-        if self.ldim == 2:
-            if weights is None:
-                eval_fields_2d_irregular_no_weights(*npoints, *degree, *cell_indexes, *global_basis,
-                                                    *global_spans, glob_arr_coeffs, out_fields)
+        if weights is None:
+            args = (*npoints, *degree, *cell_indexes, *global_basis, *global_spans, global_arr_coeffs, out_fields)
+            if   self.ldim == 1:  eval_fields_1d_irregular_no_weights(*args)
+            elif self.ldim == 2:  eval_fields_2d_irregular_no_weights(*args)
+            elif self.ldim == 3:  eval_fields_3d_irregular_no_weights(*args)
             else:
-
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_2d_irregular_weighted(*npoints, *degree, *cell_indexes, *global_basis,
-                                                  *global_spans, glob_arr_coeffs, global_weight_coeff, out_fields)
-
-        elif self.ldim == 3:
-            if weights is None:
-
-                eval_fields_3d_irregular_no_weights(*npoints, *degree, *cell_indexes, *global_basis,
-                                                    *global_spans, glob_arr_coeffs, out_fields)
-
-            else:
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_3d_irregular_weighted(*npoints, *degree, *cell_indexes, *global_basis,
-                                                  *global_spans, glob_arr_coeffs, global_weight_coeff, out_fields)
+                raise NotImplementedError(f"eval_fields_{self.ldim}d_irregular_no_weights not implemented")
         else:
-            if weights is None:
-                eval_fields_1d_irregular_no_weights(*npoints, *degree, *cell_indexes, *global_basis,
-                                                    *global_spans, glob_arr_coeffs, out_fields)
+            global_weight_coeff = weights.coeffs._data
+            args = (*npoints, *degree, *cell_indexes, *global_basis, *global_spans, global_arr_coeffs, global_weight_coeff, out_fields)
+            if   self.ldim == 1:  eval_fields_1d_irregular_weighted(*args)
+            elif self.ldim == 2:  eval_fields_2d_irregular_weighted(*args)
+            elif self.ldim == 3:  eval_fields_3d_irregular_weighted(*args)
             else:
-                global_weight_coeff = weights.coeffs._data
-
-                eval_fields_1d_irregular_weighted(*npoints, *degree, *cell_indexes, *global_basis,
-                                                  *global_spans, glob_arr_coeffs, global_weight_coeff, out_fields)
+                raise NotImplementedError(f"eval_fields_{self.ldim}d_irregular_weighted not implemented")
 
         return out_fields
 
     # ...
-    def eval_field_gradient( self, field, *eta , weights=None):
+    def eval_field_gradient(self, field, *eta, weights=None):
 
-        assert isinstance( field, FemField )
+        assert isinstance(field, FemField)
         assert field.space is self
-        assert len( eta ) == self.ldim
+        assert len(eta) == self.ldim
 
         bases_0 = []
         bases_1 = []
@@ -661,9 +645,9 @@ class TensorFemSpace( FemSpace ):
         return grad
 
     # ...
-    def integral( self, f ):
+    def integral(self, f):
 
-        assert hasattr( f, '__call__' )
+        assert hasattr(f, '__call__')
 
         # Extract and store quadrature data
         quad_grids = self.quad_grids()
@@ -677,29 +661,29 @@ class TensorFemSpace( FemSpace ):
 
         # Iterator over multi-index k (equivalent to nested loops over each dimension)
         multi_range = lambda starts, ends: \
-                itertools.product( *[range(s,e+1) for s,e in zip(starts,ends)] )
+                itertools.product(*[range(s, e+1) for s, e in zip(starts, ends)])
 
         # Shortcut: Numpy product of all elements in a list
         np_prod = np.prod
 
         # Perform Gaussian quadrature in multiple dimensions
         c = 0.0
-        for k in multi_range( sk, ek ):
+        for k in multi_range(sk, ek):
 
-            x = [ points_i[k_i,:] for  points_i,k_i in zip( points,k)]
-            w = [weights_i[k_i,:] for weights_i,k_i in zip(weights,k)]
+            x = [ points_i[k_i, :] for  points_i, k_i in zip( points, k)]
+            w = [weights_i[k_i, :] for weights_i, k_i in zip(weights, k)]
 
             for q in np.ndindex( *nq ):
 
-                y  = [x_i[q_i] for x_i,q_i in zip(x,q)]
-                v  = [w_i[q_i] for w_i,q_i in zip(w,q)]
+                y  = [x_i[q_i] for x_i, q_i in zip(x, q)]
+                v  = [w_i[q_i] for w_i, q_i in zip(w, q)]
 
-                c += f(*y) * np_prod( v )
+                c += f(*y) * np_prod(v)
 
         # All reduce (MPI_SUM)
         if self.vector_space.parallel:
             mpi_comm = self.vector_space.cart.comm
-            c = mpi_comm.allreduce( c )
+            c = mpi_comm.allreduce(c)
 
         return c
 
@@ -748,15 +732,15 @@ class TensorFemSpace( FemSpace ):
         return [V.ncells for V in self.spaces]
 
     @property
-    def spaces( self ):
+    def spaces(self):
         return self._spaces
     
     @property
-    def nquads( self ):
+    def nquads(self):
         return self._nquads
 
     #@property
-    def quad_grids( self, *nquads ):
+    def quad_grids(self, *nquads):
         """
         Tuple of 'FemAssemblyGrid' objects (one for each direction)
         containing all 1D information local to process that is necessary
@@ -794,7 +778,7 @@ class TensorFemSpace( FemSpace ):
         return tuple(quad_grids)
 
     @property
-    def local_domain( self ):
+    def local_domain(self):
         """
         Logical domain local to the process, assuming the global domain is
         decomposed across processes without any overlapping.
@@ -814,15 +798,15 @@ class TensorFemSpace( FemSpace ):
         return self._element_starts, self._element_ends
 
     @property
-    def global_element_starts( self ):
+    def global_element_starts(self):
         return self._global_element_starts
 
     @property
-    def global_element_ends( self ):
+    def global_element_ends(self):
         return self._global_element_ends
 
     @property
-    def eta_lims( self ):
+    def eta_lims(self):
         """
         Eta limits of domain local to the process (for field evaluation).
 
@@ -835,21 +819,21 @@ class TensorFemSpace( FemSpace ):
         return self._eta_limits
 
     # ...
-    def init_interpolation( self ):
+    def init_interpolation(self):
         for V in self.spaces:
             # TODO: check if OK to access private attribute...
             if not V._interpolation_ready:
                 V.init_interpolation(dtype=self.dtype)
 
     # ...
-    def init_histopolation( self ):
+    def init_histopolation(self):
         for V in self.spaces:
             # TODO: check if OK to access private attribute...
             if not V._histopolation_ready:
                 V.init_histopolation(dtype=self.dtype)
 
     # ...
-    def compute_interpolant( self, values, field ):
+    def compute_interpolant(self, values, field):
         """
         Compute field (i.e. update its spline coefficients) such that it
         interpolates a certain function $f(x1,x2,..)$ at the Greville points.
@@ -948,35 +932,35 @@ class TensorFemSpace( FemSpace ):
         return V
 
     # ...
-    def export_fields( self, filename, **fields ):
+    def export_fields(self, filename, **fields):
         """ Write spline coefficients of given fields to HDF5 file.
         """
-        assert isinstance( filename, str )
-        assert all( field.space is self for field in fields.values() )
+        assert isinstance(filename, str)
+        assert all(field.space is self for field in fields.values())
 
         V    = self.vector_space
         comm = V.cart.comm if V.parallel else None
 
         # Multi-dimensional index range local to process
-        index = tuple( slice( s, e+1 ) for s,e in zip( V.starts, V.ends ) )
+        index = tuple(slice(s, e+1) for s,e in zip(V.starts, V.ends))
 
         # Create HDF5 file (in parallel mode if MPI communicator size > 1)
         kwargs = {}
         if comm is not None:
             if comm.size > 1:
-                kwargs.update( driver='mpio', comm=comm )
-        h5 = h5py.File( filename, mode='w', **kwargs )
+                kwargs.update(driver='mpio', comm=comm)
+        h5 = h5py.File(filename, mode='w', **kwargs)
 
         # Add field coefficients as named datasets
         for name,field in fields.items():
-            dset = h5.create_dataset( name, shape=V.npts, dtype=V.dtype )
+            dset = h5.create_dataset(name, shape=V.npts, dtype=V.dtype)
             dset[index] = field.coeffs[index]
 
         # Close HDF5 file
         h5.close()
 
     # ...
-    def import_fields( self, filename, *field_names ):
+    def import_fields(self, filename, *field_names):
         """
         Load fields from HDF5 file containing spline coefficients.
 
@@ -994,21 +978,21 @@ class TensorFemSpace( FemSpace ):
             Distributed fields, given in the same order of the names.
 
         """
-        assert isinstance( filename, str )
-        assert all( isinstance( name, str ) for name in field_names )
+        assert isinstance(filename, str)
+        assert all(isinstance(name, str) for name in field_names)
 
         V    = self.vector_space
         comm = V.cart.comm if V.parallel else None
 
         # Multi-dimensional index range local to process
-        index = tuple( slice( s, e+1 ) for s,e in zip( V.starts, V.ends ) )
+        index = tuple(slice(s, e+1) for s,e in zip(V.starts, V.ends))
 
         # Open HDF5 file (in parallel mode if MPI communicator size > 1)
         kwargs = {}
         if comm is not None:
             if comm.size > 1:
-                kwargs.update( driver='mpio', comm=comm )
-        h5 = h5py.File( filename, mode='r', **kwargs )
+                kwargs.update(driver='mpio', comm=comm)
+        h5 = h5py.File(filename, mode='r', **kwargs)
 
         # Create fields and load their coefficients from HDF5 datasets
         fields = []
@@ -1016,11 +1000,11 @@ class TensorFemSpace( FemSpace ):
             dset = h5[name]
             if dset.shape != V.npts:
                 h5.close()
-                raise TypeError( 'Dataset not compatible with spline space.' )
-            field = FemField( self )
+                raise TypeError('Dataset not compatible with spline space.')
+            field = FemField(self)
             field.coeffs[index] = dset[index]
             field.coeffs.update_ghost_regions()
-            fields.append( field )
+            fields.append(field)
 
         # Close HDF5 file
         h5.close()
@@ -1064,7 +1048,7 @@ class TensorFemSpace( FemSpace ):
         global_starts, global_ends = partition_coefficients(v.cart.domain_decomposition, spaces)
 
         # create new CartDecomposition
-        red_cart   = v.cart.reduce_npts(npts, global_starts, global_ends, shifts=multiplicity)
+        red_cart = v.cart.reduce_npts(npts, global_starts, global_ends, shifts=multiplicity)
 
         # create new TensorFemSpace
 
@@ -1110,12 +1094,10 @@ class TensorFemSpace( FemSpace ):
             new_global_starts[-1] = np.array(new_global_starts[-1])
             new_global_ends  [-1] = np.array(new_global_ends  [-1])
 
-        domain = domain.refine(ncells, new_global_starts, new_global_ends)
+        new_domain = domain.refine(ncells, new_global_starts, new_global_ends)
+        new_space  = TensorFemSpace(new_domain, *spaces, nquads=self.nquads, dtype=self._vector_space.dtype)
 
-
-        FS     = TensorFemSpace(domain, *spaces, nquads=self.nquads, dtype=self._vector_space.dtype)
-
-        self.set_refined_space(ncells, FS)
+        self.set_refined_space(ncells, new_space)
 
     # ...
     def create_interface_space(self, axis, ext, cart):
@@ -1135,18 +1117,22 @@ class TensorFemSpace( FemSpace ):
         """
         axis = int(axis)
         ext  = int(ext)
-        assert axis<self.ldim
-        assert ext in [-1,1]
 
-        if cart.is_comm_null or self._interfaces.get((axis, ext), None): return
+        assert axis < self.ldim
+        assert ext in [-1, 1]
+
+        if cart.is_comm_null or self._interfaces.get((axis, ext), None):
+            return
+
         spaces       = self.spaces
         vector_space = self.vector_space
         nquads       = self.nquads
 
         vector_space.set_interface(axis, ext, cart)
 
-        space = TensorFemSpace( self._domain_decomposition, *spaces, vector_space=vector_space.interfaces[axis, ext],
-                                nquads=self.nquads, dtype=vector_space.dtype)
+        space = TensorFemSpace(self._domain_decomposition, *spaces,
+                               vector_space=vector_space.interfaces[axis, ext],
+                               nquads=self.nquads, dtype=vector_space.dtype)
 
         self._interfaces[axis, ext] = space
 
@@ -1158,7 +1144,7 @@ class TensorFemSpace( FemSpace ):
         self._refined_space[tuple(ncells)] = new_space
 
     # ...
-    def plot_2d_decomposition( self, mapping=None, refine=10 ):
+    def plot_2d_decomposition(self, mapping=None, refine=10):
 
         import matplotlib.pyplot as plt
         from matplotlib.patches  import Polygon, Patch
@@ -1171,16 +1157,16 @@ class TensorFemSpace( FemSpace ):
             assert mapping.pdim == self.ldim == 2
 
         assert refine >= 1
-        N = int( refine )
+        N = int(refine)
         V1, V2 = self.spaces
 
         mpi_comm = self.vector_space.cart.comm
         mpi_rank = mpi_comm.rank
 
         # Local grid, refined
-        [sk1,sk2], [ek1,ek2] = self.local_domain
-        eta1 = refine_array_1d( V1.breaks[sk1:ek1+2], N )
-        eta2 = refine_array_1d( V2.breaks[sk2:ek2+2], N )
+        [sk1, sk2], [ek1, ek2] = self.local_domain
+        eta1 = refine_array_1d(V1.breaks[sk1:ek1+2], N)
+        eta2 = refine_array_1d(V2.breaks[sk2:ek2+2], N)
         pcoords = np.array([[mapping(e1, e2) for e2 in eta2] for e1 in eta1])
 
         # Local domain as Matplotlib polygonal patch
@@ -1188,11 +1174,11 @@ class TensorFemSpace( FemSpace ):
         BC = pcoords[  -1,    :, :] # eta1 = max
         CD = pcoords[::-1,   -1, :] # eta2 = max (points must be reversed)
         DA = pcoords[   0, ::-1, :] # eta1 = min (points must be reversed)
-        xy = np.concatenate( [AB, BC, CD, DA], axis=0 )
-        poly = Polygon( xy, edgecolor='None' )
+        xy = np.concatenate([AB, BC, CD, DA], axis=0)
+        poly = Polygon(xy, edgecolor='None')
 
         # Gather polygons on master process
-        polys = mpi_comm.gather( poly )
+        polys = mpi_comm.gather(poly)
 
         #-------------------------------
         # Non-master processes stop here
@@ -1201,31 +1187,31 @@ class TensorFemSpace( FemSpace ):
         #-------------------------------
 
         # Global grid, refined
-        eta1    = refine_array_1d( V1.breaks, N )
-        eta2    = refine_array_1d( V2.breaks, N )
+        eta1    = refine_array_1d(V1.breaks, N)
+        eta2    = refine_array_1d(V2.breaks, N)
         pcoords = np.array([[mapping(e1, e2) for e2 in eta2] for e1 in eta1])
-        xx      = pcoords[:,:,0]
-        yy      = pcoords[:,:,1]
+        xx      = pcoords[:, :, 0]
+        yy      = pcoords[:, :, 1]
 
         # Plot decomposed domain
-        fig, ax = plt.subplots( 1, 1 )
-        colors  = itertools.cycle( plt.rcParams['axes.prop_cycle'].by_key()['color'] )
+        fig, ax = plt.subplots(1, 1)
+        colors  = itertools.cycle(plt.rcParams['axes.prop_cycle'].by_key()['color'])
         handles = []
-        for i, (poly, color) in enumerate( zip( polys, colors ) ):
+        for i, (poly, color) in enumerate(zip(polys, colors)):
             # Add patch
-            poly.set_facecolor( color )
-            ax.add_patch( poly )
+            poly.set_facecolor(color)
+            ax.add_patch(poly)
             # Create legend entry
-            handle = Patch( color=color, label='Rank {}'.format(i) )
-            handles.append( handle )
+            handle = Patch(color=color, label='Rank {}'.format(i))
+            handles.append(handle)
 
-        ax.set_xlabel( r'$x$', rotation='horizontal' )
-        ax.set_ylabel( r'$y$', rotation='horizontal' )
-        ax.set_title ( 'Domain decomposition' )
-        ax.plot( xx[:,::N]  , yy[:,::N]  , 'k' )
-        ax.plot( xx[::N,:].T, yy[::N,:].T, 'k' )
+        ax.set_xlabel(r'$x$', rotation='horizontal')
+        ax.set_ylabel(r'$y$', rotation='horizontal')
+        ax.set_title ('Domain decomposition')
+        ax.plot(xx[:,::N]  , yy[:,::N]  , 'k')
+        ax.plot(xx[::N,:].T, yy[::N,:].T, 'k')
         ax.set_aspect('equal')
-        ax.legend( handles=handles, bbox_to_anchor=(1.05, 1), loc=2 )
+        ax.legend(handles=handles, bbox_to_anchor=(1.05, 1), loc=2)
         fig.tight_layout()
         fig.show()
 


### PR DESCRIPTION
The ``eval_fields`` method of class `TensorFemSpace` raises a ``NotImplementedError`` when called to evaluate fields in 1D. To fix this, the missing 1D kernels have been added, and they are now called when needed.

List of changes
--------------

- Add kernel functions ``eval_fields_1d_no_weights``, ``eval_fields_1d_irregular_no_weights``, ``eval_fields_1d_weighted``, and ``eval_fields_1d_irregular_weighted`` to ``psydac/core/field_evaluation_kernels.py``. 
- Modify functions ``eval_fields_irregular_tensor_grid`` and ``eval_fields_regular_tensor_grid`` in ``psydac/fem/tensor.py`` to call these kernel functions in the case of 1D fields.
- Add several 1D tests to ``test_regular_evaluations`` in ``psydac/core/tests/test_field_evaluation_kernel.py``.

Note
-------
An evaluation kernel for the L2 pushforward in 1D was not added. I am not sure if this is needed as mappings are not likely to be needed in 1D problems. Therefore, I refrained from adding this functionality in this PR. 