### PR TITLE
Small fixes for operators with complex

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -546,7 +546,7 @@ class ScaledLinearOperator(LinearOperator):
         assert isinstance(domain, VectorSpace)
         assert isinstance(codomain, VectorSpace)
         assert np.isscalar(c)
-        assert(np.isreal(c) or np.iscomplex(c) == (codomain._dtype == complex))
+        assert np.iscomplexobj(c) == (codomain._dtype == complex)
         assert isinstance(A, LinearOperator)
         assert domain   == A.domain
         assert codomain == A.codomain

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -291,7 +291,6 @@ class LinearOperator(ABC):
 
         """
         assert np.isscalar(c)
-        assert np.isreal(c)
         if c==0:
             return ZeroOperator(self.domain, self.codomain)
         elif c == 1:
@@ -538,7 +537,7 @@ class IdentityOperator(LinearOperator):
 #===============================================================================
 class ScaledLinearOperator(LinearOperator):
     """
-    A linear operator $A$ scalar multiplied by a real constant $c$. 
+    A linear operator $A$ scalar multiplied by a constant $c$. 
     
     """
 
@@ -547,7 +546,7 @@ class ScaledLinearOperator(LinearOperator):
         assert isinstance(domain, VectorSpace)
         assert isinstance(codomain, VectorSpace)
         assert np.isscalar(c)
-        assert np.isreal(c)
+        assert(np.isreal(c) or np.iscomplex(c) == (codomain._dtype == complex))
         assert isinstance(A, LinearOperator)
         assert domain   == A.domain
         assert codomain == A.codomain
@@ -594,7 +593,7 @@ class ScaledLinearOperator(LinearOperator):
         return self._scalar*csr_matrix(self._operator.toarray())
 
     def transpose(self, conjugate=False):
-        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=self._scalar, A=self._operator.transpose(conjugate=conjugate))
+        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=np.conjugate(self._scalar), A=self._operator.transpose(conjugate=conjugate))
 
     def __neg__(self):
         return ScaledLinearOperator(domain=self.domain, codomain=self.codomain, c=-1*self._scalar, A=self._operator)

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -593,7 +593,7 @@ class ScaledLinearOperator(LinearOperator):
         return self._scalar*csr_matrix(self._operator.toarray())
 
     def transpose(self, conjugate=False):
-        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=np.conjugate(self._scalar), A=self._operator.transpose(conjugate=conjugate))
+        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=self._scalar if not conjugate else np.conjugate(self._scalar), A=self._operator.transpose(conjugate=conjugate))
 
     def __neg__(self):
         return ScaledLinearOperator(domain=self.domain, codomain=self.codomain, c=-1*self._scalar, A=self._operator)

--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -946,7 +946,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
         rp.copy(out=rp0)
 
         # squared residual norm and squared tolerance
-        res_sqr = r.dot(r)
+        res_sqr = r.dot(r).real
         tol_sqr = tol**2
 
         if verbose:

--- a/psydac/linalg/tests/test_linalg.py
+++ b/psydac/linalg/tests/test_linalg.py
@@ -530,7 +530,7 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
     assert isinstance(Z3, StencilMatrix)
     assert isinstance(T, StencilMatrix)
     assert np.array_equal(w2.toarray(), np.dot(np.dot(2, Sa), v_array))
-test_in_place_operations(10, 10, 2, 2, P1=False, P2=False)   
+ 
 #===============================================================================
 @pytest.mark.parametrize('n1', n1array)
 @pytest.mark.parametrize('n2', n2array)

--- a/psydac/linalg/tests/test_linalg.py
+++ b/psydac/linalg/tests/test_linalg.py
@@ -450,29 +450,37 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
 
     # Initiate StencilVectorSpace
     V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-
+    Vc = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    Vc._dtype = complex
     v = StencilVector(V)
+    vc = StencilVector(Vc)
     v_array = np.zeros(n1*n2)
 
     for i in range(n1):
         for j in range(n2):
             v[i,j] = i+1
             v_array[i*n2+j] = i+1
+            vc[i,j] = i+1       
     
     I1 = IdentityOperator(V,V)
     I2 = IdentityOperator(V,V)
     I3 = IdentityOperator(V,V)
+    I4 = IdentityOperator(Vc,Vc)
 
     I1 *= 0
     I2 *= 1
     I3 *= 3
     v3 = I3.dot(v)
+    I4 *= 3j
+    v4 = I4.dot(vc)
 
     assert np.array_equal(v.toarray(), v_array)
     assert isinstance(I1, ZeroOperator)
     assert isinstance(I2, IdentityOperator)
     assert isinstance(I3, ScaledLinearOperator)
     assert np.array_equal(v3.toarray(), np.dot(v_array, 3))
+    assert isinstance(I4, ScaledLinearOperator)
+    assert np.array_equal(v4.toarray(), np.dot(v_array, 3j))
 
     # testing __iadd__ and __isub__ although not explicitly implemented (in the LinearOperator class)
 
@@ -522,7 +530,7 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
     assert isinstance(Z3, StencilMatrix)
     assert isinstance(T, StencilMatrix)
     assert np.array_equal(w2.toarray(), np.dot(np.dot(2, Sa), v_array))
-    
+test_in_place_operations(10, 10, 2, 2, P1=False, P2=False)   
 #===============================================================================
 @pytest.mark.parametrize('n1', n1array)
 @pytest.mark.parametrize('n2', n2array)


### PR DESCRIPTION
- Make `ScaledLinearOperator` work with a complex scalar;
- Take real part of `r.dot(r)` to avoid complex warning in `sqrt`;
- Add unit test.