### PR TITLE
Provide alternative shell command for discovering HDF5_DIR

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Determine directory of parallel HDF5 library
         run: |
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
-            HDF5_DIR=/usr/lib/x86_64-linux-gnu/hdf5/openmpi
+            HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname)
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
           fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,7 +84,7 @@ jobs:
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
             HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname)
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            HDF5_DIR=$((h5pcc -showconfig -echo || true) | grep "Installation point:" | cut -d ":" -f2 | tr -d " ")
+            HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname)
           fi
           echo $HDF5_DIR
           echo "HDF5_DIR=$HDF5_DIR" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -96,17 +96,13 @@ python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install -r requirements_extra.txt --no-build-isolation
 ```
-where the `HDF5_DIR` environment variable should store the absolute path to the **installation point** of your parallel HDF5 library, which can be found with
+where the `HDF5_DIR` environment variable should store the absolute path to the **installation point** of your parallel HDF5 library, which can be found with command/s specific to your system:
 ```sh
-h5pcc -showconfig
-```
-or (on macOS)
-```sh
-brew info hdf5-mpi
-```
-Alternatively, on Ubuntu/Debian systems, the HDF5 **installation point** can be discovered by running
-```sh
+# HDF5_DIR on Ubuntu/Debian
 dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname
+
+# HDF5_DIR on macOS
+brew info hdf5-mpi
 ```
 
 At this point the Psydac library may be installed in **standard mode**, which copies the relevant files to the correct locations of the virtual environment, or in **development mode**, which only installs symbolic links to the Psydac directory. The latter mode allows one to effect the behavior of Psydac by modifying the source files.

--- a/README.md
+++ b/README.md
@@ -88,21 +88,18 @@ The latter command requires a GitHub account.
 Psydac depends on several Python packages, which should be installed in the newly created virtual environment.
 These dependencies can be installed from the cloned directory `<ROOT-PATH>/psydac` using
 ```sh
+# Set env variables required by h5py
 export CC="mpicc"
 export HDF5_MPI="ON"
-export HDF5_DIR=/path/to/parallel/hdf5
 
+# Specify path to parallel HDF5 library. Run one command below that corresponds to your system:
+export HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep "libhdf5.so" | xargs dirname) # Ubuntu/Debian
+export HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname)       # macOS
+
+# Install dependencies
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install -r requirements_extra.txt --no-build-isolation
-```
-where the `HDF5_DIR` environment variable should store the absolute path to the **installation point** of your parallel HDF5 library, which can be found with command/s specific to your system:
-```sh
-# HDF5_DIR on Ubuntu/Debian
-dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname
-
-# HDF5_DIR on macOS
-brew info hdf5-mpi
 ```
 
 At this point the Psydac library may be installed in **standard mode**, which copies the relevant files to the correct locations of the virtual environment, or in **development mode**, which only installs symbolic links to the Psydac directory. The latter mode allows one to effect the behavior of Psydac by modifying the source files.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ or (on macOS)
 ```sh
 brew info hdf5-mpi
 ```
+Alternatively, on Ubuntu/Debian systems, the HDF5 **installation point** can be discovered by running
+```sh
+dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname
+```
 
 At this point the Psydac library may be installed in **standard mode**, which copies the relevant files to the correct locations of the virtual environment, or in **development mode**, which only installs symbolic links to the Psydac directory. The latter mode allows one to effect the behavior of Psydac by modifying the source files.
 


### PR DESCRIPTION
On Ubuntu 22.04, `h5pcc -showconfig` gives the wrong installation point required by `h5py`:

```sh

            SUMMARY OF THE HDF5 CONFIGURATION
            =================================

General Information:
-------------------
                   HDF5 Version: 1.10.7
                  Configured on: Wed, 08 Dec 2021 23:33:27 +0000
                  Configured by: Debian
                    Host system: x86_64-pc-linux-gnu
              Uname information: Debian
                       Byte sex: little-endian
             Installation point: /usr
                    Flavor name: openmpi
```

`pip3 install h5py` will look for `libhdf5.so` which is at `/usr/lib/x86_64-linux-gnu/hdf5/openmpi`, not `/usr`. On Ubuntu/Debian one could directly extract `HDF5_DIR` with the command

```sh
export HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname)
```

I wonder if we should still suggest `h5pcc -showconfig` which doesn't really work and may trip users (e.g. #219). The command above may look "hacky", but I believe its robust and would still work for future Ubuntu/Debian releases unless `libhdf5-openmpi-dev` has been renamed—in such case the README has to be updated anyway to change the parallel HDF5 library name for the `apt install` step.


