### PR TITLE
Avoid installing h5py from cache

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [ 3.9, '3.10', '3.11', '3.12' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
-        exclude:
-          - { isMerge: false, python-version: '3.10' }
-          - { isMerge: false, python-version: '3.11' }
+        #exclude:
+        #  - { isMerge: false, python-version: '3.10' }
+        #  - { isMerge: false, python-version: '3.11' }
         include:
           - os: macos-latest
             python-version: '3.10'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,7 +142,7 @@ jobs:
           export CC="mpicc"
           export HDF5_MPI="ON"
           python -m pip install -r requirements.txt
-          python -m pip install -r requirements_extra.txt --no-build-isolation
+          python -m pip install -r requirements_extra.txt --no-build-isolation --no-cache-dir
           python -m pip list
 
       - name: Check parallel h5py installation

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,9 +19,9 @@ jobs:
         python-version: [ 3.9, '3.10', '3.11', '3.12' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
-        #exclude:
-        #  - { isMerge: false, python-version: '3.10' }
-        #  - { isMerge: false, python-version: '3.11' }
+        exclude:
+          - { isMerge: false, python-version: '3.10' }
+          - { isMerge: false, python-version: '3.11' }
         include:
           - os: macos-14
             python-version: '3.10'

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ export HDF5_MPI="ON"
 
 python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
-python3 -m pip install -r requirements_extra.txt --no-build-isolation
+python3 -m pip install -r requirements_extra.txt --no-build-isolation --no-cache-dir
 ```
 
 At this point the Psydac library may be installed in **standard mode**, which copies the relevant files to the correct locations of the virtual environment, or in **development mode**, which only installs symbolic links to the Psydac directory. The latter mode allows one to effect the behavior of Psydac by modifying the source files.


### PR DESCRIPTION
From @yguclu:

> If people have a cached version of the h5py library which was compiled using NumPy < 2.0 and try to install Psydac in a clean Python environment, they end up with a broken version. This is because the cached version of h5py tries to call C functions from NumPy 2.0 which are not ABI compatible.

Adding [`--no-cache-dir`](https://stackoverflow.com/questions/45594707/what-is-pips-no-cache-dir-good-for) to `pip` guarantees that `h5py` is always [built during installation](https://docs.h5py.org/en/stable/build.html#custom-installation). Re-using a prebuilt `h5py` (*i.e.* cached `h5py`) could become an issue stale when `h5py` dependencies upgrade. 