### PR TITLE
Improve function `array_to_psydac`

### DIFF
--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -1167,7 +1167,7 @@ def test_block_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2,
     for i1 in range(V.starts[0], V.ends[0]+1):
         for i2 in range(V.starts[1], V.ends[1]+1):
             x[0][i1, i2] = f(i1, i2)
-            x[1][i1, i2] = f(i1, i2)
+            x[1][i1, i2] = -13*f(i1, i2)
             x2[0] = x
             x2[1] = 2*x
             x2[2][i1, i2] = 7*f(i1, i2)
@@ -1187,6 +1187,15 @@ def test_block_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2,
     assert isinstance(w2, BlockVector)
     assert w2.space is W2
     assert np.array_equal(x2a, w2.toarray())
+
+    # Check also ghost regions:
+    for i in range(2):
+        assert np.array_equal(x[i]._data, w[i]._data)
+        for j in range(2):
+            assert np.array_equal(x2[i][j]._data, w2[i][j]._data)
+            assert np.array_equal(x2[i][j]._data, w2[i][j]._data)
+
+    assert np.array_equal(x2[2]._data, w2[2]._data)
 
 #===============================================================================    
 @pytest.mark.parametrize( 'dtype', [float, complex] )

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -1125,6 +1125,69 @@ def test_block_linear_operator_parallel_dot( dtype, n1, n2, p1, p2, P1, P2 ):
     assert np.allclose( Z.blocks[0].toarray(), y1.toarray(), rtol=1e-14, atol=1e-14 )
     assert np.allclose( Z.blocks[1].toarray(), y2.toarray(), rtol=1e-14, atol=1e-14 )
 
+
+# ===============================================================================
+@pytest.mark.parametrize('dtype', [float, complex])
+@pytest.mark.parametrize('n1', [10, 17])
+@pytest.mark.parametrize('n2', [13, 7])
+@pytest.mark.parametrize('p1', [1, 2])
+@pytest.mark.parametrize('p2', [1])
+@pytest.mark.parametrize('s1', [1, 2])
+@pytest.mark.parametrize('s2', [1])
+@pytest.mark.parametrize('P1', [True, False])
+@pytest.mark.parametrize('P2', [True])
+@pytest.mark.parallel
+
+def test_block_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
+    npts = [n1, n2]   
+
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+
+    # Create domain decomposition
+    D = DomainDecomposition(npts, periods=[P1, P2], comm=comm)
+
+    # Partition the points
+    global_starts, global_ends = compute_global_starts_ends(D, npts)
+    C = CartDecomposition(D, npts, global_starts, global_ends, pads=[p1, p2], shifts=[s1, s2])
+
+    # Create Vector spaces and Vectors
+    V = StencilVectorSpace(C, dtype=dtype)
+    W = BlockVectorSpace(V, V)
+    W2 = BlockVectorSpace(W, W, V)
+    x = W.zeros()
+    x2 = W2.zeros()
+
+    # Fill the vector with data
+
+    if dtype == complex:
+        f = lambda i1, i2: 10j * i1 + i2
+    else:
+        f = lambda i1, i2: 10 * i1 + i2
+    for i1 in range(V.starts[0], V.ends[0]+1):
+        for i2 in range(V.starts[1], V.ends[1]+1):
+            x[0][i1, i2] = f(i1, i2)
+            x[1][i1, i2] = f(i1, i2)
+            x2[0] = x
+            x2[1] = 2*x
+            x2[2][i1, i2] = 7*f(i1, i2)
+
+    # Convert Vectors to arrays
+    xa = x.toarray()
+    x2a = x2.toarray()
+
+    # Convert arrays to Vectors of W, W2
+    w = array_to_psydac(xa, W)
+    w2 = array_to_psydac(x2a, W2)
+
+    # Test properties and data contained
+    assert isinstance(w, BlockVector)
+    assert w.space is W
+    assert np.array_equal(xa, w.toarray())
+    assert isinstance(w2, BlockVector)
+    assert w2.space is W2
+    assert np.array_equal(x2a, w2.toarray())
+
 #===============================================================================    
 @pytest.mark.parametrize( 'dtype', [float, complex] )
 @pytest.mark.parametrize( 'n1', [8, 16] )

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -1178,12 +1178,12 @@ def test_block_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2,
     xa = x.toarray()
     x2a = x2.toarray()
 
-    # Apply left inverse:
+    # Apply array_to_psydac as left inverse of toarray
     w = array_to_psydac(xa, W)
     w2 = array_to_psydac(x2a, W2)
 
 
-    # Apply right inverse:
+    # Apply array_to_psydac first, and toarray next
     xa_r_inv = np.array(np.random.rand(xa.size), dtype=dtype)*xa # the vector must be distributed as xa
     x_r_inv = array_to_psydac(xa_r_inv, W)
     x_r_inv.update_ghost_regions()

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -783,6 +783,8 @@ def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s
         for i2 in range(V.starts[1], V.ends[1]+1):
             x[i1, i2] = f(i1, i2)
 
+    x.update_ghost_regions()
+
     # Convert vector to array
     xa = x.toarray()
 
@@ -792,7 +794,10 @@ def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s
     # Test properties of v and data contained
     assert isinstance(v, StencilVector)
     assert v.space is V
+    # Check that array_to_psydac is the inverse of toarray
     assert np.array_equal(xa, v.toarray())
+    # Check that the ghost regions are properly updated
+    assert np.array_equal(x._data, v._data)
 
 # TODO: test that ghost regions have been properly copied to 'xe' array
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -774,7 +774,6 @@ def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s
     x = StencilVector(V)
 
     # Fill the vector with data
-
     if dtype == complex:
         f = lambda i1, i2: 10j * i1 + i2
     else:
@@ -788,16 +787,22 @@ def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s
     # Convert vector to array
     xa = x.toarray()
 
-    # Convert array to vector of V
-    v = array_to_psydac(xa, V)
+    # Apply left inverse:
+    v_l_inv = array_to_psydac(xa, V)
 
-    # Test properties of v and data contained
-    assert isinstance(v, StencilVector)
-    assert v.space is V
-    # Check that array_to_psydac is the inverse of toarray
-    assert np.array_equal(xa, v.toarray())
-    # Check that the ghost regions are properly updated
-    assert np.array_equal(x._data, v._data)
+    # Apply right inverse
+    xa_r_inv = np.array(np.random.rand(xa.size), dtype=dtype)*xa # the vector must be distributed as xa
+    x_r_inv = array_to_psydac(xa_r_inv, V)
+    x_r_inv.update_ghost_regions()
+    va_r_inv = x_r_inv.toarray()
+
+    ## Check that array_to_psydac is the inverse of .toarray():
+    # left inverse:
+    assert isinstance(v_l_inv, StencilVector)
+    assert v_l_inv.space is V    
+    assert np.array_equal(x._data, v_l_inv._data)
+    # right inverse:
+    assert np.array_equal(xa_r_inv, va_r_inv)
 
 # TODO: test that ghost regions have been properly copied to 'xe' array
 # ===============================================================================

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -787,10 +787,10 @@ def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s
     # Convert vector to array
     xa = x.toarray()
 
-    # Apply left inverse:
+    # Apply array_to_psydac as left inverse of toarray
     v_l_inv = array_to_psydac(xa, V)
 
-    # Apply right inverse
+    # Apply array_to_psydac first, and toarray next
     xa_r_inv = np.array(np.random.rand(xa.size), dtype=dtype)*xa # the vector must be distributed as xa
     x_r_inv = array_to_psydac(xa_r_inv, V)
     x_r_inv.update_ghost_regions()

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -745,6 +745,55 @@ def test_stencil_vector_2d_parallel_toarray(dtype, n1, n2, p1, p2, s1, s2, P1=Tr
     # assert xe.shape == (n1, n2)
     # assert np.array_equal(xe, z1)
 
+# ===============================================================================
+@pytest.mark.parametrize('dtype', [float, complex])
+@pytest.mark.parametrize('n1', [10, 17])
+@pytest.mark.parametrize('n2', [13, 7])
+@pytest.mark.parametrize('p1', [1, 2])
+@pytest.mark.parametrize('p2', [1])
+@pytest.mark.parametrize('s1', [1, 2])
+@pytest.mark.parametrize('s2', [1])
+@pytest.mark.parametrize('P1', [True, False])
+@pytest.mark.parametrize('P2', [True])
+@pytest.mark.parallel
+def test_stencil_vector_2d_parallel_array_to_psydac(dtype, n1, n2, p1, p2, s1, s2, P1, P2):
+    npts = [n1, n2]   
+
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+
+    # Create domain decomposition
+    D = DomainDecomposition(npts, periods=[P1, P2], comm=comm)
+
+    # Partition the points
+    global_starts, global_ends = compute_global_starts_ends(D, npts)
+    C = CartDecomposition(D, npts, global_starts, global_ends, pads=[p1, p2], shifts=[s1, s2])
+
+    # Create vector space and stencil vector
+    V = StencilVectorSpace(C, dtype=dtype)
+    x = StencilVector(V)
+
+    # Fill the vector with data
+
+    if dtype == complex:
+        f = lambda i1, i2: 10j * i1 + i2
+    else:
+        f = lambda i1, i2: 10 * i1 + i2
+    for i1 in range(V.starts[0], V.ends[0]+1):
+        for i2 in range(V.starts[1], V.ends[1]+1):
+            x[i1, i2] = f(i1, i2)
+
+    # Convert vector to array
+    xa = x.toarray()
+
+    # Convert array to vector of V
+    v = array_to_psydac(xa, V)
+
+    # Test properties of v and data contained
+    assert isinstance(v, StencilVector)
+    assert v.space is V
+    assert np.array_equal(xa, v.toarray())
+
 # TODO: test that ghost regions have been properly copied to 'xe' array
 # ===============================================================================
 @pytest.mark.parametrize('dtype', [float, complex])

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -3,6 +3,7 @@
 import numpy as np
 from math import sqrt
 
+from psydac.linalg.basic   import Vector
 from psydac.linalg.stencil import StencilVectorSpace, StencilVector
 from psydac.linalg.block   import BlockVector, BlockVectorSpace
 
@@ -13,46 +14,62 @@ __all__ = (
 )
 
 #==============================================================================
-def array_to_psydac(x, Xh):
-    """ converts a numpy array to StencilVector or BlockVector format"""
+def array_to_psydac(x, V):
+    """ 
+    Convert a NumPy array to a Vector of the space V. 
+    This function works in parallel but it is very costly and should be avoided if performance is a priority.
 
-    if isinstance(Xh, BlockVectorSpace):
-        u = BlockVector(Xh)
-        if isinstance(Xh.spaces[0], BlockVectorSpace):
-            for d in range(len(Xh.spaces)):
-                starts = [np.array(V.starts) for V in Xh.spaces[d].spaces]
-                ends   = [np.array(V.ends)   for V in Xh.spaces[d].spaces]
+    Parameters
+    ----------
+    x : numpy.ndarray
+        Array to be converted. It only contains the true data, the ghost regions must not be included.
 
-                for i in range(len(starts)):
-                    g = tuple(slice(s,e+1) for s,e in zip(starts[i], ends[i]))
-                    shape = tuple(ends[i]-starts[i]+1)
-                    u[d][i][g] = x[:np.prod(shape) ].reshape(shape)
-                    x          = x[ np.prod(shape):]
+    V : psydac.linalg.stencil.StencilVectorSpace or psydac.linalg.block.BlockVectorSpace
+        Space where the final Psydac Vector belongs to.
 
-        else:
-            starts = [np.array(V.starts) for V in Xh.spaces]
-            ends   = [np.array(V.ends)   for V in Xh.spaces]
+    Returns
+    -------
+    u : psydac.linalg.stencil.StencilVector or psydac.linalg.block.BlockVector
+        Element of space V, the coefficients of which (excluding ghost regions) are the entries of x.
 
-            for i in range(len(starts)):
-                g = tuple(slice(s,e+1) for s,e in zip(starts[i], ends[i]))
-                shape = tuple(ends[i]-starts[i]+1)
-                u[i][g] = x[:np.prod(shape) ].reshape(shape)
-                x       = x[ np.prod(shape):]
+    """
 
-    elif isinstance(Xh, StencilVectorSpace):
+    assert x.ndim == 1, 'Array must be 1D.'
+    assert x.dtype == V.dtype, 'Array must be the same data type as the space.'
+    assert x.size == V.dimension, 'Array must have the same global size as the space.'
 
-        u =  StencilVector(Xh)
-        starts = np.array(Xh.starts)
-        ends   = np.array(Xh.ends)
-        g = tuple(slice(s, e+1) for s,e in zip(starts, ends))
-        shape = tuple(ends-starts+1)
-        u[g] = x[:np.prod(shape)].reshape(shape)
-    else:
-        raise ValueError('Xh must be a StencilVectorSpace or a BlockVectorSpace')
-
+    u = V.zeros()
+    _array_to_psydac_recursive(x, u)
     u.update_ghost_regions()
+
     return u
 
+
+def _array_to_psydac_recursive(x, u):
+    """
+    Recursive function filling in the coefficients of each block of u.
+    """
+    assert isinstance(u, Vector)
+    V = u.space
+
+    assert x.ndim == 1, 'Array must be 1D.'
+    assert x.dtype == V.dtype, 'Array must be the same data type as the space.'
+    assert x.size == V.dimension, 'Array must have the same global size as the space.'    
+
+    if isinstance(V, BlockVectorSpace):
+        for i, V_i in enumerate(V.spaces):
+            x_i = x[:V_i.dimension]
+            x   = x[V_i.dimension:]
+            u_i = u[i]
+            _array_to_psydac_recursive(x_i, u_i)
+
+    elif isinstance(V, StencilVectorSpace):
+        index_global = tuple(slice(s, e+1) for s, e in zip(V.starts, V.ends))
+        u[index_global] = x.reshape(V.npts)[index_global]
+
+    else:
+        raise NotImplementedError(f'Can only handle StencilVector or BlockVector spaces, got {type(V)} instead')
+    
 #==============================================================================
 def petsc_to_psydac(x, Xh):
     """Convert a PETSc.Vec object to a StencilVector or BlockVector. It assumes that PETSc was installed with the configuration for complex numbers.

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -35,7 +35,8 @@ def array_to_psydac(x, V):
     """
 
     assert x.ndim == 1, 'Array must be 1D.'
-    assert x.dtype == V.dtype, 'Array must be the same data type as the space.'
+    if x.dtype==complex:
+        assert V.dtype==complex, 'Complex array cannot be converted to a real StencilVector'
     assert x.size == V.dimension, 'Array must have the same global size as the space.'
 
     u = V.zeros()
@@ -53,7 +54,8 @@ def _array_to_psydac_recursive(x, u):
     V = u.space
 
     assert x.ndim == 1, 'Array must be 1D.'
-    assert x.dtype == V.dtype, 'Array must be the same data type as the space.'
+    if x.dtype==complex:
+        assert V.dtype==complex, 'Complex array cannot be converted to a real StencilVector'
     assert x.size == V.dimension, 'Array must have the same global size as the space.'    
 
     if isinstance(V, BlockVectorSpace):

--- a/psydac/linalg/utilities.py
+++ b/psydac/linalg/utilities.py
@@ -16,8 +16,8 @@ __all__ = (
 #==============================================================================
 def array_to_psydac(x, V):
     """ 
-    Convert a NumPy array to a Vector of the space V. 
-    This function works in parallel but it is very costly and should be avoided if performance is a priority.
+    Convert a NumPy array to a Vector of the space V. This function is designed to be the inverse of the method .toarray() of the class Vector.
+    Note: This function works in parallel but it is very costly and should be avoided if performance is a priority.
 
     Parameters
     ----------
@@ -25,12 +25,12 @@ def array_to_psydac(x, V):
         Array to be converted. It only contains the true data, the ghost regions must not be included.
 
     V : psydac.linalg.stencil.StencilVectorSpace or psydac.linalg.block.BlockVectorSpace
-        Space where the final Psydac Vector belongs to.
+        Space of the final Psydac Vector.
 
     Returns
     -------
     u : psydac.linalg.stencil.StencilVector or psydac.linalg.block.BlockVector
-        Element of space V, the coefficients of which (excluding ghost regions) are the entries of x.
+        Element of space V, the coefficients of which (excluding ghost regions) are the entries of x. The ghost regions of u are up to date.
 
     """
 


### PR DESCRIPTION
The function `array_to_psydac`:
 - was not working in parallel
 - was not tested in parallel
 - was not general enough
 
 This PR fixes it and rewrites it in a recursive way, so that it also works in more general cases as for example:
- A `BlockVectorSpace` of a `BlockVectorSpace` and a `StencilVectorSpace`
- A `BlockVectorSpace` of a `BlockVectorSpace`  of a `BlockVectorSpace` 