### PR TITLE
Add sqrt option for diagonal in stencil and block matrices.

### DIFF
--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -777,13 +777,17 @@ class BlockLinearOperator(LinearOperator):
     #--------------------------------------
     # New properties/methods
     #--------------------------------------
-    def diagonal(self, *, inverse = False, out = None):
+    def diagonal(self, *, inverse = False, sqrt = False, out = None):
         """Get the coefficients on the main diagonal as another BlockLinearOperator object.
 
         Parameters
         ----------
         inverse : bool
             If True, get the inverse of the diagonal. (Default: False).
+
+        sqrt : bool
+            If True, get the square root of the diagonal. (Default: False).
+            Can be combined with inverse to get the inverse square root
 
         out : BlockLinearOperator
             If provided, write the diagonal entries into this matrix. (Default: None).
@@ -815,7 +819,7 @@ class BlockLinearOperator(LinearOperator):
         # Store the diagonal (or its inverse) into `out`
         for i, j in self.nonzero_block_indices:
             if i == j:
-                out[i, i] = self[i, i].diagonal(inverse = inverse, out = out[i, i])
+                out[i, i] = self[i, i].diagonal(inverse = inverse, sqrt=sqrt, out = out[i, i])
 
         return out
 

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -1372,7 +1372,7 @@ class StencilMatrix(LinearOperator):
                 self._data[idx_to] += self._data[idx_from]
 
     # ...
-    def diagonal(self, *, inverse = False, out = None):
+    def diagonal(self, *, inverse = False, sqrt = False, out = None):
         """
         Get the coefficients on the main diagonal as a StencilDiagonalMatrix object.
 
@@ -1380,6 +1380,10 @@ class StencilMatrix(LinearOperator):
         ----------
         inverse : bool
             If True, get the inverse of the diagonal. (Default: False).
+
+        sqrt : bool
+            If True, get the square root of the diagonal. (Default: False).
+            Can be combined with inverse to get the inverse square root
 
         out : StencilDiagonalMatrix
             If provided, write the diagonal entries into this matrix. (Default: None).
@@ -1409,6 +1413,9 @@ class StencilMatrix(LinearOperator):
         diagonal_indices = self._get_diagonal_indices()
         diag = self._data[diagonal_indices]
         data = out._data if out else None
+
+        if sqrt:
+            diag = np.sqrt(diag)
 
         # Calculate entries of StencilDiagonalMatrix
         if inverse:


### PR DESCRIPTION
 Corresponds to commit [121215d](https://github.com/pyccel/psydac/commit/121215db3f1ee2076e6560d631bb7bf522c8caae) in stefan-psydac.