### PR TITLE
Pass `nquads` when discretizing integral expressions, not spaces

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -84,7 +84,7 @@ jobs:
           if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then
             HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep libhdf5.so | xargs dirname)
           elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname)
+            HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname | xargs dirname)
           fi
           echo $HDF5_DIR
           echo "HDF5_DIR=$HDF5_DIR" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -86,17 +86,26 @@ The latter command requires a GitHub account.
 ## Installing the library
 
 Psydac depends on several Python packages, which should be installed in the newly created virtual environment.
-These dependencies can be installed from the cloned directory `<ROOT-PATH>/psydac` using
+These dependencies can be installed from the cloned directory `<ROOT-PATH>/psydac` with the following steps.
+
+First, set an environment variable with the path to the parallel HDF5 library.
+This path can be obtained with a command which depends on your system.
+
+-   **Ubuntu/Debian**:
+    ```sh
+    export HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep "libhdf5.so" | xargs dirname)
+    ```
+
+-   **macOS**:
+    ```sh
+    export HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname | xargs dirname)
+    ```
+
+Next, install the Python dependencies using `pip`:
 ```sh
-# Set env variables required by h5py
 export CC="mpicc"
 export HDF5_MPI="ON"
 
-# Specify path to parallel HDF5 library. Run one command below that corresponds to your system:
-export HDF5_DIR=$(dpkg -L libhdf5-openmpi-dev | grep "libhdf5.so" | xargs dirname) # Ubuntu/Debian
-export HDF5_DIR=$(brew list hdf5-mpi | grep "libhdf5.dylib" | xargs dirname)       # macOS
-
-# Install dependencies
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 python3 -m pip install -r requirements_extra.txt --no-build-isolation

--- a/examples/notebooks/Helmholtz_non_periodic.ipynb
+++ b/examples/notebooks/Helmholtz_non_periodic.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,6 +122,8 @@
     "degree = [3, 3]\n",
     "periodic = [False, True]\n",
     "\n",
+    "nquads = [p + 1 for p in degree]\n",
+    "\n",
     "# MPI version\n",
     "# from mpi4py import MPI\n",
     "# comm = MPI.COMM_WORLD\n",
@@ -129,9 +131,9 @@
     "Omega_h = discretize(Omega, ncells=ncells, periodic=periodic)\n",
     "\n",
     "Vh         = discretize(V, Omega_h, degree=degree)\n",
-    "equation_h = discretize(equation, Omega_h, [Vh, Vh], backend=backend)\n",
-    "l2norm_h   = discretize(l2norm, Omega_h, Vh, backend=backend)\n",
-    "h1norm_h   = discretize(h1norm, Omega_h, Vh, backend=backend)"
+    "equation_h = discretize(equation, Omega_h, [Vh, Vh], nquads=nquads, backend=backend)\n",
+    "l2norm_h   = discretize(l2norm, Omega_h, Vh, nquads=nquads, backend=backend)\n",
+    "h1norm_h   = discretize(h1norm, Omega_h, Vh, nquads=nquads, backend=backend)"
    ]
   },
   {
@@ -143,18 +145,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "> CG info       ::  {'niter': 45, 'success': True, 'res_norm': 2.8926962059736328e-15}\n",
+      "> CG info       ::  {'niter': 46, 'success': True, 'res_norm': 5.330478803717119e-15}\n",
       "> L2 error      :: 2.07e-07\n",
       "> H1 error      :: 3.80e-05\n",
-      "> Solution time :: 8.96e+00s\n",
-      "> Evaluat. time :: 3.72e+00s \n"
+      "> Solution time :: 3.76e+00s\n",
+      "> Evaluat. time :: 4.00e-01s \n"
      ]
     }
    ],
@@ -191,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/notebooks/Poisson_non_periodic.ipynb
+++ b/examples/notebooks/Poisson_non_periodic.ipynb
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,6 +164,8 @@
     "degree = [2, 2]\n",
     "periodic = [False, False]\n",
     "\n",
+    "nquads = [p + 1 for p in degree]\n",
+    "\n",
     "# MPI version\n",
     "# from mpi4py import MPI\n",
     "# comm = MPI.COMM_WORLD\n",
@@ -171,9 +173,9 @@
     "Omega_h = discretize(Omega, ncells=ncells, periodic=periodic)\n",
     "\n",
     "Vh         = discretize(V, Omega_h, degree=degree)\n",
-    "equation_h = discretize(equation, Omega_h, [Vh, Vh], backend=backend)\n",
-    "l2norm_h   = discretize(l2norm, Omega_h, Vh, backend=backend)\n",
-    "h1norm_h   = discretize(h1norm, Omega_h, Vh, backend=backend)"
+    "equation_h = discretize(equation, Omega_h, [Vh, Vh], nquads=nquads, backend=backend)\n",
+    "l2norm_h   = discretize(l2norm, Omega_h, Vh, nquads=nquads, backend=backend)\n",
+    "h1norm_h   = discretize(h1norm, Omega_h, Vh, nquads=nquads, backend=backend)"
    ]
   },
   {
@@ -233,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/poisson_1d.py
+++ b/examples/poisson_1d.py
@@ -102,7 +102,7 @@ def kernel( p1, k1, bs1, w1, mat_m, mat_s ):
             mat_s[il_1, p1+jl_1-il_1] = v_s
 
 #==============================================================================
-def assemble_matrices( V, kernel ):
+def assemble_matrices(V, kernel, *, nquads):
     """
     Assemble mass and stiffness matrices using 1D stencil format.
 
@@ -122,6 +122,8 @@ def assemble_matrices( V, kernel ):
     stiffness : StencilMatrix
         Stiffness matrix in 1D stencil format.
 
+    nquads : list or tuple of int
+        Number of quadrature points in each direction (here only one).
     """
     # Sizes
     [s1] = V.vector_space.starts
@@ -129,7 +131,7 @@ def assemble_matrices( V, kernel ):
     [p1] = V.vector_space.pads
 
     # Quadrature data
-    quad_grid = V.quad_grids()[0]
+    quad_grid = V.get_quadrature_grids(*nquads)[0]
     nk1       = quad_grid.num_elements
     nq1       = quad_grid.num_quad_pts
     spans_1   = quad_grid.spans
@@ -137,32 +139,32 @@ def assemble_matrices( V, kernel ):
     weights_1 = quad_grid.weights
 
     # Create global matrices
-    mass      = StencilMatrix( V.vector_space, V.vector_space )
-    stiffness = StencilMatrix( V.vector_space, V.vector_space )
+    mass      = StencilMatrix(V.vector_space, V.vector_space)
+    stiffness = StencilMatrix(V.vector_space, V.vector_space)
 
     # Create element matrices
-    mat_m = np.zeros( (p1+1, 2*p1+1) ) # mass
-    mat_s = np.zeros( (p1+1, 2*p1+1) ) # stiffness
+    mat_m = np.zeros((p1+1, 2*p1+1)) # mass
+    mat_s = np.zeros((p1+1, 2*p1+1)) # stiffness
 
     # Build global matrices: cycle over elements
     for k1 in range( nk1 ):
 
         # Get spline index, B-splines' values and quadrature weights
         is1 =   spans_1[k1]
-        bs1 =   basis_1[k1,:,:,:]
-        w1  = weights_1[k1,:]
+        bs1 =   basis_1[k1, :, :, :]
+        w1  = weights_1[k1, :]
 
         # Compute element matrices
-        kernel( p1, nq1, bs1, w1, mat_m, mat_s )
+        kernel(p1, nq1, bs1, w1, mat_m, mat_s)
 
         # Update global matrices
-        mass     [is1-p1:is1+1,:] += mat_m[:,:]
-        stiffness[is1-p1:is1+1,:] += mat_s[:,:]
+        mass     [is1-p1:is1+1, :] += mat_m[:, :]
+        stiffness[is1-p1:is1+1, :] += mat_s[:, :]
 
     return mass, stiffness
 
 #==============================================================================
-def assemble_rhs( V, f ):
+def assemble_rhs(V, f, *, nquads):
     """
     Assemble right-hand-side vector.
 
@@ -173,6 +175,9 @@ def assemble_rhs( V, f ):
 
     f : callable
         Right-hand side function (charge density).
+
+    nquads : list or tuple of int
+        Number of quadrature points in each direction (here only one).
 
     Returns
     -------
@@ -186,7 +191,7 @@ def assemble_rhs( V, f ):
     [p1] = V.vector_space.pads
 
     # Quadrature data
-    quad_grid = V.quad_grids()[0]
+    quad_grid = V.get_quadrature_grids(*nquads)[0]
     nk1       = quad_grid.num_elements
     nq1       = quad_grid.num_quad_pts
     spans_1   = quad_grid.spans
@@ -231,11 +236,14 @@ if __name__ == '__main__':
     p  = 3
     ne = 2**4
 
+    # Number of quadrature points for assembling of matrices and vectors
+    nquads = [p + 1]
+
     # Method of manufactured solution
     model = Poisson1D()
 
     # Create uniform grid
-    grid = np.linspace( *model.domain, num=ne+1 )
+    grid = np.linspace(*model.domain, num=ne+1)
 
     # Create finite element space
     space = SplineSpace(p, grid=grid, periodic=model.periodic)
@@ -244,19 +252,19 @@ if __name__ == '__main__':
 
     # Build mass and stiffness matrices
     t0 = time()
-    mass, stiffness = assemble_matrices( V, kernel )
+    mass, stiffness = assemble_matrices(V, kernel, nquads=nquads)
     t1 = time()
     timing['assembly'] = t1-t0
 
     # Build right-hand side vector
-    rhs = assemble_rhs( V, model.rho )
+    rhs = assemble_rhs(V, model.rho, nquads=nquads)
 
     # Apply homogeneous dirichlet boundary conditions
     s1, = V.vector_space.starts
     e1, = V.vector_space.ends
 
-    stiffness[s1,:] = 0.
-    stiffness[e1,:] = 0.
+    stiffness[s1, :] = 0.
+    stiffness[e1, :] = 0.
     rhs[s1] = 0.
     rhs[e1] = 0.
 
@@ -269,24 +277,24 @@ if __name__ == '__main__':
     timing['solution'] = t1-t0
 
     # Create potential field
-    phi = FemField( V, coeffs=x )
+    phi = FemField(V, coeffs=x)
     phi.coeffs.update_ghost_regions()
 
     # Compute L2 norm of error
     t0 = time()
-    e2 = np.sqrt( V.integral( lambda x: (phi(x)-model.phi(x))**2 ) )
+    e2 = np.sqrt(V.integral(lambda x: (phi(x)-model.phi(x))**2, nquads=[8]))
     t1 = time()
     timing['diagnostics'] = t1-t0
 
     # Print some information to terminal
-    print( '> Grid          :: {ne}'.format(ne=ne) )
-    print( '> Degree        :: {p}'.format(p=p) )
-    print( '> CG info       :: ',info )
-    print( '> L2 error      :: {:.2e}'.format( e2 ) )
-    print( '' )
-    print( '> Assembly time :: {:.2e}'.format( timing['assembly'] ) )
-    print( '> Solution time :: {:.2e}'.format( timing['solution'] ) )
-    print( '> Evaluat. time :: {:.2e}'.format( timing['diagnostics'] ) )
+    print('> Grid          :: {ne}'.format(ne=ne))
+    print('> Degree        :: {p}'.format(p=p))
+    print('> CG info       :: ', info)
+    print('> L2 error      :: {:.2e}'.format(e2))
+    print()
+    print('> Assembly time :: {:.2e}'.format(timing['assembly']))
+    print('> Solution time :: {:.2e}'.format(timing['solution']))
+    print('> Evaluat. time :: {:.2e}'.format(timing['diagnostics']))
 
     # Plot solution on refined grid
     y      = np.linspace( grid[0], grid[-1], 101 )

--- a/examples/poisson_1d.py
+++ b/examples/poisson_1d.py
@@ -16,30 +16,30 @@ class Poisson1D:
     $\frac{d^2}{dx^2}\phi(x) = -\rho(x)$
 
     """
-    def __init__( self ):
+    def __init__(self):
         from sympy import symbols, sin, pi, lambdify
         x = symbols('x')
-        phi_e = sin( 2*pi*x )
-        rho_e = -phi_e.diff(x,2)
-        self._phi = lambdify( x, phi_e )
-        self._rho = lambdify( x, rho_e )
+        phi_e = sin(2*pi*x)
+        rho_e = -phi_e.diff(x, 2)
+        self._phi = lambdify(x, phi_e)
+        self._rho = lambdify(x, rho_e)
 
-    def phi( self, x ):
-        return self._phi( x )
+    def phi(self, x):
+        return self._phi(x)
 
-    def rho( self, x ):
-        return self._rho( x )
+    def rho(self, x):
+        return self._rho(x)
 
     @property
-    def domain( self ):
+    def domain(self):
         return (0, 1)
 
     @property
-    def periodic( self ):
+    def periodic(self):
         return False
 
 #==============================================================================
-def kernel( p1, k1, bs1, w1, mat_m, mat_s ):
+def kernel(p1, k1, bs1, w1, mat_m, mat_s):
     """
     Kernel for computing the mass/stiffness element matrices.
 
@@ -66,8 +66,8 @@ def kernel( p1, k1, bs1, w1, mat_m, mat_s ):
 
     """
     # Reset element matrices
-    mat_m[:,:] = 0.
-    mat_s[:,:] = 0.
+    mat_m[:, :] = 0.
+    mat_s[:, :] = 0.
 
     # Cycle over non-zero test functions in element
     for il_1 in range(p1+1):
@@ -114,6 +114,9 @@ def assemble_matrices(V, kernel, *, nquads):
     kernel : callable
         Function that performs the assembly process on small element matrices.
 
+    nquads : list or tuple of int
+        Number of quadrature points in each direction (here only one).
+
     Returns
     -------
     mass : StencilMatrix
@@ -122,8 +125,6 @@ def assemble_matrices(V, kernel, *, nquads):
     stiffness : StencilMatrix
         Stiffness matrix in 1D stencil format.
 
-    nquads : list or tuple of int
-        Number of quadrature points in each direction (here only one).
     """
     # Sizes
     [s1] = V.vector_space.starts
@@ -147,7 +148,7 @@ def assemble_matrices(V, kernel, *, nquads):
     mat_s = np.zeros((p1+1, 2*p1+1)) # stiffness
 
     # Build global matrices: cycle over elements
-    for k1 in range( nk1 ):
+    for k1 in range(nk1):
 
         # Get spline index, B-splines' values and quadrature weights
         is1 =   spans_1[k1]
@@ -200,18 +201,18 @@ def assemble_rhs(V, f, *, nquads):
     weights_1 = quad_grid.weights
 
     # Data structure
-    rhs = StencilVector( V.vector_space )
+    rhs = StencilVector(V.vector_space)
 
     # Build RHS
-    for k1 in range( nk1 ):
+    for k1 in range(nk1):
 
         is1    =   spans_1[k1]
-        bs1    =   basis_1[k1,:,:,:]
+        bs1    =   basis_1[k1, :, :, :]
         x1     =  points_1[k1, :]
         wvol   = weights_1[k1, :]
-        f_quad = f( x1 )
+        f_quad = f(x1)
 
-        for il1 in range( p1+1 ):
+        for il1 in range(p1+1):
 
             bi_0 = bs1[il1, 0, :]
             v    = bi_0 * f_quad * wvol
@@ -259,7 +260,7 @@ if __name__ == '__main__':
     # Build right-hand side vector
     rhs = assemble_rhs(V, model.rho, nquads=nquads)
 
-    # Apply homogeneous dirichlet boundary conditions
+    # Apply homogeneous Dirichlet boundary conditions
     s1, = V.vector_space.starts
     e1, = V.vector_space.ends
 

--- a/examples/poisson_2d_multi_patch.py
+++ b/examples/poisson_2d_multi_patch.py
@@ -76,13 +76,15 @@ def run_poisson_2d(solution, f, domain, ncells, degree, comm=None):
     #+++++++++++++++++++++++++++++++
     # 2. Discretization
     #+++++++++++++++++++++++++++++++
+    nquads = [p+1 for p in degree]
+
     domain_h = discretize(domain, ncells=ncells, comm=comm)
     Vh       = discretize(V, domain_h, degree=degree)
 
-    equation_h = discretize(equation, domain_h, [Vh, Vh])
+    equation_h = discretize(equation, domain_h, [Vh, Vh], nquads=nquads)
 
-    l2norm_h = discretize(l2norm, domain_h, Vh)
-    h1norm_h = discretize(h1norm, domain_h, Vh)
+    l2norm_h = discretize(l2norm, domain_h, Vh, nquads=nquads)
+    h1norm_h = discretize(h1norm, domain_h, Vh, nquads=nquads)
 
     equation_h.set_solver('cg', info=True, tol=1e-14)
 

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -236,19 +236,13 @@ def get_degrees(funcs, space):
     return new_degrees
 
 #==============================================================================
-def get_nquads(Vh):
-    if isinstance(Vh, (ProductFemSpace, VectorFemSpace)):
-        return get_nquads(Vh.spaces[0])
-    return tuple([g.weights.shape[1] for g in Vh.quad_grids()])
-
-#==============================================================================
 class AST(object):
     """
     The Ast class transforms a terminal expression returned from sympde
     into a DefNode
 
     """
-    def __init__(self, expr, terminal_expr, spaces, mapping_space=None, tag=None, mapping=None, is_rational_mapping=None,
+    def __init__(self, expr, terminal_expr, spaces, *, nquads, mapping_space=None, tag=None, mapping=None, is_rational_mapping=None,
                      num_threads=1, **kwargs):
         # ... compute terminal expr
         # TODO check that we have one single domain/interface/boundary
@@ -269,6 +263,7 @@ class AST(object):
         dim                 = domain.dim
         constants           = expr.constants
         mask                = None
+        nquads              = tuple(nquads)
 
         # Define mask for different domain
         if isinstance(domain, Boundary):
@@ -292,7 +287,6 @@ class AST(object):
             tests               = expr.test_functions
             fields              = expr.fields
             is_broken           = spaces.symbolic_space.is_broken
-            nquads              = get_nquads(spaces)
             tests_degrees       = get_degrees(tests, spaces)
             multiplicity_tests  = get_multiplicity(tests, spaces.vector_space)
             is_parallel         = spaces.vector_space.parallel
@@ -308,7 +302,6 @@ class AST(object):
             atoms               = terminal_expr.expr.atoms(ScalarFunction, VectorFunction)
             fields              = tuple(i for i in atoms if i not in tests+trials)
             is_broken           = spaces[1].symbolic_space.is_broken
-            nquads              = get_nquads(spaces[1])
             tests_degrees       = get_degrees(tests, spaces[1])
             trials_degrees      = get_degrees(trials, spaces[0])
             multiplicity_tests  = get_multiplicity(tests, spaces[1].vector_space)
@@ -330,7 +323,6 @@ class AST(object):
             is_functional       = True
             fields              = tuple(expr.atoms(ScalarFunction, VectorFunction))
             is_broken           = spaces.symbolic_space.is_broken
-            nquads              = get_nquads(spaces)
             fields_degrees      = get_degrees(fields, spaces)
             multiplicity_fields = get_multiplicity(fields, spaces.vector_space)
             is_parallel         = spaces.vector_space.parallel

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -92,7 +92,7 @@ def change_dtype(V, dtype):
     return V
 
 #==============================================================================           
-def discretize_derham(derham, domain_h, get_H1vec_space = False, *args, **kwargs):
+def discretize_derham(derham, domain_h, *, get_H1vec_space=False, **kwargs):
     """
     Create a discrete De Rham sequence from a symbolic one.
     
@@ -107,10 +107,10 @@ def discretize_derham(derham, domain_h, get_H1vec_space = False, *args, **kwargs
     domain_h : Geometry
         Discrete domain where the spaces will be discretized.
         
-    get_H1vec_space : Bool
+    get_H1vec_space : bool, default=False
         True to also get the "Hvec" space discretizing (H1)^n vector fields.
         
-    **kwargs : list
+    **kwargs : dict
         Optional parameters for the space discretization.
         
     Returns
@@ -271,7 +271,7 @@ def reduce_space_degrees(V, Vh, *, basis='B', sequence='DR'):
 
 #==============================================================================
 # TODO knots
-def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None, nquads=None, basis='B', sequence='DR'):
+def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None, basis='B', sequence='DR'):
     """
     This function creates the discretized space starting from the symbolic space.
 
@@ -291,9 +291,6 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
 
     knots: list | dict
         The knots sequence of the h1 space in each direction.
-
-    nquads: list
-        The number of quadrature points in each direction.
 
     basis: str
         The type of basis function can be 'B' for B-splines or 'M' for M-splines.
@@ -417,7 +414,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
 
 
         carts    = create_cart(ddms, spaces)
-        g_spaces = {inter:TensorFemSpace( ddms[i], *spaces[i], cart=carts[i], nquads=nquads, dtype=dtype) for i,inter in enumerate(interiors)}
+        g_spaces = {inter : TensorFemSpace(ddms[i], *spaces[i], cart=carts[i], dtype=dtype) for i, inter in enumerate(interiors)}
 
 
         for i,j in connectivity:

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -91,6 +91,58 @@ def change_dtype(V, dtype):
 
     return V
 
+#==============================================================================
+def get_max_degree_of_one_space(Vh):
+    """
+    Get the maximum polynomial degree of a finite element space, along each
+    logical (parametric) coordinate.
+
+    Parameters
+    ----------
+    Vh : FemSpace
+        The finite element space under investigation.
+
+    Results
+    -------
+    list[int]
+        The maximum polynomial degre of Vh with respect to each coordinate.
+
+    """
+
+    if isinstance(Vh, TensorFemSpace):
+        return Vh.degree
+
+    elif isinstance(Vh, VectorFemSpace):
+        return [max(p) for p in zip(*Vh.degree)]
+
+    elif isinstance(Vh, ProductFemSpace):
+        degree = [get_max_degree_of_one_space(Vh_i) for Vh_i in Vh.spaces]
+        return [max(p) for p in zip(*degree)]
+
+    else:
+        raise TypeError(f'Type({V}) not understood')
+
+
+def get_max_degree(*spaces):
+    """
+    Get the maximum polynomial degree across several finite element spaces,
+    along each logical (parametric) coordinate.
+
+    Parameters
+    ----------
+    *spaces : tuple[FemSpace]
+        The finite element spaces under investigation.
+
+    Results
+    -------
+    list[int]
+        The maximum polynomial degree across all spaces, with respect to each
+        coordinate.
+
+    """
+    degree = [get_max_degree_of_one_space(Vh) for Vh in spaces]
+    return [max(p) for p in zip(*degree)]
+
 #==============================================================================           
 def discretize_derham(derham, domain_h, *, get_H1vec_space=False, **kwargs):
     """
@@ -106,25 +158,30 @@ def discretize_derham(derham, domain_h, *, get_H1vec_space=False, **kwargs):
 
     domain_h : Geometry
         Discrete domain where the spaces will be discretized.
-        
+
     get_H1vec_space : bool, default=False
         True to also get the "Hvec" space discretizing (H1)^n vector fields.
-        
+
     **kwargs : dict
         Optional parameters for the space discretization.
-        
+
     Returns
     -------
     DiscreteDerham
       The discrete De Rham sequence containing the discrete spaces, 
       differential operators and projectors.
+
+    See Also
+    --------
+    discretize_space
+
     """
 
     ldim    = derham.shape
     mapping = domain_h.domain.mapping # NOTE: assuming single-patch domain!
-    bases  = ['B'] + ldim * ['M']
-    spaces = [discretize_space(V, domain_h, basis=basis, **kwargs) \
-            for V, basis in zip(derham.spaces, bases)]
+    bases   = ['B'] + ldim * ['M']
+    spaces  = [discretize_space(V, domain_h, basis=basis, **kwargs)
+               for V, basis in zip(derham.spaces, bases)]
 
     if get_H1vec_space:
         X = VectorFunctionSpace('X', domain_h.domain, kind='h1')
@@ -480,6 +537,29 @@ def discretize(a, *args, **kwargs):
         domain  = domain_h.domain
         mapping = domain_h.domain.mapping
         kwargs['symbolic_mapping'] = mapping
+
+    #...
+    # In the case of Equation, BilinearForm, LinearForm, or Functional, we
+    # need the number of quadrature points along each direction.
+    #
+    # If not given, we set `nquads[i] = max_p[i] + 1`, where `max_p[i]` is the
+    # maximum polynomial degree of the spaces along direction i.
+    #
+    # If a scalar integer is passed, we use the same number of quadrature
+    # points in all directions.
+    if isinstance(a, (sym_BasicForm, sym_Equation)):
+        nquads = kwargs.get('nquads', None)
+        if nquads is None:
+            spaces = args[1]
+            if not hasattr(spaces, '__iter__'):
+                spaces = [spaces]
+            nquads = [p + 1 for p in get_max_degree(*spaces)]
+        elif not hasattr(nquads, '__iter__'):
+            assert isinstance(nquads, int)
+            domain_h = args[0]
+            nquads = [nquads] * domain_h.ldim
+        kwargs['nquads'] = nquads
+    #...
 
     if isinstance(a, sym_BasicForm):
         if isinstance(a, (sym_Norm, sym_SemiNorm)):

--- a/psydac/api/feec.py
+++ b/psydac/api/feec.py
@@ -188,6 +188,17 @@ class DiscreteDerham(BasicDiscrete):
         if not (kind == 'global'):
             raise NotImplementedError('only global projectors are available')
 
+        if nquads is None:
+            nquads = [p + 1 for p in self.V0.degree]
+        elif isinstance(nquads, int):
+            nquads = [nquads] * self.dim
+        else:
+            assert hasattr(nquads, '__iter__')
+            nquads = list(nquads)
+
+        assert all(isinstance(nq, int) for nq in nquads)
+        assert all(nq >= 1 for nq in nquads)
+
         if self.dim == 1:
             P0 = Projector_H1(self.V0)
             P1 = Projector_L2(self.V1, nquads)

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -32,10 +32,19 @@ from psydac.fem.projectors   import knot_insertion_projection_operator
 from psydac.core.bsplines    import find_span, basis_funs_all_ders
 from psydac.ddm.cart         import InterfaceCartDecomposition
 
-__all__ = ('collect_spaces', 'compute_diag_len', 'get_nquads',
-           'construct_test_space_arguments', 'construct_trial_space_arguments', 
-           'construct_quad_grids_arguments', 'reset_arrays', 'do_nothing', 'extract_stencil_mats', 
-           'DiscreteBilinearForm', 'DiscreteFunctional', 'DiscreteLinearForm', 'DiscreteSumForm'
+__all__ = (
+    'collect_spaces',
+    'compute_diag_len',
+    'construct_test_space_arguments',
+    'construct_trial_space_arguments',
+    'construct_quad_grids_arguments',
+    'reset_arrays',
+    'do_nothing',
+    'extract_stencil_mats',
+    'DiscreteBilinearForm',
+    'DiscreteFunctional',
+    'DiscreteLinearForm',
+    'DiscreteSumForm',
 )
 
 #==============================================================================
@@ -79,22 +88,12 @@ def collect_spaces(space, *args):
             args = [[e[0]] for e in args]
 
     return args
+
 #==============================================================================
 def compute_diag_len(p, md, mc):
     n = ((np.ceil((p+1)/mc)-1)*md).astype('int')
     n = n-np.minimum(0, n-p)+p+1
     return n.astype('int')
-
-def get_nquads(Vh):
-    """
-    This function is to be deleted in the future, as we intend to make the number of
-    quadrature points a property of DiscreteLinearForms, DiscreteBilinearForms and
-    DiscreteFunctionals rather than a property of spaces.
-    
-    """
-    if isinstance(Vh, (ProductFemSpace, VectorFemSpace)):
-        return get_nquads(Vh.spaces[0])
-    return tuple([g.weights.shape[1] for g in Vh.quad_grids()])
 
 #==============================================================================
 def construct_test_space_arguments(basis_values):
@@ -157,63 +156,74 @@ def extract_stencil_mats(mats):
         elif isinstance(M, ComposedLinearOperator):
             new_mats += [i for i in M.multiplicants if isinstance(i, (StencilInterfaceMatrix, StencilMatrix))]
     return new_mats
+
 #==============================================================================
 class DiscreteBilinearForm(BasicDiscrete):
-    """ Class that represents the concept of a discrete bi-linear form.
-        This class allocates the matrix and generates the matrix assembly method.
+    """
+    Discrete bilinear form ready to be assembled into a matrix.
+
+    This class represents the concept of a discrete bilinear form in Psydac.
+    Instances of this class generate an appropriate matrix assembly kernel,
+    allocate the matrix if not provided, and prepare a list of arguments for
+    the kernel.
 
     Parameters
     ----------
 
     expr : sympde.expr.expr.BilinearForm
-        The symbolic bi-linear form.
+        The symbolic bilinear form.
 
     kernel_expr : sympde.expr.evaluation.KernelExpression
-        The atomic representation of the bi-linear form.
+        The atomic representation of the bilinear form.
 
     domain_h : Geometry
-        The discretized domain
+        The discretized domain.
 
-    spaces: list of FemSpace
-        The trial and test discrete spaces.
+    spaces : list of FemSpace
+        The discrete trial and test spaces.
 
-    matrix: Matrix
-        The matrix that we assemble into it.
-        If not provided, it will create a new Matrix of the appropriate space.
+    nquads : list or tuple of int
+        The number of quadrature points used in the assembly kernel along each
+        direction.
 
-    update_ghost_regions: bool
+    matrix : StencilMatrix or BlockLinearOperator, optional
+        The matrix that we assemble into. If not provided, a new matrix is
+        created with the appropriate domain and codomain (default: None).
+
+    update_ghost_regions : bool, default=True
         Accumulate the contributions of the neighbouring processes.
 
-    nquads: list of tuple
-        The number of quadrature points used in the assembly method.
-        This optional argument will be mandatory in the future, when quadrature grids
-        will not be property-like attributes of a TensorFemSpace anymore, but instead will only be
-        given to the constructors of DiscreteBilinearForm, DiscreteLinearForm, and DiscreteFunctional.
-
-    backend: dict
+    backend : dict, optional
         The backend used to accelerate the computing kernels.
         The backend dictionaries are defined in the file psydac/api/settings.py
 
-    assembly_backend: dict
-        The backend used to accelerate the assembly method.
+    assembly_backend : dict, optional
+        The backend used to accelerate the assembly kernel.
         The backend dictionaries are defined in the file psydac/api/settings.py
 
-    linalg_backend: dict
+    linalg_backend : dict, optional
         The backend used to accelerate the computing kernels of the linear operator.
         The backend dictionaries are defined in the file psydac/api/settings.py
 
-    symbolic_mapping: Sympde.topology.Mapping
-        The symbolic mapping which defines the physical domain of the bi-linear form.
+    symbolic_mapping : Sympde.topology.Mapping, optional
+        The symbolic mapping which defines the physical domain of the bilinear form.
+
+    See Also
+    --------
+    DiscreteLinearForm
+    DiscreteFunctional
+    DiscreteSumForm
 
     """
-    def __init__(self, expr, kernel_expr, domain_h, spaces, *, matrix=None, update_ghost_regions=True,
-                       nquads=None, backend=None, linalg_backend=None, assembly_backend=None,
-                       symbolic_mapping=None):
+    def __init__(self, expr, kernel_expr, domain_h, spaces, *, nquads,
+                 matrix=None, update_ghost_regions=True, backend=None,
+                 linalg_backend=None, assembly_backend=None,
+                 symbolic_mapping=None):
 
         if not isinstance(expr, sym_BilinearForm):
             raise TypeError('> Expecting a symbolic BilinearForm')
 
-        assert( isinstance(domain_h, Geometry) )
+        assert isinstance(domain_h, Geometry)
 
         self._spaces = spaces
 
@@ -331,11 +341,6 @@ class DiscreteBilinearForm(BasicDiscrete):
 
         #...
         discrete_space = (trial_space, test_space)
-        space_nquads   = [qo - 1 for qo in get_nquads(test_space)]
-        nquads         = [qo + 1 for qo in (nquads or space_nquads)]
-
-        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert np.array_equal(nquads, get_nquads(test_space))
 
         # Assuming that all vector spaces (and their Cartesian decomposition,
         # if any) are compatible with each other, extract the first available
@@ -344,10 +349,10 @@ class DiscreteBilinearForm(BasicDiscrete):
         ends   = vector_space.ends
         npts   = vector_space.npts
 
-        comm = None
-        if vector_space.parallel:
-            comm = vector_space.cart.comm
+        # MPI communicator
+        comm = vector_space.cart.comm if vector_space.parallel else None
 
+        # Backends for code generation
         assembly_backend = backend or assembly_backend
         linalg_backend   = backend or linalg_backend
 
@@ -355,11 +360,11 @@ class DiscreteBilinearForm(BasicDiscrete):
         # self._func, self._free_args, self._max_nderiv and self._backend
         BasicDiscrete.__init__(self, expr, kernel_expr, comm=comm, root=0, discrete_space=discrete_space,
                        nquads=nquads, is_rational_mapping=is_rational_mapping, mapping=symbolic_mapping,
-                       mapping_space=mapping_space, num_threads=self._num_threads,backend=assembly_backend)
+                       mapping_space=mapping_space, num_threads=self._num_threads, backend=assembly_backend)
 
-        #...
+        #... Handle the special case where the current MPI process does not need to do anything
         if isinstance(target, (Boundary, Interface)):
-            #...
+
             # If process does not own the boundary or interface, do not assemble anything
             if test_ext == -1:
                 if starts[axis] != 0:
@@ -369,7 +374,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                 if ends[axis] != npts[axis]-1:
                     self._func = do_nothing
 
-            # In case of target==Interface, we only use the mpi ranks that are on the interface to assemble the BilinearForm
+            # In case of target==Interface, we only use the MPI ranks that are on the interface to assemble the BilinearForm
             if self._func == do_nothing and isinstance(target, Interface):
                 self._free_args = ()
                 self._args      = ()
@@ -378,10 +383,12 @@ class DiscreteBilinearForm(BasicDiscrete):
                 self._global_matrices     = ()
                 self._threads_args        = ()
                 return
+        #...
 
+        #... Build the quadrature grids
         if isinstance(target, Boundary):
-            test_grid  = QuadratureGrid( test_space, axis, test_ext)
-            trial_grid = QuadratureGrid( trial_space, axis, trial_ext)
+            test_grid  = QuadratureGrid( test_space, axis,  test_ext, nquads=nquads)
+            trial_grid = QuadratureGrid(trial_space, axis, trial_ext, nquads=nquads)
             self._grid = (test_grid,)
         elif isinstance(target, Interface):
             # this part treats the cases of:
@@ -389,22 +396,29 @@ class DiscreteBilinearForm(BasicDiscrete):
             # integral(v_plus  * u_minus)
             # the other cases, integral(v_minus * u_minus) and integral(v_plus * u_plus)
             # are converted to boundary integrals by Sympde
-            test_grid  = QuadratureGrid( test_space, axis, test_ext)
-            trial_grid = QuadratureGrid( trial_space, axis, trial_ext)
+            test_grid  = QuadratureGrid( test_space, axis,  test_ext, nquads=nquads)
+            trial_grid = QuadratureGrid(trial_space, axis, trial_ext, nquads=nquads)
             self._grid = (test_grid, trial_grid) if test_target == target.minus else (trial_grid, test_grid)
-            self._test_ext  = test_target.ext
+            self._test_ext  =  test_target.ext
             self._trial_ext = trial_target.ext
         else:
-            test_grid  = QuadratureGrid(test_space)
-            trial_grid = QuadratureGrid(trial_space)
+            test_grid  = QuadratureGrid( test_space, nquads=nquads)
+            trial_grid = QuadratureGrid(trial_space, nquads=nquads)
             self._grid = (test_grid,)
         #...
-        self._test_basis  = BasisValues( test_space, nderiv = self.max_nderiv, trial=False, grid= test_grid)
-        self._trial_basis = BasisValues(trial_space, nderiv = self.max_nderiv, trial=True , grid=trial_grid)
 
+        # Extract the basis function values on the quadrature grids
+        self._test_basis  = BasisValues( test_space, nderiv=self.max_nderiv, trial=False, grid= test_grid)
+        self._trial_basis = BasisValues(trial_space, nderiv=self.max_nderiv, trial=True , grid=trial_grid)
+
+        # Allocate the output matrix, if needed
         self.allocate_matrices(linalg_backend)
+
+        # Determine whether OpenMP instructions were generated
         with_openmp = (assembly_backend['name'] == 'pyccel' and assembly_backend['openmp']) if assembly_backend else False
-        self._args , self._threads_args = self.construct_arguments(with_openmp=with_openmp)
+
+        # Construct the arguments to be passed to the assemble() function, which is stored in self._func
+        self._args, self._threads_args = self.construct_arguments(with_openmp=with_openmp)
 
     @property
     def domain(self):
@@ -421,6 +435,10 @@ class DiscreteBilinearForm(BasicDiscrete):
     @property
     def grid(self):
         return self._grid
+
+    @property
+    def nquads(self):
+        return self._grid[0].nquads
 
     @property
     def test_basis(self):
@@ -462,7 +480,7 @@ class DiscreteBilinearForm(BasicDiscrete):
             for key in self._free_args:
                 v = kwargs[key]
 
-                if len(self.domain)>1 and isinstance(v, FemField) and v.space.is_product:
+                if len(self.domain) > 1 and isinstance(v, FemField) and v.space.is_product:
                     i, j = self.get_space_indices_from_target(self.domain, self.target)
                     assert i == j
                     v = v[i]
@@ -500,7 +518,9 @@ class DiscreteBilinearForm(BasicDiscrete):
         # TODO : uncomment this line when the conjugate is applied on the dot product in the complex case
         #self._matrix.conjugate(out=self._matrix)
 
-        if self._matrix: self._matrix.ghost_regions_in_sync = False
+        if self._matrix:
+            self._matrix.ghost_regions_in_sync = False
+
         return self._matrix
 
     def get_space_indices_from_target(self, domain, target):
@@ -887,15 +907,16 @@ class DiscreteSesquilinearForm(DiscreteBilinearForm):
     spaces: list of FemSpace
         The trial and test discrete spaces.
 
+    nquads : list or tuple of int
+        The number of quadrature points used in the low-level assembly function
+        along each direction.
+
     matrix: Matrix
         The matrix that we assemble into it.
         If not provided, it will create a new Matrix of the appropriate space.
 
     update_ghost_regions: bool
         Accumulate the contributions of the neighbouring processes.
-
-    nquads: list of tuple
-        The number of quadrature points used in the assembly method.
 
     backend: dict
         The backend used to accelerate the computing kernels.
@@ -917,8 +938,13 @@ class DiscreteSesquilinearForm(DiscreteBilinearForm):
 
 #==============================================================================
 class DiscreteLinearForm(BasicDiscrete):
-    """ Class that represents the concept of a discrete linear form.
-        This class allocates the vector and generates the vector assembly method.
+    """
+    Discrete linear form ready to be assembled into a vector.
+
+    This class represents the concept of a discrete linear form in Psydac.
+    Instances of this class generate an appropriate vector assembly kernel,
+    allocate the vector if not provided, and prepare a list of arguments for
+    the kernel.
 
     Parameters
     ----------
@@ -930,42 +956,46 @@ class DiscreteLinearForm(BasicDiscrete):
         The atomic representation of the linear form.
 
     domain_h : Geometry
-        The discretized domain
+        The discretized domain.
 
     space : FemSpace
-        The discrete space.
+        The discrete test space.
 
-    vector : Vector
-        The vector that we assemble into it.
-        If not provided, it will create a new Vector of the appropriate space.
+    nquads : list or tuple of int
+        The number of quadrature points used in the assembly kernel along each
+        direction.
 
-    update_ghost_regions : bool
+    vector : StencilVector or BlockVector, optional
+        The vector that we assemble into. If not provided, a new vector of the
+        appropriate space is created.
+
+    update_ghost_regions : bool, default=False
         Accumulate the contributions of the neighbouring processes.
 
-    nquads : list or tuple
-        The number of quadrature points used in the assembly method.
-        This optional argument will be mandatory in the future, when quadrature grids
-        will not be property-like attributes of a TensorFemSpace anymore, but instead will only be
-        given to the constructors of DiscreteBilinearForm, DiscreteLinearForm, and DiscreteFunctional.
-
-    backend : dict
+    backend : dict, optional
         The backend used to accelerate the computing kernels.
         The backend dictionaries are defined in the file psydac/api/settings.py
 
-    symbolic_mapping : Sympde.topology.Mapping
+    symbolic_mapping : Sympde.topology.Mapping, optional
         The symbolic mapping which defines the physical domain of the linear form.
 
+    See Also
+    --------
+    DiscreteBilinearForm
+    DiscreteFunctional
+    DiscreteSumForm
+
     """
-    def __init__(self, expr, kernel_expr, domain_h, space, *, vector=None,
-                       update_ghost_regions=True, nquads=None, backend=None,
-                       symbolic_mapping=None):
+    def __init__(self, expr, kernel_expr, domain_h, space, *, nquads,
+                 vector=None, update_ghost_regions=True, backend=None,
+                 symbolic_mapping=None):
 
         if not isinstance(expr, sym_LinearForm):
             raise TypeError('> Expecting a symbolic LinearForm')
 
-        assert( isinstance(domain_h, Geometry) )
+        assert isinstance(domain_h, Geometry)
 
-        self._space  = space
+        self._space = space
 
         if isinstance(kernel_expr, (tuple, list)):
             if len(kernel_expr) == 1:
@@ -982,7 +1012,7 @@ class DiscreteLinearForm(BasicDiscrete):
         domain = self.domain
         target = self.target
 
-        if len(domain)>1:
+        if len(domain) > 1:
             i = self.get_space_indices_from_target(domain, target)
             test_space  = self._space.spaces[i]
             mapping = list(domain_h.mappings.values())[i]
@@ -1016,25 +1046,18 @@ class DiscreteLinearForm(BasicDiscrete):
             self._update_ghost_regions = False
             return
 
-        is_rational_mapping = False
-        mapping_space       = None
-        if not( mapping is None ):
-            is_rational_mapping = isinstance( mapping, NurbsMapping )
+        if mapping is not None:
+            is_rational_mapping = isinstance(mapping, NurbsMapping)
             mapping_space = mapping.space
+        else:
+            is_rational_mapping = False
+            mapping_space = None
 
         self._is_rational_mapping = is_rational_mapping
         discrete_space            = test_space
 
-
-        space_nquads = [qo - 1 for qo in get_nquads(test_space)]
-        nquads       = [qo + 1 for qo in (nquads or space_nquads)]
-
-        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert np.array_equal(nquads, get_nquads(test_space))
-
-        comm        = None
-        if vector_space.parallel:
-            comm = vector_space.cart.comm
+        # MPI communicator
+        comm = vector_space.cart.comm if vector_space.parallel else None
 
         # BasicDiscrete generates the assembly code and sets the following attributes that are used afterwards:
         # self._func, self._free_args, self._max_nderiv and self._backend
@@ -1042,6 +1065,7 @@ class DiscreteLinearForm(BasicDiscrete):
                               nquads=nquads, is_rational_mapping=is_rational_mapping, mapping=symbolic_mapping,
                               mapping_space=mapping_space, num_threads=self._num_threads, backend=backend)
 
+        #... Handle the special case where the current MPI process does not need to do anything
         if not isinstance(target, Boundary):
             ext  = None
             axis = None
@@ -1063,16 +1087,23 @@ class DiscreteLinearForm(BasicDiscrete):
                 npts = vector_space.npts[axis]
                 if end + 1 != npts:
                     self._func = do_nothing
-            #...
+        #...
 
-        grid             = QuadratureGrid( test_space, axis=axis, ext=ext )
-        self._grid       = grid
-        self._test_basis = BasisValues( test_space, nderiv = self.max_nderiv, grid=grid)
+        # Build the quadrature grids
+        test_grid  = QuadratureGrid(test_space, axis=axis, ext=ext, nquads=nquads)
+        self._grid = test_grid
 
+        # Extract the basis function values on the quadrature grid
+        self._test_basis = BasisValues(test_space, nderiv=self.max_nderiv, grid=test_grid)
+
+        # Allocate the output vector, if needed
         self.allocate_matrices()
 
-        with_openmp  = (backend['name'] == 'pyccel' and backend['openmp']) if backend else False
-        self._args , self._threads_args = self.construct_arguments(with_openmp=with_openmp)
+        # Determine whether OpenMP instructions were generated
+        with_openmp = (backend['name'] == 'pyccel' and backend['openmp']) if backend else False
+
+        # Construct the arguments to be passed to the assemble() function, which is stored in self._func
+        self._args, self._threads_args = self.construct_arguments(with_openmp=with_openmp)
 
     @property
     def domain(self):
@@ -1089,6 +1120,10 @@ class DiscreteLinearForm(BasicDiscrete):
     @property
     def grid(self):
         return self._grid
+
+    @property
+    def nquads(self):
+        return self._grid.nquads
 
     @property
     def test_basis(self):
@@ -1123,7 +1158,7 @@ class DiscreteLinearForm(BasicDiscrete):
             consts  = []
             for key in self._free_args:
                 v = kwargs[key]
-                if len(self.domain)>1 and isinstance(v, FemField) and v.space.is_product:
+                if len(self.domain) > 1 and isinstance(v, FemField) and v.space.is_product:
                     i = self.get_space_indices_from_target(self.domain, self.target)
                     v = v[i]
                 if isinstance(v, FemField):
@@ -1157,7 +1192,9 @@ class DiscreteLinearForm(BasicDiscrete):
         # TODO : uncomment this line when the conjugate is applied on the dot product in the complex case
         # self._vector.conjugate(out=self._vector)
 
-        if self._vector: self._vector.ghost_regions_in_sync = False
+        if self._vector:
+            self._vector.ghost_regions_in_sync = False
+
         return self._vector
 
     def get_space_indices_from_target(self, domain, target):
@@ -1303,50 +1340,59 @@ class DiscreteLinearForm(BasicDiscrete):
 
 
 #==============================================================================
+# NOTE: why do we pass a FemSpace to the constructor?
 class DiscreteFunctional(BasicDiscrete):
-    """ Class that represents the concept of a discrete functional form.
-        This class generates the functiona form assembly method.
+    """
+    Discrete functional ready to be assembled into a scalar (real or complex).
+
+    This class represents the concept of a discrete functional in Psydac.
+    Instances of this class generate an appropriate functional assembly kernel,
+    and prepare a list of arguments for the kernel.
 
     Parameters
     ----------
 
-    expr : sympde.expr.expr.LinearForm
+    expr : sympde.expr.expr.Functional
         The symbolic functional form.
 
     kernel_expr : sympde.expr.evaluation.KernelExpression
         The atomic representation of the functional form.
 
     domain_h : Geometry
-        The discretized domain
+        The discretized domain.
 
     space : FemSpace
         The discrete space.
 
-    update_ghost_regions : bool
-        Accumulate the contributions of the neighbouring processes.
+    nquads : list or tuple of int
+        The number of quadrature points used in the assembly kernel along each
+        direction.
 
-    nquads : list or tuple
-        The number of quadrature points used in the assembly method.
-        This optional argument will be mandatory in the future, when quadrature grids
-        will not be property-like attributes of a TensorFemSpace anymore, but instead will only be
-        given to the constructors of DiscreteBilinearForm, DiscreteLinearForm, and DiscreteFunctional.
+    update_ghost_regions : bool, default=True
+        Accumulate the contributions of the neighbouring processes.
 
     backend : dict
         The backend used to accelerate the computing kernels.
         The backend dictionaries are defined in the file psydac/api/settings.py
 
     symbolic_mapping : Sympde.topology.Mapping
-        The symbolic mapping which defines the physical domain of the functional form.
+        The symbolic mapping which defines the physical domain of the functional.
+
+    See Also
+    --------
+    DiscreteBilinearForm
+    DiscreteLinearForm
+    DiscreteSumForm
 
     """
-    def __init__(self, expr, kernel_expr, domain_h, space, *, nquads=None,
-                       backend=None, symbolic_mapping=None):
+    def __init__(self, expr, kernel_expr, domain_h, space, *, nquads,
+                 backend=None, symbolic_mapping=None):
 
         if not isinstance(expr, sym_Functional):
             raise TypeError('> Expecting a symbolic Functional')
 
         # ...
-        assert( isinstance(domain_h, Geometry) )
+        assert isinstance(domain_h, Geometry)
 
         self._space = space
 
@@ -1366,9 +1412,9 @@ class DiscreteFunctional(BasicDiscrete):
         domain = self.domain
         target = self.target
 
-        if len(domain)>1:
+        if len(domain) > 1:
             i = self.get_space_indices_from_target(domain, target)
-            self._space  = self._space.spaces[i]
+            self._space = self._space.spaces[i]
             mapping = list(domain_h.mappings.values())[i]
         else:
             mapping = list(domain_h.mappings.values())[0]
@@ -1380,8 +1426,8 @@ class DiscreteFunctional(BasicDiscrete):
         else:
             vector_space = self.space.vector_space
 
-        num_threads  = 1
-        if vector_space.parallel and vector_space.cart.num_threads>1:
+        num_threads = 1
+        if vector_space.parallel and vector_space.cart.num_threads > 1:
             num_threads = vector_space.cart._num_threads
 
         # In case of multiple patches, if the communicator is MPI_COMM_NULL, we do not generate the assembly code
@@ -1401,25 +1447,20 @@ class DiscreteFunctional(BasicDiscrete):
             ext  = None
             axis = None
 
-        is_rational_mapping = False
-        mapping_space       = None
-        if not( mapping is None ):
+        if mapping is not None:
             is_rational_mapping = isinstance( mapping, NurbsMapping )
             mapping_space = mapping.space
+        else:
+            is_rational_mapping = False
+            mapping_space = None
 
         self._mapping             = mapping
         self._is_rational_mapping = is_rational_mapping
         discrete_space            = self._space
 
-        comm = None
-        if vector_space.parallel:
-            comm = vector_space.cart.comm
-
-        space_nquads = [qo - 1 for qo in get_nquads(self._space)]
-        nquads       = [qo + 1 for qo in (nquads or space_nquads)]
-
-        # this doesn't work right now otherwise. TODO: fix this and remove this assertion
-        assert np.array_equal(nquads, get_nquads(self.space))
+        # MPI communicator
+        comm = vector_space.cart.comm if vector_space.parallel else None
+        self._comm = domain_h.comm  # NOTE: why?
 
         # BasicDiscrete generates the assembly code and sets the following attributes that are used afterwards:
         # self._func, self._free_args, self._max_nderiv and self._backend
@@ -1427,11 +1468,14 @@ class DiscreteFunctional(BasicDiscrete):
                               nquads=nquads, is_rational_mapping=is_rational_mapping, mapping=symbolic_mapping,
                               mapping_space=mapping_space, num_threads=num_threads, backend=backend)
 
-        self._comm       = domain_h.comm
-        grid             = QuadratureGrid( self.space,  axis=axis, ext=ext)
-        self._grid       = grid
-        self._test_basis = BasisValues( self.space, nderiv = self.max_nderiv, trial=True, grid=grid)
+        # Build the quadrature grid
+        grid       = QuadratureGrid(self.space,  axis=axis, ext=ext, nquads=nquads)
+        self._grid = grid
 
+        # Extract the basis function values on the quadrature grid
+        self._test_basis = BasisValues(self.space, nderiv=self.max_nderiv, trial=True, grid=grid)
+
+        # Construct the arguments to be passed to the assemble() function, which is stored in self._func
         self._args = self.construct_arguments()
 
     @property
@@ -1449,6 +1493,10 @@ class DiscreteFunctional(BasicDiscrete):
     @property
     def grid(self):
         return self._grid
+
+    @property
+    def nquads(self):
+        return self._grid.nquads
 
     @property
     def test_basis(self):
@@ -1567,7 +1615,6 @@ class DiscreteFunctional(BasicDiscrete):
                 raise NotImplementedError('TODO')
         return v
 
-
 #==============================================================================
 class DiscreteSumForm(BasicDiscrete):
 
@@ -1586,7 +1633,7 @@ class DiscreteSumForm(BasicDiscrete):
         self._folder = self._initialize_folder(folder)
 
         # create a module name if not given
-        tag = random_string( 8 )
+        tag = random_string(8)
 
         # ...
         forms = []
@@ -1658,5 +1705,4 @@ class DiscreteSumForm(BasicDiscrete):
             M = [form.assemble(**kwargs) for form in self.forms]
             M = np.sum(M)
             return M
-
 

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -1491,7 +1491,6 @@ class DiscreteFunctional(BasicDiscrete):
 
         # MPI communicator
         comm = vector_space.cart.comm if vector_space.parallel else None
-        self._comm = domain_h.comm  # NOTE: why?
 
         # BasicDiscrete generates the assembly code and sets the following attributes that are used afterwards:
         # self._func, self._free_args, self._max_nderiv and self._backend
@@ -1511,6 +1510,10 @@ class DiscreteFunctional(BasicDiscrete):
             trial  = True,
             grid   = grid
         )
+
+        # Store MPI communicator
+        # NOTE [YG 18.04.2024]: this is not equal to the variable `comm` when we have multiple patches
+        self._comm = domain_h.comm
 
         # Construct the arguments to be passed to the assemble() function, which is stored in self._func
         self._args = self.construct_arguments()

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -597,8 +597,8 @@ class DiscreteBilinearForm(BasicDiscrete):
                 map_coeffs = [[e._coeffs._data for e in self.mapping._fields]]
                 spaces     = [self.mapping._fields[0].space]
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans - s for q,s in zip(sp.get_quadrature_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
-                map_basis  = [[q.basis for q in sp.get_quadrature_grids(*self.nquads)] for sp in spaces]
+                map_span   = [[q.spans - s for q,s in zip(sp.get_assembly_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_basis  = [[q.basis for q in sp.get_assembly_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
                 weights    = [self.mapping.weights_field.coeffs._data] if self.is_rational_mapping else []
 
@@ -638,8 +638,8 @@ class DiscreteBilinearForm(BasicDiscrete):
                         weights_p[0] = weights_p[0]._interface_data[axis, ext]
 
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans - s for q, s in zip(sp.get_quadrature_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
-                map_basis  = [[q.basis for q in sp.get_quadrature_grids(*self.nquads)] for sp in spaces]
+                map_span   = [[q.spans - s for q, s in zip(sp.get_assembly_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_basis  = [[q.basis for q in sp.get_assembly_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
 
             nderiv = self.max_nderiv
@@ -1272,8 +1272,8 @@ class DiscreteLinearForm(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans - s for q, s in zip(space.get_quadrature_grids(*self.nquads), space.vector_space.starts)]
-            map_basis  = [q.basis for q in space.get_quadrature_grids(*self.nquads)]
+            map_span   = [q.spans - s for q, s in zip(space.get_assembly_grids(*self.nquads), space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.get_assembly_grids(*self.nquads)]
             axis       = self.grid.axis
             ext        = self.grid.ext
             points     = self.grid.points
@@ -1591,8 +1591,8 @@ class DiscreteFunctional(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans-s for q,s in zip(space.get_quadrature_grids(*self.nquads), space.vector_space.starts)]
-            map_basis  = [q.basis for q in space.get_quadrature_grids(*self.nquads)]
+            map_span   = [q.spans-s for q,s in zip(space.get_assembly_grids(*self.nquads), space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.get_assembly_grids(*self.nquads)]
 
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -592,14 +592,16 @@ class DiscreteBilinearForm(BasicDiscrete):
         # When self._target is an Interface domain len(self._grid) == 2
         # where grid contains the QuadratureGrid of both sides of the interface
         if self.mapping:
+
             if len(self.grid) == 1:
                 map_coeffs = [[e._coeffs._data for e in self.mapping._fields]]
                 spaces     = [self.mapping._fields[0].space]
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans-s for q,s in zip(sp.quad_grids(), sp.vector_space.starts)] for sp in spaces]
-                map_basis  = [[q.basis for q in sp.quad_grids()] for sp in spaces]
+                map_span   = [[q.spans - s for q,s in zip(sp.get_quadrature_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_basis  = [[q.basis for q in sp.get_quadrature_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
                 weights    = [self.mapping.weights_field.coeffs._data] if self.is_rational_mapping else []
+
             elif len(self.grid) == 2:
                 target = self.kernel_expr.target
                 assert isinstance(target, Interface)
@@ -636,8 +638,8 @@ class DiscreteBilinearForm(BasicDiscrete):
                         weights_p[0] = weights_p[0]._interface_data[axis, ext]
 
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans-s for q,s in zip(sp.quad_grids(), sp.vector_space.starts)] for sp in spaces]
-                map_basis  = [[q.basis for q in sp.quad_grids()] for sp in spaces]
+                map_span   = [[q.spans - s for q, s in zip(sp.get_quadrature_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_basis  = [[q.basis for q in sp.get_quadrature_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
 
             nderiv = self.max_nderiv
@@ -1270,8 +1272,8 @@ class DiscreteLinearForm(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans-s for q,s in zip(space.quad_grids(), space.vector_space.starts)]
-            map_basis  = [q.basis for q in space.quad_grids()]
+            map_span   = [q.spans - s for q, s in zip(space.get_quadrature_grids(*self.nquads), space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.get_quadrature_grids(*self.nquads)]
             axis       = self.grid.axis
             ext        = self.grid.ext
             points     = self.grid.points
@@ -1586,8 +1588,8 @@ class DiscreteFunctional(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans-s for q,s in zip(space.quad_grids(), space.vector_space.starts)]
-            map_basis  = [q.basis for q in space.quad_grids()]
+            map_span   = [q.spans-s for q,s in zip(space.get_quadrature_grids(*self.nquads), space.vector_space.starts)]
+            map_basis  = [q.basis for q in space.get_quadrature_grids(*self.nquads)]
 
             if self.is_rational_mapping:
                 mapping = [*mapping, self.mapping._weights_field._coeffs._data]

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -503,7 +503,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                     basis_v = BasisValues(
                         v.space,
                         nderiv = self.max_nderiv,
-                        nquads = nquads,
+                        nquads = self.nquads,
                         trial  = True,
                         grid   = self.grid[0]
                     )
@@ -1192,7 +1192,7 @@ class DiscreteLinearForm(BasicDiscrete):
                     basis_v  = BasisValues(
                         v.space,
                         nderiv = self.max_nderiv,
-                        nquads = nquads,
+                        nquads = self.nquads,
                         trial  = True,
                         grid   = self.grid
                     )

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -387,8 +387,8 @@ class DiscreteBilinearForm(BasicDiscrete):
 
         #... Build the quadrature grids
         if isinstance(target, Boundary):
-            test_grid  = QuadratureGrid( test_space, axis,  test_ext, nquads=nquads)
-            trial_grid = QuadratureGrid(trial_space, axis, trial_ext, nquads=nquads)
+            test_grid  = QuadratureGrid( test_space, axis=axis, ext= test_ext, nquads=nquads)
+            trial_grid = QuadratureGrid(trial_space, axis=axis, ext=trial_ext, nquads=nquads)
             self._grid = (test_grid,)
         elif isinstance(target, Interface):
             # this part treats the cases of:
@@ -396,8 +396,8 @@ class DiscreteBilinearForm(BasicDiscrete):
             # integral(v_plus  * u_minus)
             # the other cases, integral(v_minus * u_minus) and integral(v_plus * u_plus)
             # are converted to boundary integrals by Sympde
-            test_grid  = QuadratureGrid( test_space, axis,  test_ext, nquads=nquads)
-            trial_grid = QuadratureGrid(trial_space, axis, trial_ext, nquads=nquads)
+            test_grid  = QuadratureGrid( test_space, axis=axis, ext= test_ext, nquads=nquads)
+            trial_grid = QuadratureGrid(trial_space, axis=axis, ext=trial_ext, nquads=nquads)
             self._grid = (test_grid, trial_grid) if test_target == target.minus else (trial_grid, test_grid)
             self._test_ext  =  test_target.ext
             self._trial_ext = trial_target.ext
@@ -408,8 +408,20 @@ class DiscreteBilinearForm(BasicDiscrete):
         #...
 
         # Extract the basis function values on the quadrature grids
-        self._test_basis  = BasisValues( test_space, nderiv=self.max_nderiv, trial=False, grid= test_grid)
-        self._trial_basis = BasisValues(trial_space, nderiv=self.max_nderiv, trial=True , grid=trial_grid)
+        self._test_basis  = BasisValues(
+            test_space,
+            nderiv = self.max_nderiv,
+            nquads = nquads,
+            trial  = False,
+            grid   = test_grid
+        )
+        self._trial_basis = BasisValues(
+            trial_space,
+            nderiv = self.max_nderiv,
+            nquads = nquads,
+            trial  = True ,
+            grid   = trial_grid
+        )
 
         # Allocate the output matrix, if needed
         self.allocate_matrices(linalg_backend)
@@ -488,7 +500,13 @@ class DiscreteBilinearForm(BasicDiscrete):
                     assert len(self.grid) == 1
                     if not v.coeffs.ghost_regions_in_sync:
                         v.coeffs.update_ghost_regions()
-                    basis_v = BasisValues(v.space, nderiv = self.max_nderiv, trial=True, grid=self.grid[0])
+                    basis_v = BasisValues(
+                        v.space,
+                        nderiv = self.max_nderiv,
+                        nquads = nquads,
+                        trial  = True,
+                        grid   = self.grid[0]
+                    )
                     bs, d, s, p = construct_test_space_arguments(basis_v)
                     basis   += bs
                     spans   += s
@@ -1094,7 +1112,12 @@ class DiscreteLinearForm(BasicDiscrete):
         self._grid = test_grid
 
         # Extract the basis function values on the quadrature grid
-        self._test_basis = BasisValues(test_space, nderiv=self.max_nderiv, grid=test_grid)
+        self._test_basis = BasisValues(
+            test_space,
+            nderiv = self.max_nderiv,
+            nquads = nquads,
+            grid   = test_grid
+        )
 
         # Allocate the output vector, if needed
         self.allocate_matrices()
@@ -1164,7 +1187,13 @@ class DiscreteLinearForm(BasicDiscrete):
                 if isinstance(v, FemField):
                     if not v.coeffs.ghost_regions_in_sync:
                         v.coeffs.update_ghost_regions()
-                    basis_v  = BasisValues(v.space, nderiv = self.max_nderiv, trial=True, grid=self.grid)
+                    basis_v  = BasisValues(
+                        v.space,
+                        nderiv = self.max_nderiv,
+                        nquads = nquads,
+                        trial  = True,
+                        grid   = self.grid
+                    )
                     bs, d, s, p = construct_test_space_arguments(basis_v)
                     basis   += bs
                     spans   += s
@@ -1473,7 +1502,13 @@ class DiscreteFunctional(BasicDiscrete):
         self._grid = grid
 
         # Extract the basis function values on the quadrature grid
-        self._test_basis = BasisValues(self.space, nderiv=self.max_nderiv, trial=True, grid=grid)
+        self._test_basis = BasisValues(
+            self.space,
+            nderiv = self.max_nderiv,
+            nquads = nquads,
+            trial  = True,
+            grid   = grid
+        )
 
         # Construct the arguments to be passed to the assemble() function, which is stored in self._func
         self._args = self.construct_arguments()

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -52,7 +52,7 @@ class QuadratureGrid():
         Number of quadrature points along each direction.
 
     """
-    def __init__(self, V, axis=None, ext=None, trial_space=None, nquads):
+    def __init__(self, V, *, nquads, axis=None, ext=None, trial_space=None):
 
         n_elements          = []
         indices             = []
@@ -199,7 +199,7 @@ class BasisValues():
         The spans of the basis functions.
 
     """
-    def __init__(self, V, nderiv, trial=False, grid=None, nquads):
+    def __init__(self, V, *, nderiv, nquads, trial=False, grid=None):
 
         self._space = V
         assert grid is not None

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -88,11 +88,11 @@ class QuadratureGrid():
                 if e < quad_grid_i.indices[0]:
                     local_element_start[-1] += 1
                     local_element_end  [-1] += 1
-                    p, w = get_points_weights(spaces, i, e)  # TODO: remove
+                    p, w = get_points_weights(spaces, i, e, nquads)  # TODO: remove
                     points [-1] = np.concatenate((p, points [-1]))
                     weights[-1] = np.concatenate((w, weights[-1]))
                 elif e > quad_grid_i.indices[-1]:
-                    p, w = get_points_weights(spaces, i, e)  # TODO: remove
+                    p, w = get_points_weights(spaces, i, e, nquads)  # TODO: remove
                     points [-1] = np.concatenate((points [-1], p))
                     weights[-1] = np.concatenate((weights[-1], w))
                 else:

--- a/psydac/api/tests/test_2d_navier_stokes.py
+++ b/psydac/api/tests/test_2d_navier_stokes.py
@@ -290,7 +290,7 @@ def run_steady_state_navier_stokes_2d(domain, f, ue, pe, *, ncells, degree, mult
 
     # Discretize norms
     l2norm_u_h = discretize(l2norm_u, domain_h, V1h, backend=PSYDAC_BACKEND_GPYCCEL)
-    l2norm_p_h = discretize(l2norm_p, domain_h, V2h, backend=PSYDAC_BACKEND_GPYCCEL)
+    l2norm_p_h = discretize(l2norm_p, domain_h, V2h, backend=PSYDAC_BACKEND_GPYCCEL, nquads=[deg+1 for deg in degree])
 
     l2norm_du_h = discretize(l2norm_du, domain_h, V1h, backend=PSYDAC_BACKEND_GPYCCEL)
     l2norm_dp_h = discretize(l2norm_dp, domain_h, V2h, backend=PSYDAC_BACKEND_GPYCCEL)

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -68,7 +68,7 @@ def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     ah = discretize(equation, domain_h, [Xh, Xh])
     # ...
     # ... discretize norms
-    l2norm_F_h = discretize(l2norm_F, domain_h, V2h)
+    l2norm_F_h = discretize(l2norm_F, domain_h, V2h, nquads=[deg+1 for deg in degree])
     # ...
 
     # ...
@@ -197,7 +197,7 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
 
     # L2 error norm of the pressure, after removing the average value from the field
     l2norm_p  = Norm(pe - (p - p_avg), domain, kind='l2')
-    l2norm_ph = discretize(l2norm_p, domain_h, V2h)
+    l2norm_ph = discretize(l2norm_p, domain_h, V2h, nquads=[deg+1 for deg in degree])
 
     # Compute error norms
     l2_error_u = l2norm_uh.assemble(u = uh)

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -68,7 +68,7 @@ def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     ah = discretize(equation, domain_h, [Xh, Xh])
     # ...
     # ... discretize norms
-    l2norm_F_h = discretize(l2norm_F, domain_h, V2h, nquads=[deg+1 for deg in degree])
+    l2norm_F_h = discretize(l2norm_F, domain_h, V2h, nquads=[d+1 for d in degree])
     # ...
 
     # ...
@@ -197,7 +197,7 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
 
     # L2 error norm of the pressure, after removing the average value from the field
     l2norm_p  = Norm(pe - (p - p_avg), domain, kind='l2')
-    l2norm_ph = discretize(l2norm_p, domain_h, V2h, nquads=[deg+1 for deg in degree])
+    l2norm_ph = discretize(l2norm_p, domain_h, V2h, nquads=[d+1 for d in degree])
 
     # Compute error norms
     l2_error_u = l2norm_uh.assemble(u = uh)
@@ -334,7 +334,7 @@ def run_stokes_2d_dir_petsc(domain, f, ue, pe, *, homogeneous, ncells, degree):
 
     # L2 error norm of the pressure, after removing the average value from the field
     l2norm_p  = Norm(pe - (p - p_avg), domain, kind='l2')
-    l2norm_ph = discretize(l2norm_p, domain_h, V2h)
+    l2norm_ph = discretize(l2norm_p, domain_h, V2h, nquads=[d+1 for d in degree])
 
     # Compute error norms
     l2_error_u = l2norm_uh.assemble(u = uh)

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -416,7 +416,7 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
     F = mapping.get_callable_mapping()
     errE = lambda x1: (E(x1) - E_ex(t, *F(x1)))**2 * np.sqrt(F.metric_det(x1))
     errB = lambda x1: (push_1d_l2(B, x1, F) - B_ex(t, *F(x1)))**2 * np.sqrt(F.metric_det(x1))
-    error_l2_E = np.sqrt(derham_h.V1.integral(errE))
+    error_l2_E = np.sqrt(derham_h.V1.integral(errE, nquads=[degree+1]))
     error_l2_B = np.sqrt(derham_h.V0.integral(errB))
     print('L2 norm of error on E(t,x) at final time: {:.2e}'.format(error_l2_E))
     print('L2 norm of error on B(t,x) at final time: {:.2e}'.format(error_l2_B))

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -63,9 +63,11 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
     from psydac.api.discretization import discretize
     from psydac.linalg.solvers     import inverse
 
-    # for now, switch to the Python backend, to be able to detect out of bounds errors
-    from psydac.api.settings       import PSYDAC_BACKEND_PYTHON
+    from psydac.api.settings       import PSYDAC_BACKENDS
     from psydac.feec.pull_push     import push_1d_l2
+
+    # For now, use the Python backend, to be able to detect out of bounds errors
+    backend = PSYDAC_BACKENDS['python']
 
     #--------------------------------------------------------------------------
     # Analytical objects: SymPDE
@@ -135,8 +137,8 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
     derham_h = discretize(derham, domain_h, degree=[degree], multiplicity=[mult])
 
     # Discrete bilinear forms
-    a0_h = discretize(a0, domain_h, (derham_h.V0, derham_h.V0), backend=PSYDAC_BACKEND_PYTHON)
-    a1_h = discretize(a1, domain_h, (derham_h.V1, derham_h.V1), backend=PSYDAC_BACKEND_PYTHON)
+    a0_h = discretize(a0, domain_h, (derham_h.V0, derham_h.V0), nquads=[degree+1], backend=backend)
+    a1_h = discretize(a1, domain_h, (derham_h.V1, derham_h.V1), nquads=[degree+1], backend=backend)
 
     # Mass matrices (StencilMatrix objects)
     M0 = a0_h.assemble()
@@ -171,7 +173,7 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
 
         # Option 2: Discretize and assemble penalization matrix
         elif bc_mode == 'penalization':
-            a0_bc_h = discretize(a0_bc, domain_h, (derham_h.V0, derham_h.V0), backend=PSYDAC_BACKEND_PYTHON)
+            a0_bc_h = discretize(a0_bc, domain_h, (derham_h.V0, derham_h.V0), nquads=[degree+1], backend=backend)
             M0_bc   = a0_bc_h.assemble()
 
     # Projectors

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -207,11 +207,13 @@ def run_maxwell_2d_TE(*, use_spline_mapping,
     from sympde.expr     import BilinearForm
 
     from psydac.api.discretization import discretize
-    from psydac.api.settings       import PSYDAC_BACKEND_GPYCCEL
+    from psydac.api.settings       import PSYDAC_BACKENDS
     from psydac.feec.pull_push     import push_2d_hcurl, push_2d_l2
     from psydac.linalg.solvers     import inverse
     from psydac.utilities.utils    import refine_array_1d
     from psydac.mapping.discrete   import SplineMapping, NurbsMapping
+
+    backend = PSYDAC_BACKENDS['pyccel-gcc']
 
     #--------------------------------------------------------------------------
     # Problem setup
@@ -290,7 +292,7 @@ def run_maxwell_2d_TE(*, use_spline_mapping,
     #--------------------------------------------------------------------------
     if use_spline_mapping:
         domain_h = discretize(domain, filename=filename, comm=MPI.COMM_WORLD)
-        derham_h = discretize(derham, domain_h, multiplicity = [mult,mult])
+        derham_h = discretize(derham, domain_h, multiplicity = [mult, mult])
 
         periodic_list = mapping.get_callable_mapping().space.periodic
         degree_list   = mapping.get_callable_mapping().space.degree
@@ -311,22 +313,23 @@ def run_maxwell_2d_TE(*, use_spline_mapping,
     else:
         # Discrete physical domain and discrete DeRham sequence
         domain_h = discretize(domain, ncells=[ncells, ncells], periodic=[periodic, periodic], comm=MPI.COMM_WORLD)
-        derham_h = discretize(derham, domain_h, degree=[degree, degree], multiplicity = [mult,mult])
+        derham_h = discretize(derham, domain_h, degree=[degree, degree], multiplicity = [mult, mult])
 
     # Discrete bilinear forms
-    a1_h = discretize(a1, domain_h, (derham_h.V1, derham_h.V1), backend=PSYDAC_BACKEND_GPYCCEL)
-    a2_h = discretize(a2, domain_h, (derham_h.V2, derham_h.V2), backend=PSYDAC_BACKEND_GPYCCEL)
+    nquads = [degree + 1, degree + 1]
+    a1_h = discretize(a1, domain_h, (derham_h.V1, derham_h.V1), nquads=nquads, backend=backend)
+    a2_h = discretize(a2, domain_h, (derham_h.V2, derham_h.V2), nquads=nquads, backend=backend)
 
-    # Mass matrices (StencilMatrix objects)
+    # Mass matrices (StencilMatrix or BlockLinearOperator objects)
     M1 = a1_h.assemble()
     M2 = a2_h.assemble()
 
-    # Differential operators
+    # Differential operators (StencilMatrix or BlockLinearOperator objects)
     D0, D1 = derham_h.derivatives_as_matrices
 
     # Discretize and assemble penalization matrix
     if not periodic:
-        a1_bc_h = discretize(a1_bc, domain_h, (derham_h.V1, derham_h.V1), backend=PSYDAC_BACKEND_GPYCCEL)
+        a1_bc_h = discretize(a1_bc, domain_h, (derham_h.V1, derham_h.V1), nquads=nquads, backend=backend)
         M1_bc   = a1_bc_h.assemble()
 
     # Transpose of derivative matrix
@@ -624,9 +627,9 @@ def run_maxwell_2d_TE(*, use_spline_mapping,
     errx = lambda x1, x2: (push_2d_hcurl(E.fields[0], E.fields[1], x1, x2, F)[0] - Ex_ex(t, *F(x1, x2)))**2 * np.sqrt(F.metric_det(x1,x2))
     erry = lambda x1, x2: (push_2d_hcurl(E.fields[0], E.fields[1], x1, x2, F)[1] - Ey_ex(t, *F(x1, x2)))**2 * np.sqrt(F.metric_det(x1,x2))
     errz = lambda x1, x2: (push_2d_l2(B, x1, x2, F) - Bz_ex(t, *F(x1, x2)))**2 * np.sqrt(F.metric_det(x1,x2))
-    error_l2_Ex = np.sqrt(derham_h.V1.spaces[0].integral(errx))
-    error_l2_Ey = np.sqrt(derham_h.V1.spaces[1].integral(erry))
-    error_l2_Bz = np.sqrt(derham_h.V0.integral(errz))
+    error_l2_Ex = np.sqrt(derham_h.V1.spaces[0].integral(errx, nquads=nquads))
+    error_l2_Ey = np.sqrt(derham_h.V1.spaces[1].integral(erry, nquads=nquads))
+    error_l2_Bz = np.sqrt(derham_h.V0.integral(errz, nquads=nquads))
     print('L2 norm of error on Ex(t,x,y) at final time: {:.2e}'.format(error_l2_Ex))
     print('L2 norm of error on Ey(t,x,y) at final time: {:.2e}'.format(error_l2_Ey))
     print('L2 norm of error on Bz(t,x,y) at final time: {:.2e}'.format(error_l2_Bz))

--- a/psydac/api/tests/test_quadorder.py
+++ b/psydac/api/tests/test_quadorder.py
@@ -34,10 +34,14 @@ def test_custom_nquads(test_nquads):
 
     domain_h = discretize(domain, ncells=ncells)
 
-    Vh = discretize(V, domain_h, degree=degree, nquads=test_nquads)
+    Vh = discretize(V, domain_h, degree=degree)
 
     # NOTE: we _need_ the Python backend here for range checking, otherwise we'd only get segfaults at best
-    _ = discretize(a, domain_h, [Vh, Vh], nquads=test_nquads, backend=PSYDAC_BACKEND_PYTHON).assemble()
-    _ = discretize(l, domain_h,      Vh , nquads=test_nquads, backend=PSYDAC_BACKEND_PYTHON).assemble()
+    ah = discretize(a, domain_h, [Vh, Vh], nquads=test_nquads, backend=PSYDAC_BACKEND_PYTHON)
+    lh = discretize(l, domain_h,      Vh , nquads=test_nquads, backend=PSYDAC_BACKEND_PYTHON)
 
-    assert np.array_equal(Vh.nquads, test_nquads)
+    ah.assemble()
+    lh.assemble()
+
+    assert np.array_equal(ah.nquads, test_nquads)
+    assert np.array_equal(lh.nquads, test_nquads)

--- a/psydac/core/tests/test_bsplines.py
+++ b/psydac/core/tests/test_bsplines.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
     from psydac.core.bsplines import quadrature_grid, basis_ders_on_quad_grid
     from psydac.core.bsplines import elements_spans
 
-    u, w = gauss_legendre(p)
+    u, w = gauss_legendre(p + 1)
     quad_x, quad_w = quadrature_grid(grid, u, w)
     quad_basis = basis_ders_on_quad_grid(knots, p, quad_x, nders=0, normalization='B')
     integrals  = np.zeros(nb)

--- a/psydac/core/tests/test_bsplines_pyccel.py
+++ b/psydac/core/tests/test_bsplines_pyccel.py
@@ -424,29 +424,29 @@ def elevate_knots_true(knots, degree, periodic, multiplicity=1, tol=1e-15):
     return np.array([*left, *knots, *right])
 
 #==============================================================================
-def quadrature_grid_true( breaks, quad_rule_x, quad_rule_w ):
+def quadrature_grid_true(breaks, quad_rule_x, quad_rule_w):
     # Check that input arrays have correct size
     assert len(breaks)      >= 2
     assert len(quad_rule_x) == len(quad_rule_w)
 
-    # Check that provided quadrature rule is defined on interval [-1,1]
+    # Check that provided quadrature rule is defined on interval [-1, 1]
     assert min(quad_rule_x) >= -1
     assert max(quad_rule_x) <= +1
 
-    quad_rule_x = np.asarray( quad_rule_x )
-    quad_rule_w = np.asarray( quad_rule_w )
+    quad_rule_x = np.asarray(quad_rule_x)
+    quad_rule_w = np.asarray(quad_rule_w)
 
-    ne     = len(breaks)-1
+    ne     = len(breaks) - 1
     nq     = len(quad_rule_x)
-    quad_x = np.zeros( (ne,nq) )
-    quad_w = np.zeros( (ne,nq) )
+    quad_x = np.zeros((ne, nq))
+    quad_w = np.zeros((ne, nq))
 
     # Compute location and weight of quadrature points from basic rule
-    for ie,(a,b) in enumerate(zip(breaks[:-1],breaks[1:])):
-        c0 = 0.5*(a+b)
-        c1 = 0.5*(b-a)
-        quad_x[ie,:] = c1*quad_rule_x[:] + c0
-        quad_w[ie,:] = c1*quad_rule_w[:]
+    for ie, (a, b) in enumerate(zip(breaks[:-1], breaks[1:])):
+        c0 = 0.5 * (a + b)
+        c1 = 0.5 * (b - a)
+        quad_x[ie, :] = c1 * quad_rule_x[:] + c0
+        quad_w[ie, :] = c1 * quad_rule_w[:]
 
     return quad_x, quad_w
 
@@ -703,8 +703,8 @@ def test_elevate_knots(knots, degree, periodic, multiplicity):
 @pytest.mark.parametrize('nquads', (2, 3, 4, 5))
 def test_quadrature_grid(breaks, nquads):
     quad_x, quad_w = gauss_legendre(nquads)
-    expected = quadrature_grid_true(breaks, quad_x[::-1], quad_w[::-1])
-    out = quadrature_grid(breaks, quad_x[::-1], quad_w[::-1])
+    expected = quadrature_grid_true(breaks, quad_x, quad_w)
+    out = quadrature_grid(breaks, quad_x, quad_w)
 
     assert np.allclose(expected, out, atol=ATOL, rtol=RTOL)
 

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -24,17 +24,18 @@ __all__ = ('GlobalProjector', 'Projector_H1', 'Projector_Hcurl', 'Projector_Hdiv
 #==============================================================================
 class GlobalProjector(metaclass=ABCMeta):
     """
-    A global projector to some TensorFemSpace or VectorFemSpace object.
-    It is constructed over a tensor-product grid in the
-    logical domain. The vertices of this grid are obtained as the tensor
-    product of the 1D splines' Greville points along each direction.
+    Projects callable functions to some scalar or vector FEM space.
 
-    This projector matches the "geometric" degrees of freedom of
-    discrete n-forms (where n depends on the underlying space).
-    This is done by projecting each component of the vector field
-    independently, by combining 1D histopolation with 1D interpolation.
+    A global projector is constructed over a tensor-product grid in the logical
+    domain. The vertices of this grid are obtained as the tensor product of the
+    1D splines' Greville points along each direction.
 
-    This class can currently not be instantiated directly (use a subclass instead).
+    This projector matches the "geometric" degrees of freedom of discrete
+    n-forms (where n depends on the underlying space).
+    This is done by projecting each component of the vector field independently,
+    by combining 1D histopolation with 1D interpolation.
+
+    This class cannot be instantiated directly (use a subclass instead).
 
     Parameters
     ----------
@@ -77,8 +78,7 @@ class GlobalProjector(metaclass=ABCMeta):
         # set up quadrature weights
         if nquads:
             assert len(nquads) == self._dim
-            uw = [gauss_legendre(k-1) for k in nquads]
-            uw = [(u[::-1], w[::-1]) for u, w in uw]
+            uw = [gauss_legendre(k) for k in nquads]
 
         # retrieve projection space structure
         # this is a 2D Python array (first level: block, second level: tensor direction)

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -77,13 +77,9 @@ class GlobalProjector(metaclass=ABCMeta):
         # set up quadrature weights
         if nquads:
             assert len(nquads) == self._dim
-            uw = [gauss_legendre( k-1 ) for k in nquads]
-            uw = [(u[::-1], w[::-1]) for u,w in uw]
-        else:
-            # for now, we assume that all tensorspaces have the same quad_grids
-            # (this seems to be the case at the moment, but maybe checking it might be a good idea nontheless...)
-            uw = [(quad_grid.quad_rule_x,quad_grid.quad_rule_w) for quad_grid in tensorspaces[0].quad_grids()]
-        
+            uw = [gauss_legendre(k-1) for k in nquads]
+            uw = [(u[::-1], w[::-1]) for u, w in uw]
+
         # retrieve projection space structure
         # this is a 2D Python array (first level: block, second level: tensor direction)
         # which indicates where to use histopolation and where interpolation
@@ -99,6 +95,9 @@ class GlobalProjector(metaclass=ABCMeta):
             for cell in block:
                 if cell == 'I': has_i = True
                 if cell == 'H': has_h = True
+
+        if has_h and nquads is None:
+            raise ValueError('The number of quadrature points `nquads` must be provided for performing histopolation')
 
         # ... and activate them.
         for space in tensorspaces:
@@ -149,14 +148,15 @@ class GlobalProjector(metaclass=ABCMeta):
                     if quad_x[j] is None:
                         u, w = uw[j]
                         global_quad_x, global_quad_w = quadrature_grid(V.histopolation_grid, u, w)
-                        #"roll" back points to the interval to ensure that the quadrature points are
-                        #in the domain. Only usefull in the periodic case (else do nothing)
-                        #if not used then you will have quadrature points outside of the domain which 
-                        #might cause problem when your function is only defined inside the domain
 
+                        # "roll" back points to the interval to ensure that the quadrature points are
+                        # in the domain. Only useful in the periodic case (else do nothing)
+                        # if not used then you will have quadrature points outside of the domain which
+                        # might cause problem when your function is only defined inside the domain.
                         roll_edges(V.domain, global_quad_x) 
                         quad_x[j] = global_quad_x[s:e+1]
                         quad_w[j] = global_quad_w[s:e+1]
+
                     local_x, local_w = quad_x[j], quad_w[j]
                     solvercells += [V._histopolator]
                 else:

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -291,9 +291,7 @@ class ConformingProjection_V0( FemLinearOperator):
             a = BilinearForm((u,v), integral(domain, expr) + integral(Interfaces, expr_I))
             # print('[[ forcing python backend for ConformingProjection_V0]] ')
             # backend_language = 'python'
-            nquads = [p + 1 for p in V0h.spaces[0].degree]
-            ah = discretize(a, domain_h, [V0h, V0h], nquads=nquads,
-                            backend=PSYDAC_BACKENDS[backend_language])
+            ah = discretize(a, domain_h, [V0h, V0h], backend=PSYDAC_BACKENDS[backend_language])
 
             # self._A = ah.assemble()
             self._A = ah.forms[0]._matrix
@@ -509,9 +507,7 @@ class ConformingProjection_V1( FemLinearOperator ):
             a = BilinearForm((u,v), integral(domain, expr) + integral(Interfaces, expr_I))
             # print('[[ forcing python backend for ConformingProjection_V1]] ')
             # backend_language = 'python'
-            nquads = [p + 1 for p in V1h.spaces[0].degree]
-            ah = discretize(a, domain_h, [V1h, V1h], nquads=nquads,
-                            backend=PSYDAC_BACKENDS[backend_language])
+            ah = discretize(a, domain_h, [V1h, V1h], backend=PSYDAC_BACKENDS[backend_language])
             #
             # # self._A = ah.assemble()
             self._A = ah.forms[0]._matrix

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -291,7 +291,7 @@ class ConformingProjection_V0( FemLinearOperator):
             a = BilinearForm((u,v), integral(domain, expr) + integral(Interfaces, expr_I))
             # print('[[ forcing python backend for ConformingProjection_V0]] ')
             # backend_language = 'python'
-            nquads = [p + 1 for p in V0h.spaces[0].degrees]
+            nquads = [p + 1 for p in V0h.spaces[0].degree]
             ah = discretize(a, domain_h, [V0h, V0h], nquads=nquads,
                             backend=PSYDAC_BACKENDS[backend_language])
 

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -237,7 +237,7 @@ def allocate_interface_matrix(corners, test_space, trial_space):
     cs    = list(zip(*[i.coordinates for i in bi]))
     axis  = [all(i[0]==j for j in i) for i in cs].index(True)
     ext   = 1 if cs[axis][0]==1 else -1
-    s     = test_space.quad_grids()[axis].spans[-1 if ext==1 else 0] - test_space.degree[axis]
+    s     = test_space.get_quadrature_grids()[axis].spans[-1 if ext==1 else 0] - test_space.degree[axis]
 
     mat  = StencilInterfaceMatrix(trial_space.vector_space, test_space.vector_space, s, s, axis, flip=flips[0], permutation=list(permutation))
     return mat
@@ -291,7 +291,9 @@ class ConformingProjection_V0( FemLinearOperator):
             a = BilinearForm((u,v), integral(domain, expr) + integral(Interfaces, expr_I))
             # print('[[ forcing python backend for ConformingProjection_V0]] ')
             # backend_language = 'python'
-            ah = discretize(a, domain_h, [V0h, V0h], backend=PSYDAC_BACKENDS[backend_language])
+            nquads = [p + 1 for p in V0h.spaces[0].degrees]
+            ah = discretize(a, domain_h, [V0h, V0h], nquads=nquads,
+                            backend=PSYDAC_BACKENDS[backend_language])
 
             # self._A = ah.assemble()
             self._A = ah.forms[0]._matrix
@@ -507,7 +509,9 @@ class ConformingProjection_V1( FemLinearOperator ):
             a = BilinearForm((u,v), integral(domain, expr) + integral(Interfaces, expr_I))
             # print('[[ forcing python backend for ConformingProjection_V1]] ')
             # backend_language = 'python'
-            ah = discretize(a, domain_h, [V1h, V1h], backend=PSYDAC_BACKENDS[backend_language])
+            nquads = [p + 1 for p in V1h.spaces[0].degree]
+            ah = discretize(a, domain_h, [V1h, V1h], nquads=nquads,
+                            backend=PSYDAC_BACKENDS[backend_language])
             #
             # # self._A = ah.assemble()
             self._A = ah.forms[0]._matrix

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -237,7 +237,7 @@ def allocate_interface_matrix(corners, test_space, trial_space):
     cs    = list(zip(*[i.coordinates for i in bi]))
     axis  = [all(i[0]==j for j in i) for i in cs].index(True)
     ext   = 1 if cs[axis][0]==1 else -1
-    s     = test_space.get_quadrature_grids()[axis].spans[-1 if ext==1 else 0] - test_space.degree[axis]
+    s     = test_space.get_assembly_grids()[axis].spans[-1 if ext==1 else 0] - test_space.degree[axis]
 
     mat  = StencilInterfaceMatrix(trial_space.vector_space, test_space.vector_space, s, s, axis, flip=flips[0], permutation=list(permutation))
     return mat

--- a/psydac/feec/tests/test_commuting_projections_dual.py
+++ b/psydac/feec/tests/test_commuting_projections_dual.py
@@ -35,7 +35,7 @@ def test_transpose_div_3d(Nel, Nq, p, bc, m):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq, multiplicity=m)
+    derham_h = discretize(derham, domain_h, degree=p, multiplicity=m)
 
     v2 = element_of(derham.V2, name='v2')
     v3 = element_of(derham.V3, name='v3')
@@ -92,7 +92,7 @@ def test_transpose_curl_3d(Nel, Nq, p, bc, m):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq, multiplicity=m)
+    derham_h = discretize(derham, domain_h, degree=p, multiplicity=m)
 
     v1 = element_of(derham.V1, name='v1')
     v2 = element_of(derham.V2, name='v2')
@@ -138,7 +138,7 @@ def test_transpose_grad_3d(Nel, Nq, p, bc, m):
     domain = Cube('domain', bounds1=(0, L[0]), bounds2=(0,L[1]), bounds3=(0,L[2]))
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=Nel, periodic=bc)
-    derham_h = discretize(derham, domain_h, degree=p, nquads=Nq, multiplicity=m)
+    derham_h = discretize(derham, domain_h, degree=p, multiplicity=m)
 
     v0 = element_of(derham.V0, name='v0')
     v1 = element_of(derham.V1, name='v1')

--- a/psydac/feec/tests/test_commuting_projections_dual.py
+++ b/psydac/feec/tests/test_commuting_projections_dual.py
@@ -11,7 +11,7 @@ import pytest
 
 
 @pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [4])
+@pytest.mark.parametrize('Nq', [5])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
 @pytest.mark.parametrize('m', [1,2])
@@ -52,8 +52,9 @@ def test_transpose_div_3d(Nel, Nq, p, bc, m):
     error = abs((u2-divT_u3).toarray()).max()
     assert error < 2e-10
 
+
 @pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [5])
+@pytest.mark.parametrize('Nq', [6])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
 @pytest.mark.parametrize('m', [1,2])
@@ -109,8 +110,9 @@ def test_transpose_curl_3d(Nel, Nq, p, bc, m):
     error = abs((u1-curlT_u2).toarray()).max()
     assert error < 2e-9
 
+
 @pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [5])
+@pytest.mark.parametrize('Nq', [6])
 @pytest.mark.parametrize('p', [2, 3])
 @pytest.mark.parametrize('bc', [True, False])
 @pytest.mark.parametrize('m', [1,2])
@@ -154,6 +156,7 @@ def test_transpose_grad_3d(Nel, Nq, p, bc, m):
 
     error = abs((u0-gradT_u1).toarray()).max()
     assert error < 5e-10
+
 
 #==============================================================================
 if __name__ == '__main__':

--- a/psydac/fem/grid.py
+++ b/psydac/fem/grid.py
@@ -53,18 +53,14 @@ class FemAssemblyGrid:
         assert isinstance(nquads, int)
         assert isinstance(nderiv, int)
 
+        # Useful shortcuts
         T      = space.knots   # knots sequence
         degree = space.degree  # spline degree
         n      = space.nbasis  # total number of control points
         grid   = space.breaks  # breakpoints
-        k      = nquads        # number of quadrature points
 
         # Gauss-legendre quadrature rule
-        u, w = gauss_legendre(k)
-
-        # invert order
-        u = u[::-1]
-        w = w[::-1]
+        u, w = gauss_legendre(nquads)
 
         #-------------------------------------------
         # GLOBAL GRID
@@ -80,24 +76,24 @@ class FemAssemblyGrid:
         # (Span is global index of last non-vanishing basis function)
         global_spans = elements_spans(T, degree)
 
-        grid    = grid[start:end+2]
-        spans   = global_spans  [start:end+1].copy()
-        basis   = global_basis  [start:end+1].copy()
-        points  = global_points [start:end+1].copy()
-        weights = global_weights[start:end+1].copy()
+        grid    = grid[start : end + 2]
+        spans   = global_spans  [start : end + 1].copy()
+        basis   = global_basis  [start : end + 1].copy()
+        points  = global_points [start : end + 1].copy()
+        weights = global_weights[start : end + 1].copy()
 
         #-------------------------------------------
         # DATA STORAGE IN OBJECT
         #-------------------------------------------
 
         # Quadrature data on extended distributed domain
-        self._num_elements = len(grid)-1
+        self._num_elements = len(grid) - 1
         self._num_quad_pts = len(u)
         self._spans        = spans
         self._basis        = basis
         self._points       = points
         self._weights      = weights
-        self._indices      = tuple(range(start, end+1))
+        self._indices      = tuple(range(start, end + 1))
         self._quad_rule_x  = u
         self._quad_rule_w  = w
 

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -21,7 +21,6 @@ from psydac.core.bsplines         import (
         basis_integrals,
         )
 
-from psydac.utilities.quadratures import gauss_legendre
 from psydac.utilities.utils import unroll_edges, refine_array_1d
 from psydac.ddm.cart        import DomainDecomposition, CartDecomposition
 
@@ -63,8 +62,8 @@ class SplineSpace( FemSpace ):
         Set to "M" for M-splines (have unit integrals)
 
     """
-    def __init__( self, degree, knots=None, grid=None, multiplicity=None, parent_multiplicity=None,
-                  periodic=False, dirichlet=(False, False), basis='B', pads=None ):
+    def __init__(self, degree, knots=None, grid=None, multiplicity=None, parent_multiplicity=None,
+                 periodic=False, dirichlet=(False, False), basis='B', pads=None):
 
         if basis not in ['B', 'M']:
             raise ValueError(" only options for basis functions are B or M ")

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -123,7 +123,7 @@ class TensorFemSpace(FemSpace):
         self._global_element_ends   = domain_decomposition.global_element_ends
 
         # Extended 1D quadrature grids (local to process) along each direction
-        self._quad_grids = {}
+        self._quad_grids = [{} for _ in range(self.ldim)]
 
         # Flag: object NOT YET prepared for interpolation
         self._interpolation_ready = False
@@ -808,7 +808,7 @@ class TensorFemSpace(FemSpace):
 
         """
 
-        assert len(nquads) == self.ndims
+        assert len(nquads) == self.ldim
         assert all(isinstance(nq, int) for nq in nquads)
         assert all(nq >= 1 for nq in nquads)
 
@@ -821,8 +821,8 @@ class TensorFemSpace(FemSpace):
             # create a new FemAssemblyGrid and store it in the local dictionary.
             if nq not in quad_grids_dict_i:
                 V = self.spaces[i]
-                s = self.starts[i]
-                e = self.ends  [i]
+                s = int(self.vector_space.starts[i])
+                e = int(self.vector_space.ends  [i])
                 quad_grids_dict_i[nq] = FemAssemblyGrid(V, s, e, nderiv=V.degree, nquads=nq)
             # Store the required FemAssemblyGrid in the list
             quad_grids[i] = quad_grids_dict_i[nq]

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -82,8 +82,6 @@ class TensorFemSpace(FemSpace):
         assert dtype in (float, complex)
         # TODO [YG 10.04.2024]: check if dtype test is too restrictive
 
-        # BEGIN NEW -------------------------------------------------------
-
         # Handle optional arguments
         if cart and vector_space:
             raise ValueError("Cannot provide both 'vector_space' and 'cart' to constructor")
@@ -133,55 +131,6 @@ class TensorFemSpace(FemSpace):
 
         # Store information about nested grids
         self.set_refined_space(self.ncells, self)
-
-        # END NEW -------------------------------------------------------
-
-#        self._domain_decomposition = domain_decomposition
-#        self._spaces = tuple(spaces)
-#        self._dtype  = dtype
-#
-#        if cart is not None:
-#            self._vector_space = StencilVectorSpace(cart, dtype=dtype)
-#        elif vector_space is not None:
-#            self._vector_space = vector_space
-#        else:
-#            cart               = create_cart([domain_decomposition], [self._spaces])
-#            self._vector_space = StencilVectorSpace(cart[0], dtype=dtype)
-#
-#        # Shortcut
-#        v = self._vector_space
-#
-#        self._symbolic_space = None
-#        self._refined_space  = {}
-#        self._interfaces     = {}
-#        self._interfaces_readonly = MappingProxyType(self._interfaces)
-#
-#        if self._vector_space.parallel and self._vector_space.cart.is_comm_null:
-#            return
-#
-#        starts = self._vector_space.cart.domain_decomposition.starts
-#        ends   = self._vector_space.cart.domain_decomposition.ends
-#
-#        # Extended 1D quadrature grids (local to process) along each direction
-#        self._quad_grids = {}
-#
-#        # Determine portion of logical domain local to process
-#        self._element_starts = starts
-#        self._element_ends   = ends
-#
-#        # Compute limits of eta_0, eta_1, eta_2, etc... in subdomain local to process
-#        self._eta_limits = tuple( (space.breaks[s], space.breaks[e+1])
-#           for s,e,space in zip( self._element_starts, self._element_ends, self.spaces ) )
-#
-#        # Store flag: object NOT YET prepared for interpolation
-#        self._interpolation_ready = False
-#        # Compute the local domains for every process
-#
-#        # ...
-#        self._global_element_starts = domain_decomposition.global_element_starts
-#        self._global_element_ends   = domain_decomposition.global_element_ends
-#
-#        self.set_refined_space(self.ncells, self)
 
     #--------------------------------------------------------------------------
     # Abstract interface: read-only attributes

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -47,7 +47,7 @@ from psydac.core.field_evaluation_kernels import (eval_fields_1d_no_weights,
 __all__ = ('TensorFemSpace',)
 
 #===============================================================================
-class TensorFemSpace( FemSpace ):
+class TensorFemSpace(FemSpace):
     """
     Tensor-product Finite Element space V.
 
@@ -55,20 +55,19 @@ class TensorFemSpace( FemSpace ):
     ----------
     domain_decomposition : psydac.ddm.cart.DomainDecomposition
 
-    spaces : list of psydac.fem.splines.SplineSpace
+    *spaces : psydac.fem.splines.SplineSpace
         1D finite element spaces.
 
     vector_space : psydac.linalg.stencil.StencilVectorSpace or None
+        The vector space to which the coefficients belong (optional).
 
     cart : psydac.ddm.CartDecomposition or None
         Object that contains all information about the Cartesian decomposition
         of a tensor-product grid of coefficients.
 
-    nquads : list of int or None
-        Number of quadrature points used in the Gauss-Legendre quadrature formula in each direction.
-        Used as a default value for various computations. Will be removed, once nquads will only be given 
-        to the constructors of DiscreteBilinearForm, DiscreteLinearForm, and DiscreteFunctional.
-    
+    dtype : {float, complex}
+        Data type of the coefficients.
+
     Notes
     -----
     For now we assume that this tensor-product space can ONLY be constructed
@@ -76,63 +75,110 @@ class TensorFemSpace( FemSpace ):
 
     """
 
+    def __init__(self, domain_decomposition, *spaces, vector_space=None, cart=None, dtype=float):
 
-    def __init__(self, domain_decomposition, *spaces, vector_space=None, cart=None, nquads=None, dtype=float):
-
-        """."""
         assert isinstance(domain_decomposition, DomainDecomposition)
-        assert all( isinstance( s, SplineSpace ) for s in spaces )
-        self._domain_decomposition = domain_decomposition
-        self._spaces = tuple(spaces)
-        self._dtype   = dtype
+        assert all(isinstance(s, SplineSpace) for s in spaces)
 
-        if cart is not None:
-            self._vector_space = StencilVectorSpace(cart, dtype=dtype)
+        # BEGIN NEW -------------------------------------------------------
+
+        # Handle optional arguments
+        if cart and vector_space:
+            raise ValueError("Cannot provide both 'vector_space' and 'cart' to constructor")
+        elif cart is not None:
+            assert isinstance(cart, CartDecomposition)
+            vector_space = StencilVectorSpace(cart, dtype=dtype)
         elif vector_space is not None:
-            self._vector_space = vector_space
+            assert isinstance(vector_space, StencilVectorSpace)
+            cart = vector_space.cart
         else:
-            cart               = create_cart([domain_decomposition], [self._spaces])
-            self._vector_space = StencilVectorSpace(cart[0], dtype=dtype)
+            cart = create_cart([domain_decomposition], [spaces])
+            vector_space = StencilVectorSpace(cart[0], dtype=dtype)
 
-        # Shortcut
-        v = self._vector_space
+        # Store some info
+        self._domain_decomposition = domain_decomposition
+        self._spaces               = spaces
+        self._vector_space         = vector_space
+        self._symbolic_space       = None
+        self._refined_space        = {}
+        self._interfaces           = {}
+        self._interfaces_readonly  = MappingProxyType(self._interfaces)
 
-        if nquads is None:
-            self._nquads = [sp.degree for sp in self.spaces]
-        else:
-            self._nquads = nquads
+        # If process does not own space, stop here
+        if vector_space.parallel and cart.is_comm_null:
+            return
 
-        self._symbolic_space = None
-        self._refined_space  = {}
-        self._interfaces     = {}
-        self._interfaces_readonly = MappingProxyType(self._interfaces)
-
-        if self._vector_space.parallel and self._vector_space.cart.is_comm_null:return
-
-        starts = self._vector_space.cart.domain_decomposition.starts
-        ends   = self._vector_space.cart.domain_decomposition.ends
-
-        # Compute extended 1D quadrature grids (local to process) along each direction
-        self._quad_grids = tuple({q: FemAssemblyGrid(V, s, e, nderiv=V.degree, nquads=q)}
-                                  for V, s, e, q in zip( self.spaces, starts, ends, self._nquads))
-
-        # Determine portion of logical domain local to process
-        self._element_starts = starts
-        self._element_ends   = ends
+        # Determine portion of logical domain local to process.
+        # This corresponds to the indices of the first and last elements
+        # owned by the current process, along each direction.
+        self._element_starts = self._vector_space.cart.domain_decomposition.starts
+        self._element_ends   = self._vector_space.cart.domain_decomposition.ends
 
         # Compute limits of eta_0, eta_1, eta_2, etc... in subdomain local to process
-        self._eta_limits = tuple( (space.breaks[s], space.breaks[e+1])
-           for s,e,space in zip( self._element_starts, self._element_ends, self.spaces ) )
+        self._eta_limits = tuple((space.breaks[s], space.breaks[e+1])
+           for s, e, space in zip(self._element_starts, self._element_ends, self._spaces))
 
-        # Store flag: object NOT YET prepared for interpolation
-        self._interpolation_ready = False
-        # Compute the local domains for every process
-
-        # ...
+        # Local domains for every process
         self._global_element_starts = domain_decomposition.global_element_starts
         self._global_element_ends   = domain_decomposition.global_element_ends
 
+        # Extended 1D quadrature grids (local to process) along each direction
+        self._quad_grids = {}
+
+        # Flag: object NOT YET prepared for interpolation
+        self._interpolation_ready = False
+
+        # Store information about nested grids
         self.set_refined_space(self.ncells, self)
+
+        # END NEW -------------------------------------------------------
+
+#        self._domain_decomposition = domain_decomposition
+#        self._spaces = tuple(spaces)
+#        self._dtype  = dtype
+#
+#        if cart is not None:
+#            self._vector_space = StencilVectorSpace(cart, dtype=dtype)
+#        elif vector_space is not None:
+#            self._vector_space = vector_space
+#        else:
+#            cart               = create_cart([domain_decomposition], [self._spaces])
+#            self._vector_space = StencilVectorSpace(cart[0], dtype=dtype)
+#
+#        # Shortcut
+#        v = self._vector_space
+#
+#        self._symbolic_space = None
+#        self._refined_space  = {}
+#        self._interfaces     = {}
+#        self._interfaces_readonly = MappingProxyType(self._interfaces)
+#
+#        if self._vector_space.parallel and self._vector_space.cart.is_comm_null:
+#            return
+#
+#        starts = self._vector_space.cart.domain_decomposition.starts
+#        ends   = self._vector_space.cart.domain_decomposition.ends
+#
+#        # Extended 1D quadrature grids (local to process) along each direction
+#        self._quad_grids = {}
+#
+#        # Determine portion of logical domain local to process
+#        self._element_starts = starts
+#        self._element_ends   = ends
+#
+#        # Compute limits of eta_0, eta_1, eta_2, etc... in subdomain local to process
+#        self._eta_limits = tuple( (space.breaks[s], space.breaks[e+1])
+#           for s,e,space in zip( self._element_starts, self._element_ends, self.spaces ) )
+#
+#        # Store flag: object NOT YET prepared for interpolation
+#        self._interpolation_ready = False
+#        # Compute the local domains for every process
+#
+#        # ...
+#        self._global_element_starts = domain_decomposition.global_element_starts
+#        self._global_element_ends   = domain_decomposition.global_element_ends
+#
+#        self.set_refined_space(self.ncells, self)
 
     #--------------------------------------------------------------------------
     # Abstract interface: read-only attributes
@@ -645,12 +691,13 @@ class TensorFemSpace( FemSpace ):
         return grad
 
     # ...
-    def integral(self, f):
+    def integral(self, f, *, nquads):
 
         assert hasattr(f, '__call__')
+        assert hasattr(nquads, '__iter__')
 
         # Extract and store quadrature data
-        quad_grids = self.quad_grids()
+        quad_grids = self.get_quadrature_grids(*nquads)
         nq      = [g.num_quad_pts for g in quad_grids]
         points  = [g.points       for g in quad_grids]
         weights = [g.weights      for g in quad_grids]
@@ -673,7 +720,7 @@ class TensorFemSpace( FemSpace ):
             x = [ points_i[k_i, :] for  points_i, k_i in zip( points, k)]
             w = [weights_i[k_i, :] for weights_i, k_i in zip(weights, k)]
 
-            for q in np.ndindex( *nq ):
+            for q in np.ndindex(*nq):
 
                 y  = [x_i[q_i] for x_i, q_i in zip(x, q)]
                 v  = [w_i[q_i] for w_i, q_i in zip(w, q)]
@@ -735,33 +782,38 @@ class TensorFemSpace( FemSpace ):
     def spaces(self):
         return self._spaces
     
-    @property
-    def nquads(self):
-        return self._nquads
-
-    #@property
-    def quad_grids(self, *nquads):
-        """
-        Tuple of 'FemAssemblyGrid' objects (one for each direction)
-        containing all 1D information local to process that is necessary
-        for the correct assembly of the l.h.s. matrix and r.h.s. vector
-        in a finite element method.
-
-        """
-        # TODO: Turn comments into docstring & add check for the case all(nquads == tuple(self._nquads))
-        if len(nquads) == 0:
-            # If *nquads is not provided, use self._nquads to convert the tuple of dictionaries self._quad_grids into a tuple of the right args
-            quad_grids = tuple(dic[nq] for dic, nq in zip(self._quad_grids, self._nquads))
-        else:
-            # If *nquads is provided, use get_quadrature_grids to compute the appropriate quadrature grids
-            quad_grids = self.get_quadrature_grids(*nquads)
-        return quad_grids
-
-    # TODO [YG 02.06.2023]: Replace nquads and quad_grids properties with this method:
     def get_quadrature_grids(self, *nquads):
+        """
+        Return a tuple of `FemAssemblyGrid` objects (one for each direction).
+
+        These objects are local to the process, and contain all 1D information
+        which is necessary for the correct assembly of the l.h.s. matrix and
+        r.h.s. vector in a finite element method. This information includes
+        the coordinates and weights of all quadrature points, as well as the
+        values of the non-zero basis functions, and their derivatives, at such
+        points.     
+
+        The computed `FemAssemblyGrid` objects are stored in a dictionary in
+        `self` with `nquads` as key, and are reused if a match is found.
+
+        Parameters
+        ----------
+        *nquads : int
+            Number of quadrature points per cell, along each direction.
+
+        Returns
+        -------
+        tuple of FemAssemblyGrid
+            The 1D assembly grids along each direction.
+
+        """
+
         assert len(nquads) == self.ndims
         assert all(isinstance(nq, int) for nq in nquads)
-        quad_grids = [None]*len(nquads)
+        assert all(nq >= 1 for nq in nquads)
+
+        quad_grids = [None] * len(nquads)
+
         for i, nq in enumerate(nquads):
             # Get a reference to the local dictionary of FemAssemblyGrid along direction i
             quad_grids_dict_i = self._quad_grids[i]
@@ -774,6 +826,7 @@ class TensorFemSpace( FemSpace ):
                 quad_grids_dict_i[nq] = FemAssemblyGrid(V, s, e, nderiv=V.degree, nquads=nq)
             # Store the required FemAssemblyGrid in the list
             quad_grids[i] = quad_grids_dict_i[nq]
+
         # Return a tuple with the FemAssemblyGrid objects
         return tuple(quad_grids)
 
@@ -926,8 +979,7 @@ class TensorFemSpace( FemSpace ):
                 global_starts[axis][0] = 0
 
         cart = v._cart.reduce_grid(tuple(global_starts), tuple(global_ends))
-
-        V    = TensorFemSpace(cart.domain_decomposition, *spaces, cart=cart, nquads=self._nquads, dtype=v.dtype)
+        V    = TensorFemSpace(cart.domain_decomposition, *spaces, cart=cart, dtype=v.dtype)
 
         return V
 
@@ -1052,8 +1104,7 @@ class TensorFemSpace( FemSpace ):
 
         # create new TensorFemSpace
 
-        tensor_vec = TensorFemSpace(self._domain_decomposition, *spaces, cart=red_cart, nquads=self._nquads, dtype=v.dtype)
-
+        tensor_vec = TensorFemSpace(self._domain_decomposition, *spaces, cart=red_cart, dtype=v.dtype)
         tensor_vec._interpolation_ready = False
 
         for key in self._refined_space:
@@ -1095,7 +1146,7 @@ class TensorFemSpace( FemSpace ):
             new_global_ends  [-1] = np.array(new_global_ends  [-1])
 
         new_domain = domain.refine(ncells, new_global_starts, new_global_ends)
-        new_space  = TensorFemSpace(new_domain, *spaces, nquads=self.nquads, dtype=self._vector_space.dtype)
+        new_space  = TensorFemSpace(new_domain, *spaces, dtype=self._vector_space.dtype)
 
         self.set_refined_space(ncells, new_space)
 
@@ -1132,7 +1183,7 @@ class TensorFemSpace( FemSpace ):
 
         space = TensorFemSpace(self._domain_decomposition, *spaces,
                                vector_space=vector_space.interfaces[axis, ext],
-                               nquads=self.nquads, dtype=vector_space.dtype)
+                               dtype=vector_space.dtype)
 
         self._interfaces[axis, ext] = space
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -833,8 +833,8 @@ class TensorFemSpace(FemSpace):
             # create a new FemAssemblyGrid and store it in the local dictionary.
             if nq not in quad_grids_dict_i:
                 V = self.spaces[i]
-                s = int(self.vector_space.starts[i])
-                e = int(self.vector_space.ends  [i])
+                s = int(self._element_starts[i])
+                e = int(self._element_ends  [i])
                 quad_grids_dict_i[nq] = FemAssemblyGrid(V, s, e, nderiv=V.degree, nquads=nq)
             # Store the required FemAssemblyGrid in the list
             quad_grids[i] = quad_grids_dict_i[nq]

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -694,10 +694,19 @@ class TensorFemSpace(FemSpace):
         return grad
 
     # ...
-    def integral(self, f, *, nquads):
+    def integral(self, f, *, nquads=None):
 
         assert hasattr(f, '__call__')
-        assert hasattr(nquads, '__iter__')
+
+        if nquads is None:
+            nquads = [p + 1 for p in self.degree]
+        elif isinstance(nquads, int):
+            nquads = [nquads] * self.ldim
+        else:
+            nquads = list(nquads)
+
+        assert all(isinstance(nq, int) for nq in nquads)
+        assert all(nq >= 1 for nq in nquads)
 
         # Extract and store quadrature data
         quad_grids = self.get_quadrature_grids(*nquads)

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -92,8 +92,8 @@ class TensorFemSpace(FemSpace):
             assert isinstance(vector_space, StencilVectorSpace)
             cart = vector_space.cart
         else:
-            cart = create_cart([domain_decomposition], [spaces])
-            vector_space = StencilVectorSpace(cart[0], dtype=dtype)
+            cart = create_cart([domain_decomposition], [spaces])[0]
+            vector_space = StencilVectorSpace(cart, dtype=dtype)
 
         # Store some info
         self._domain_decomposition = domain_decomposition

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -1180,7 +1180,6 @@ class TensorFemSpace(FemSpace):
 
         spaces       = self.spaces
         vector_space = self.vector_space
-        nquads       = self.nquads
 
         vector_space.set_interface(axis, ext, cart)
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -79,6 +79,8 @@ class TensorFemSpace(FemSpace):
 
         assert isinstance(domain_decomposition, DomainDecomposition)
         assert all(isinstance(s, SplineSpace) for s in spaces)
+        assert dtype in (float, complex)
+        # TODO [YG 10.04.2024]: check if dtype test is too restrictive
 
         # BEGIN NEW -------------------------------------------------------
 
@@ -98,6 +100,7 @@ class TensorFemSpace(FemSpace):
         # Store some info
         self._domain_decomposition = domain_decomposition
         self._spaces               = spaces
+        self._dtype                = dtype
         self._vector_space         = vector_space
         self._symbolic_space       = None
         self._refined_space        = {}

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -21,7 +21,7 @@ from psydac.fem.basic        import FemSpace, FemField
 from psydac.fem.splines      import SplineSpace
 from psydac.fem.grid         import FemAssemblyGrid
 from psydac.fem.partitioning import create_cart, partition_coefficients
-from psydac.ddm.cart         import DomainDecomposition
+from psydac.ddm.cart         import DomainDecomposition, CartDecomposition
 
 from psydac.core.bsplines  import (find_span,
                                    basis_funs,

--- a/psydac/utilities/quadratures.py
+++ b/psydac/utilities/quadratures.py
@@ -88,7 +88,6 @@ def gauss_lobatto(k):
     return xg, w[i]
 
 
-
 def quadrature(a, k, method="legendre"):
     """
     this routine generates a quad pts on the grid linspace(a,b,N)

--- a/psydac/utilities/quadratures.py
+++ b/psydac/utilities/quadratures.py
@@ -9,45 +9,70 @@ with weights equal to 1
 
 import numpy as np
 
+from math import cos, pi
+from numpy import zeros
+
+
 __all__ = ('gauss_legendre', 'gauss_lobatto', 'quadrature')
 
-# ....
-def gauss_legendre(ordergl,tol=10e-14):
-    """
-    Returns nodal abscissas {x} and weights {A} of
-    Gauss-Legendre m-point quadrature.
-    """
-    assert ordergl is not None
-    
-    m = ordergl + 1
-    from math import cos,pi
-    from numpy import zeros
 
-    def legendre(t,m):
-        p0 = 1.0; p1 = t
-        for k in range(1,m):
-            p = ((2.0*k + 1.0)*t*p1 - k*p0)/(1.0 + k )
-            p0 = p1; p1 = p
+def gauss_legendre(m, tol=1e-13):
+    """
+    Compute Gauss-Legendre quadrature points and weights on [-1, 1].
+
+    Returns nodal abscissas {x} and weights {A} of a Gauss-Legendre m-point
+    quadrature over the canonical interval [-1, 1].
+
+    Parameters
+    ----------
+    m : int
+        Number of quadrature points in the quadrature rule.
+
+    tol : float
+        Tolerance for the Newton-Raphson root-searching method.
+
+    Returns
+    -------
+    x : numpy.ndarray[float]
+        Abscissas of the quadrature points, in ascending order.
+
+    A : numpy.ndarray[float]
+        Weights of the quadrature points corresponding to the abscissas above.
+
+    """
+    assert isinstance(m, int)
+    assert isinstance(tol, float)
+    assert m >= 1
+    assert tol >= 0
+
+    def legendre(t, m):
+        p0 = 1.0
+        p1 = t
+        for k in range(1, m):
+            p = ((2.0*k + 1.0)*t*p1 - k*p0)/(1.0 + k)
+            p0 = p1
+            p1 = p
         dp = m*(p0 - t*p1)/(1.0 - t**2)
-        return p1,dp
+        return p1, dp
 
     A = zeros(m)
     x = zeros(m)
-    nRoots = (m + 1)// 2          # Number of non-neg. roots
+    nRoots = (m + 1) // 2          # Number of non-neg. roots
     for i in range(nRoots):
         t = cos(pi*(i + 0.75)/(m + 0.5))  # Approx. root
         for j in range(30):
-            p,dp = legendre(t,m)          # Newton-Raphson
-            dt = -p/dp; t = t + dt        # method
+            p, dp = legendre(t, m)        # Newton-Raphson
+            dt = -p/dp                    # method
+            t = t + dt
             if abs(dt) < tol:
-                x[i] = t; x[m-i-1] = -t
-                A[i] = 2.0/(1.0 - t**2)/(dp**2) # Eq.(6.25)
+                x[i]     = -t
+                x[m-i-1] =  t
+                A[i]     = 2.0/(1.0 - t**2)/(dp**2) # Eq.(6.25)
                 A[m-i-1] = A[i]
                 break
-    return x,A
-# ...
+    return x, A
 
-# ...
+
 def gauss_lobatto(k):
     """
     Returns nodal abscissas {x} and weights {A} of
@@ -61,9 +86,9 @@ def gauss_lobatto(k):
     w = 2 * (V[0, :]) ** 2; # weights
 
     return xg, w[i]
-# ....
 
-# ....
+
+
 def quadrature(a, k, method="legendre"):
     """
     this routine generates a quad pts on the grid linspace(a,b,N)
@@ -87,4 +112,3 @@ def quadrature(a, k, method="legendre"):
         wgl[i, :] = 0.5 * ( xmax - xmin ) * w
 
     return xgl,wgl
-# ....

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'pyevtk',
 
     # Our packages from PyPi
-    'sympde == 0.18.1',
+    'sympde == 0.18.3',
     'pyccel >= 1.11.2',
     'gelato == 0.12',
 


### PR DESCRIPTION
Allow the user to choose the number of quadrature points by passing the keyword-only argument `nquads`:
- When calling `discretize` on integral expressions (`BilinearForm`, `LinearForm`, `Functional`);
- When creating a `GlobalProjector` object which requires histopolation;
- When calling the method `integral` of `TensorFemSpace`.

`nquads` should be a list of integers where each entry represents the number of quadrature points (per element) along a different direction. (A Gauss-Legendre quadrature rule is used on each element of the discrete logical domain.)

In the case of a multipatch domain, the same values in `nquads` are used for all the patches. If the user passes a single integer instead of a list, the same number of quadrature points is used in all directions. If the user does not pass `nquads` at all, a default value is computed along each direction `i` by checking the highest spline degree `max_degree[i]` and then setting `nquads[i] = max_degree[i] + 1`.

`nquads` can no longer be passed to a call to `discretize` on a `FemSpace`. Accordingly, the property `nquads` and the method `quad_grids` have been removed from the class `TensorFemSpace`. Instead, the property `nquads` has been added to the classes `DiscreteBilinearForm`, `DiscreteLinearForm`, and `DiscreteFunctional`.

By attaching `nquads` to the discrete forms rather than the discrete spaces, we allow for more flexibility in the discretization step. Internally this is achieved by storing multiple 1D `FemAssemblyGrid` objects in a single `TensorFemSpace` object. These grids are computed on demand based on the required values of `nquads`, and stored in the object so they can be reused later.

Additional changes:

- In class`TensorFemSpace` remove method `quad_grids` and rename method `get_quadrature_grids` as `get_assembly_grids`;
- When the default values do not suffice, pass the correct `nquads` in the various unit tests in order to obtain exactly the same results as before;
- Make the function `gauss_legendre` in `psydac.utilities.quadratures` accept the number of quadrature points `m` explicitly, rather than the obscure `ordergl`. Further, fix order of abscissas (previously reversed);
- Fix command to obtain `HDF5_DIR` on macOS;
- Use SymPDE version 0.18.3 (this gives control over the linearity checks on linear and bilinear forms).

Fixes #332.