### PR TITLE
Remove deprecated distutils (Python >=3.12)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,8 +50,9 @@ jobs:
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp
-          if [[ ! -f "/usr/local/bin/gfortran" ]]; then
-            ln -s $(which gfortran) /usr/local/bin/gfortran
+          if ! command -v gfortran; then
+            echo "gfortran could not be found"
+            exit 1
           fi
           echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install non-Python dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
+          brew install gcc
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,13 +47,11 @@ jobs:
       - name: Install non-Python dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew install gfortran
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp
           if [[ ! -f "/usr/local/bin/gfortran" ]]; then
-            gfort=$(ls /usr/local/bin/gfortran-* | tail -n 1)
-            ln -s ${gfort} /usr/local/bin/gfortran
+            ln -s $(which gfortran) /usr/local/bin/gfortran
           fi
           echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,13 +47,17 @@ jobs:
       - name: Install non-Python dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew reinstall gcc
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp
-          if ! command -v gfortran; then
-            echo "gfortran could not be found"
-            exit 1
+          GFORTRAN_HOME=$(which gfortran || true)
+          echo "GFORTRAN_HOME : $GFORTRAN_HOME"
+          if [[ ! -f "$GFORTRAN_HOME" ]]; then
+            gfort=$(find ${PATH//:/\/ } -name 'gfortran-*' -exec basename {} \; | sort | tail -n 1 || true)
+            echo "Found $gfort"
+            gfort_path=$(which ${gfort})
+            folder=$(dirname ${gfort_path})
+            ln -s ${gfort_path} ${folder}/gfortran
           fi
           echo "MPI_OPTS=--oversubscribe" >> $GITHUB_ENV
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Install non-Python dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
+          brew install gfortran
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install non-Python dependencies on macOS
         if: matrix.os == 'macos-latest'
         run: |
-          brew install gcc
+          brew reinstall gcc
           brew install open-mpi
           brew install hdf5-mpi
           brew install libomp

--- a/setup.py
+++ b/setup.py
@@ -1,57 +1,35 @@
-import setuptools.command.build_py
-import distutils.command.build_py as orig
-import distutils.log
-import setuptools
-from subprocess import run as sub_run
-import shutil
+import logging
 import os
+import shutil
+from subprocess import run as sub_run
+from setuptools import setup
+from setuptools.command.build_py import build_py
 
 
-class BuildPyCommand(setuptools.command.build_py.build_py):
+class BuildPyCommand(build_py):
     """Custom build command to pyccelise _kernels files in the build directory."""
 
-    # Copy the setuptools.command.build_py.build_py.finalize_options to recreate the __updated_files variable
-    def finalize_options(self):
-        orig.build_py.finalize_options(self)
-        self.package_data = self.distribution.package_data
-        self.exclude_package_data = self.distribution.exclude_package_data or {}
-        if 'data_files' in self.__dict__:
-            del self.__dict__['data_files']
-        self.__updated_files = []
-
-    # Rewrite the build_module function to copy each module in the build repository and pyccelise the modules ending with _kernels
+    # Rewrite the build_module function to copy each module in the build
+    # repository and pyccelise the modules ending with _kernels
     def build_module(self, module, module_file, package):
-        # This part is copied from distutils.command.build_py.build_module
-        if isinstance(package, str):
-            package = package.split('.')
-        elif not isinstance(package, (list, tuple)):
-            raise TypeError(
-                "'package' must be a string (dot-separated), list, or tuple"
-            )
-        outfile = self.get_module_outfile(self.build_lib, package, module)
-        dirname = os.path.dirname(outfile)
-        self.mkpath(dirname)
-        outfile, copied = self.copy_file(module_file, outfile, preserve_mode=0)
+        outfile, copied = super().build_module(module, module_file, package)
 
-
-        # This part check if the module is pyccelisable and pyccelise it in case
+        # This part check if the module is pyccelisable and pyccelise it in
+        # case
         if module.endswith('_kernels'):
-            self.announce(
-                '\nPyccelise module: %s' % str(module),
-                level=distutils.log.INFO)
-            sub_run([shutil.which('pyccel'), outfile, '--language', 'fortran', '--openmp'], shell=False)
-
-        # This part is copy from setuptools.command.build_py.build_module
-        if copied:
-            self.__updated_files.append(outfile)
+            self.announce(f"\nPyccelise module: {module}", level=logging.INFO)
+            sub_run([shutil.which('pyccel'), outfile,
+                     '--language', 'fortran',
+                     '--openmp'],
+                    shell=False, check=True)
 
         return outfile, copied
 
     def run(self):
-        setuptools.command.build_py.build_py.run(self)
+        super().run()
 
         # Remove __pyccel__ directories
-        sub_run(['pyccel-clean', self.build_lib], shell=False)
+        sub_run(['pyccel-clean', self.build_lib], shell=False, check=True)
 
         # Remove useless .lock files
         for path, subdirs, files in os.walk(self.build_lib):
@@ -60,7 +38,7 @@ class BuildPyCommand(setuptools.command.build_py.build_py):
                     os.remove(os.path.join(path, name))
 
 
-setuptools.setup(
+setup(
     cmdclass={
         'build_py': BuildPyCommand,
     },

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from shutil import which
-from subprocess import PIPE, STDOUT
+from subprocess import PIPE, STDOUT  # nosec B404
 from subprocess import run as sub_run
 from setuptools import setup
 from setuptools.command.build_py import build_py

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ class BuildPyCommand(build_py):
             sub_run([shutil.which('pyccel'), outfile,
                      '--language', 'fortran',
                      '--openmp'],
-                    shell=False, check=True)
+                    shell=False, check=True) # nosec B603
 
         return outfile, copied
 
@@ -29,7 +29,7 @@ class BuildPyCommand(build_py):
         super().run()
 
         # Remove __pyccel__ directories
-        sub_run(['pyccel-clean', self.build_lib], shell=False, check=True)
+        sub_run(['pyccel-clean', self.build_lib], shell=False, check=True) # nosec B603, B607
 
         # Remove useless .lock files
         for path, subdirs, files in os.walk(self.build_lib):


### PR DESCRIPTION
Solves first TODO item in #406.  Summary of changes:

* Removed `finalize_options()` since this method does not differ from its [base class implementation](https://github.com/pypa/setuptools/blob/b3fc00fe1b242714029f46f03cafaaf324ae380d/setuptools/command/build_py.py#L38-L44), therefore making the override unnecessary.
* For `run()`, it's sufficient to call the [base class `run()`](https://github.com/pypa/setuptools/blob/b3fc00fe1b242714029f46f03cafaaf324ae380d/setuptools/command/build_py.py#L57) and then add the custom `pyccel` commands.
* `sub_run()` should throw an error instead of failing silently (`check=True`).
* Formatted code to conform with `Pylint` and `PEP8` checks