### PR TITLE
Fix Greville point collocation matrix for single grid point case

### DIFF
--- a/psydac/core/bsplines.py
+++ b/psydac/core/bsplines.py
@@ -340,6 +340,9 @@ def collocation_matrix(knots, degree, periodic, normalization, xgrid, out=None, 
     The collocation matrix :math:`C_ij = B_j(x_i)`, contains the
     values of each B-spline basis function :math:`B_j` at all locations :math:`x_i`.
     """
+    if xgrid.size == 1:
+        return np.ones((1, 1), dtype=float)
+
     knots = np.ascontiguousarray(knots, dtype=float)
     xgrid = np.ascontiguousarray(xgrid, dtype=float)
     if out is None:

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -171,14 +171,17 @@ class SplineSpace( FemSpace ):
         Greville points.
 
         """
-        imat = collocation_matrix(
-            knots    = self.knots,
-            degree   = self.degree,
-            periodic = self.periodic,
-            normalization = self.basis,
-            xgrid    = self.greville,
-            multiplicity = self.multiplicity
-        )
+        if self.greville.size == 1:
+            imat = np.ones((1, 1), dtype=float)
+        else:
+            imat = collocation_matrix(
+                knots    = self.knots,
+                degree   = self.degree,
+                periodic = self.periodic,
+                normalization = self.basis,
+                xgrid    = self.greville,
+                multiplicity = self.multiplicity
+            )
 
         if self.periodic:
             # Convert to CSC format and compute sparse LU decomposition

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -171,17 +171,14 @@ class SplineSpace( FemSpace ):
         Greville points.
 
         """
-        if self.greville.size == 1:
-            imat = np.ones((1, 1), dtype=float)
-        else:
-            imat = collocation_matrix(
-                knots    = self.knots,
-                degree   = self.degree,
-                periodic = self.periodic,
-                normalization = self.basis,
-                xgrid    = self.greville,
-                multiplicity = self.multiplicity
-            )
+        imat = collocation_matrix(
+            knots    = self.knots,
+            degree   = self.degree,
+            periodic = self.periodic,
+            normalization = self.basis,
+            xgrid    = self.greville,
+            multiplicity = self.multiplicity
+        )
 
         if self.periodic:
             # Convert to CSC format and compute sparse LU decomposition


### PR DESCRIPTION
Previously, in the case when `self.greville.size == 1`, `collocation_matrix` would return an empty matrix.

Now, if the grid has a single Greville point, the collocation matrix is simplified to a 1x1 matrix with a value of 1.