### PR TITLE
Circumvent `apt-get` download error

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Set default MPI and HDF5 C compilers on Ubuntu
         if: matrix.os == 'ubuntu-latest'
         run: |
+          sudo apt-get update
           sudo apt-get install --reinstall openmpi-bin libhdf5-openmpi-dev
 
       - name: Install non-Python dependencies on macOS


### PR DESCRIPTION
Update `apt` index files with `apt-get update` to avoid download error in CI workflow.