### PR TITLE
Mention C support in near future in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ python3 <PSYDAC-PATH>/mpi_tester.py --pyargs psydac -m "parallel and petsc"
 
 Many of Psydac's low-level Python functions can be translated to a compiled language using the [Pyccel](https://github.com/pyccel/pyccel) transpiler. Currently, all of those functions are collected in modules which follow the name pattern `[module]_kernels.py`.
 
-The classical installation translates all kernel files to Fortran without user intervention. This does not happen in the case of an editable install, but the command `psydac-accelerate` is made available to the user instead. This command applies Pyccel to all the kernel files in the source directory, and the C language may be selected instead of Fortran (which is the default).
+The classical installation translates all kernel files to Fortran without user intervention. This does not happen in the case of an editable install, but the command `psydac-accelerate` is made available to the user instead. This command applies Pyccel to all the kernel files in the source directory. The default language is currently Fortran, C should also be supported in a near future.
 
 -   **Only in development mode**:
     ```bash


### PR DESCRIPTION
Clarify in the `README.md` file that, although the C backend may be selected for accelerating the kernel files with Pyccel, this is not fully working yet. Hence the Fortran backend (which is the default) is the only one available. A future version of Pyccel will certainly provide a C backend as capable as the Fortran one. See issue #431.