### PR TITLE
Improve FEM API (names, properties, constructors...) & plot_field()

### DIFF
--- a/examples/maxwell_2d_multi_patch.py
+++ b/examples/maxwell_2d_multi_patch.py
@@ -102,8 +102,8 @@ if __name__ == '__main__':
     from collections                               import OrderedDict
     from sympy                                     import lambdify
     from psydac.api.tests.build_domain             import build_pretzel
-    from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-    from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+    from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_vals
+    from psydac.fem.plotting_utilities import get_patch_knots_gridlines, my_small_plot
 
     domain = build_pretzel()
     x,y    = domain.coordinates

--- a/examples/poisson_1d.py
+++ b/examples/poisson_1d.py
@@ -127,9 +127,9 @@ def assemble_matrices(V, kernel, *, nquads):
 
     """
     # Sizes
-    [s1] = V.vector_space.starts
-    [e1] = V.vector_space.ends
-    [p1] = V.vector_space.pads
+    [s1] = V.coeff_space.starts
+    [e1] = V.coeff_space.ends
+    [p1] = V.coeff_space.pads
 
     # Quadrature data
     quad_grid = V.get_quadrature_grids(*nquads)[0]
@@ -140,8 +140,8 @@ def assemble_matrices(V, kernel, *, nquads):
     weights_1 = quad_grid.weights
 
     # Create global matrices
-    mass      = StencilMatrix(V.vector_space, V.vector_space)
-    stiffness = StencilMatrix(V.vector_space, V.vector_space)
+    mass      = StencilMatrix(V.coeff_space, V.coeff_space)
+    stiffness = StencilMatrix(V.coeff_space, V.coeff_space)
 
     # Create element matrices
     mat_m = np.zeros((p1+1, 2*p1+1)) # mass
@@ -187,9 +187,9 @@ def assemble_rhs(V, f, *, nquads):
 
     """
     # Sizes
-    [s1] = V.vector_space.starts
-    [e1] = V.vector_space.ends
-    [p1] = V.vector_space.pads
+    [s1] = V.coeff_space.starts
+    [e1] = V.coeff_space.ends
+    [p1] = V.coeff_space.pads
 
     # Quadrature data
     quad_grid = V.get_quadrature_grids(*nquads)[0]
@@ -201,7 +201,7 @@ def assemble_rhs(V, f, *, nquads):
     weights_1 = quad_grid.weights
 
     # Data structure
-    rhs = StencilVector(V.vector_space)
+    rhs = StencilVector(V.coeff_space)
 
     # Build RHS
     for k1 in range(nk1):
@@ -261,8 +261,8 @@ if __name__ == '__main__':
     rhs = assemble_rhs(V, model.rho, nquads=nquads)
 
     # Apply homogeneous Dirichlet boundary conditions
-    s1, = V.vector_space.starts
-    e1, = V.vector_space.ends
+    s1, = V.coeff_space.starts
+    e1, = V.coeff_space.ends
 
     stiffness[s1, :] = 0.
     stiffness[e1, :] = 0.

--- a/examples/poisson_2d_mapping.py
+++ b/examples/poisson_2d_mapping.py
@@ -396,9 +396,9 @@ def assemble_matrices(V, mapping, kernel, *, nquads):
 
     """
     # Sizes
-    [s1, s2] = V.vector_space.starts
-    [e1, e2] = V.vector_space.ends
-    [p1, p2] = V.vector_space.pads
+    [s1, s2] = V.coeff_space.starts
+    [e1, e2] = V.coeff_space.ends
+    [p1, p2] = V.coeff_space.pads
 
     # Quadrature data
     quad_grids = V.get_quadrature_grids(*nquads)
@@ -410,8 +410,8 @@ def assemble_matrices(V, mapping, kernel, *, nquads):
     [weights_1, weights_2] = [g.weights      for g in quad_grids]
 
     # Create global matrices
-    mass      = StencilMatrix(V.vector_space, V.vector_space)
-    stiffness = StencilMatrix(V.vector_space, V.vector_space)
+    mass      = StencilMatrix(V.coeff_space, V.coeff_space)
+    stiffness = StencilMatrix(V.coeff_space, V.coeff_space)
 
     # Create element matrices
     mat_m = np.zeros((p1+1, p2+1, 2*p1+1, 2*p2+1)) # mass
@@ -478,9 +478,9 @@ def assemble_rhs(V, mapping, f, *, nquads):
 
     """
     # Sizes
-    [s1, s2] = V.vector_space.starts
-    [e1, e2] = V.vector_space.ends
-    [p1, p2] = V.vector_space.pads
+    [s1, s2] = V.coeff_space.starts
+    [e1, e2] = V.coeff_space.ends
+    [p1, p2] = V.coeff_space.pads
 
     # Quadrature data
     quad_grids = V.get_quadrature_grids(*nquads)
@@ -492,7 +492,7 @@ def assemble_rhs(V, mapping, f, *, nquads):
     [weights_1, weights_2] = [g.weights      for g in quad_grids]
 
     # Data structure
-    rhs = StencilVector(V.vector_space)
+    rhs = StencilVector(V.coeff_space)
 
     # Build RHS
     for k1 in range(nk1):
@@ -614,8 +614,8 @@ def main(*, test_case, ncells, degree, nquads,
     # Create 2D tensor product finite element space
     V = TensorFemSpace(dd, V1, V2)
 
-    s1, s2 = V.vector_space.starts
-    e1, e2 = V.vector_space.ends
+    s1, s2 = V.coeff_space.starts
+    e1, e2 = V.coeff_space.ends
 
     #+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     # Print decomposition information to terminal
@@ -627,7 +627,7 @@ def main(*, test_case, ncells, degree, nquads,
         int_tuples_to_str = lambda tuples:  ',  '.join(
                 '[{:d}, {:d}]'.format(a,b) for a,b in tuples)
 
-        cart = V.vector_space.cart
+        cart = V.coeff_space.cart
 
         block_sizes_i1     = [e1-s1+1 for s1, e1 in zip(cart.global_starts[0], cart.global_ends[0])]
         block_sizes_i2     = [e2-s2+1 for s2, e2 in zip(cart.global_starts[1], cart.global_ends[1])]

--- a/examples/poisson_2d_multi_patch.py
+++ b/examples/poisson_2d_multi_patch.py
@@ -108,8 +108,8 @@ if __name__ == '__main__':
     from collections                               import OrderedDict
     from sympy                                     import lambdify
     from psydac.api.tests.build_domain             import build_pretzel
-    from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-    from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+    from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_vals
+    from psydac.fem.plotting_utilities import get_patch_knots_gridlines, my_small_plot
 
     domain    = build_pretzel()
     x,y       = domain.coordinates

--- a/examples/poisson_3d_multi_patch.py
+++ b/examples/poisson_3d_multi_patch.py
@@ -161,9 +161,7 @@ if __name__ == '__main__':
     from collections                               import OrderedDict
     from sympy                                     import lambdify
     from psydac.api.tests.build_domain             import build_pretzel
-    from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-    from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
-
+    
     A1 = Cube('A1', bounds1=(0, 0.5), bounds2=(0, 0.5), bounds3=(0, 1))
     A2 = Cube('A2', bounds1=(0.5, 1), bounds2=(0, 0.5), bounds3=(0, 1))
     A3 = Cube('A3', bounds1=(1, 1.5), bounds2=(0, 0.5), bounds3=(0, 1))

--- a/psydac/api/ast/expr.py
+++ b/psydac/api/ast/expr.py
@@ -35,7 +35,7 @@ from .utilities  import build_pythran_types_header, variables
 from .utilities  import build_pyccel_type_annotations
 from .utilities  import math_atoms_as_str
 
-from psydac.fem.vector import ProductFemSpace
+from psydac.fem.vector import MultipatchFemSpace
 from .nodes            import Zeros
 
 #==============================================================================
@@ -196,7 +196,7 @@ class ExprKernel(SplBasic):
         Vh   = self.space
         expr = self.expr
         dim  = Vh.ldim
-        if isinstance(Vh, ProductFemSpace):
+        if isinstance(Vh, MultipatchFemSpace):
             size = len(Vh.spaces)
         else:
             size = 1
@@ -208,7 +208,7 @@ class ExprKernel(SplBasic):
         n_elements = Vh.ncells
         degrees    = Vh.degree
         # TODO improve
-        if isinstance(Vh, ProductFemSpace):
+        if isinstance(Vh, MultipatchFemSpace):
             degrees = degrees[0]
         # ...
 

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -49,7 +49,7 @@ from .nodes import Block, ParallelBlock
 from psydac.api.ast.utilities import variables
 from psydac.api.utilities     import flatten
 from psydac.linalg.block      import BlockVectorSpace
-from psydac.fem.vector        import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector        import VectorFemSpace
 
 #==============================================================================
 def toInteger(a):

--- a/psydac/api/ast/fem.py
+++ b/psydac/api/ast/fem.py
@@ -288,8 +288,8 @@ class AST(object):
             fields              = expr.fields
             is_broken           = spaces.symbolic_space.is_broken
             tests_degrees       = get_degrees(tests, spaces)
-            multiplicity_tests  = get_multiplicity(tests, spaces.vector_space)
-            is_parallel         = spaces.vector_space.parallel
+            multiplicity_tests  = get_multiplicity(tests, spaces.coeff_space)
+            is_parallel         = spaces.coeff_space.parallel
             spaces              = spaces.symbolic_space
 
             # Define the type of scalar that the code should manage
@@ -304,9 +304,9 @@ class AST(object):
             is_broken           = spaces[1].symbolic_space.is_broken
             tests_degrees       = get_degrees(tests, spaces[1])
             trials_degrees      = get_degrees(trials, spaces[0])
-            multiplicity_tests  = get_multiplicity(tests, spaces[1].vector_space)
-            multiplicity_trials = get_multiplicity(trials, spaces[0].vector_space)
-            is_parallel         = spaces[1].vector_space.parallel
+            multiplicity_tests  = get_multiplicity(tests, spaces[1].coeff_space)
+            multiplicity_trials = get_multiplicity(trials, spaces[0].coeff_space)
+            is_parallel         = spaces[1].coeff_space.parallel
             spaces              = [V.symbolic_space for V in spaces]
 
             # Define the type of scalar that the code should manage
@@ -324,8 +324,8 @@ class AST(object):
             fields              = tuple(expr.atoms(ScalarFunction, VectorFunction))
             is_broken           = spaces.symbolic_space.is_broken
             fields_degrees      = get_degrees(fields, spaces)
-            multiplicity_fields = get_multiplicity(fields, spaces.vector_space)
-            is_parallel         = spaces.vector_space.parallel
+            multiplicity_fields = get_multiplicity(fields, spaces.coeff_space)
+            is_parallel         = spaces.coeff_space.parallel
             spaces              = spaces.symbolic_space
 
             # Define the type of scalar that the code should manage
@@ -418,8 +418,8 @@ class AST(object):
 
                 mapping_degrees_m      = get_degrees([f_m], mapping_space[0])
                 mapping_degrees_p      = get_degrees([f_p], mapping_space[1])
-                multiplicity_mapping_m = get_multiplicity([f_m], mapping_space[0].vector_space)
-                multiplicity_mapping_p = get_multiplicity([f_p], mapping_space[1].vector_space)
+                multiplicity_mapping_m = get_multiplicity([f_m], mapping_space[0].coeff_space)
+                multiplicity_mapping_p = get_multiplicity([f_p], mapping_space[1].coeff_space)
                 mapping_degrees        = (mapping_degrees_m, mapping_degrees_p)
                 multiplicity_mapping   = (multiplicity_mapping_m, multiplicity_mapping_p)
             else:
@@ -427,7 +427,7 @@ class AST(object):
                 f  = expand([f])[0]
                 f  = (f,)
                 mapping_degrees      = (get_degrees(f, mapping_space),)
-                multiplicity_mapping = (get_multiplicity(f, mapping_space.vector_space),)
+                multiplicity_mapping = (get_multiplicity(f, mapping_space.coeff_space),)
 
             d_mapping = {fi: {'global':       GlobalTensorQuadratureTestBasis (fi),
                               'local' :       LocalTensorQuadratureTestBasis(fi),

--- a/psydac/api/ast/glt.py
+++ b/psydac/api/ast/glt.py
@@ -45,7 +45,7 @@ from .utilities  import is_mapping
 from .utilities  import math_atoms_as_str
 from .evaluation import EvalArrayMapping, EvalArrayField
 
-from psydac.fem.vector  import ProductFemSpace
+from psydac.fem.vector  import MultipatchFemSpace
 from .nodes             import Zeros
 
 #==============================================================================
@@ -178,7 +178,7 @@ class GltKernel(SplBasic):
         n_elements = Vh.ncells
         degrees    = Vh.degree
         # TODO improve
-        if isinstance(Vh, ProductFemSpace):
+        if isinstance(Vh, MultipatchFemSpace):
             degrees = degrees[0]
         # ...
 

--- a/psydac/api/ast/nodes.py
+++ b/psydac/api/ast/nodes.py
@@ -565,8 +565,8 @@ class EvalMapping(BaseNode):
         mapping_atoms  = components.arguments
         basis          = q_basis
         target         = basis.target
-        multiplicity   = tuple(mapping_space.vector_space.shifts) if mapping_space else ()
-        pads           = tuple(mapping_space.vector_space.pads) if mapping_space else ()
+        multiplicity   = tuple(mapping_space.coeff_space.shifts) if mapping_space else ()
+        pads           = tuple(mapping_space.coeff_space.pads) if mapping_space else ()
         quad_loop      = True if quad_loop is None else quad_loop
 
         if isinstance(target, IndexedVectorFunction):

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -503,11 +503,22 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
         new_g_spaces[inter]   = Vh
 
     construct_reduced_interface_spaces(g_spaces, new_g_spaces, interiors, connectivity)
+    spaces = list(new_g_spaces.values())
 
-    Vh = create_product_space(*new_g_spaces.values(), connectivity=connectivity)
+    if len(connectivity) == 0:
+        assert all(isinstance(Wh, FemSpace) for Wh in spaces)
+        if  len(spaces) == 1:
+            Vh = spaces[0]
+        else:
+            Vh = VectorFemSpace(*spaces)
+    else:
+        assert all((isinstance(Wh, FemSpace) and not Wh.is_multipatch) for Wh in spaces)
+        Vh = MultipatchFemSpace(*spaces, connectivity=connectivity)
+    
     Vh.symbolic_space = V
 
     return Vh
+
 
 #==============================================================================
 def discretize_domain(domain, *, filename=None, ncells=None, periodic=None, comm=None, mpi_dims_mask=None):

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -78,13 +78,13 @@ def change_dtype(V, dtype):
             for v in V.spaces:
                 change_dtype(v, dtype)
                 new_spaces.append(v.vector_space)
-            V._vector_space = BlockVectorSpace(*new_spaces, connectivity=V.vector_space.connectivity)
+            V._coeff_space = BlockVectorSpace(*new_spaces, connectivity=V.vector_space.connectivity)
 
         # If the vector_space is a StencilVectorSpace
         else:
             # Recreate the StencilVectorSpace
             interfaces = V.vector_space.interfaces
-            V._vector_space = StencilVectorSpace(V.vector_space.cart, dtype=dtype)
+            V._coeff_space = StencilVectorSpace(V.vector_space.cart, dtype=dtype)
 
             # Recreate the interface in the StencilVectorSpace
             for (axis, ext), interface_space in interfaces.items():

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -37,7 +37,7 @@ from psydac.api.utilities    import flatten
 from psydac.fem.splines      import SplineSpace
 from psydac.fem.tensor       import TensorFemSpace
 from psydac.fem.partitioning import create_cart, construct_connectivity, construct_interface_spaces, construct_reduced_interface_spaces
-from psydac.fem.vector       import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector       import MultipatchFemSpace, VectorFemSpace
 from psydac.cad.geometry     import Geometry
 from psydac.mapping.discrete import NurbsMapping
 from psydac.linalg.stencil   import StencilVectorSpace
@@ -115,7 +115,7 @@ def get_max_degree_of_one_space(Vh):
     elif isinstance(Vh, VectorFemSpace):
         return [max(p) for p in zip(*Vh.degree)]
 
-    elif isinstance(Vh, ProductFemSpace):
+    elif isinstance(Vh, MultipatchFemSpace):
         degree = [get_max_degree_of_one_space(Vh_i) for Vh_i in Vh.spaces]
         return [max(p) for p in zip(*degree)]
 
@@ -504,7 +504,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
 
     construct_reduced_interface_spaces(g_spaces, new_g_spaces, interiors, connectivity)
 
-    Vh = ProductFemSpace(*new_g_spaces.values(), connectivity=connectivity)
+    Vh = MultipatchFemSpace(*new_g_spaces.values(), connectivity=connectivity)
     Vh.symbolic_space = V
 
     return Vh

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -37,7 +37,7 @@ from psydac.api.utilities    import flatten
 from psydac.fem.splines      import SplineSpace
 from psydac.fem.tensor       import TensorFemSpace
 from psydac.fem.partitioning import create_cart, construct_connectivity, construct_interface_spaces, construct_reduced_interface_spaces
-from psydac.fem.vector       import MultipatchFemSpace, VectorFemSpace
+from psydac.fem.vector       import MultipatchFemSpace, VectorFemSpace, create_product_space
 from psydac.cad.geometry     import Geometry
 from psydac.mapping.discrete import NurbsMapping
 from psydac.linalg.stencil   import StencilVectorSpace
@@ -504,7 +504,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
 
     construct_reduced_interface_spaces(g_spaces, new_g_spaces, interiors, connectivity)
 
-    Vh = MultipatchFemSpace(*new_g_spaces.values(), connectivity=connectivity)
+    Vh = create_product_space(*new_g_spaces.values(), connectivity=connectivity)
     Vh.symbolic_space = V
 
     return Vh

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -37,7 +37,7 @@ from psydac.api.utilities    import flatten
 from psydac.fem.splines      import SplineSpace
 from psydac.fem.tensor       import TensorFemSpace
 from psydac.fem.partitioning import create_cart, construct_connectivity, construct_interface_spaces, construct_reduced_interface_spaces
-from psydac.fem.vector       import MultipatchFemSpace, VectorFemSpace, create_product_space
+from psydac.fem.vector       import MultipatchFemSpace, VectorFemSpace
 from psydac.cad.geometry     import Geometry
 from psydac.mapping.discrete import NurbsMapping
 from psydac.linalg.stencil   import StencilVectorSpace

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -55,7 +55,7 @@ __all__ = (
 #==============================================================================
 def change_dtype(V, dtype):
     """
-    Given a FemSpace V, change its underlying vector_space (i.e. the space of
+    Given a FemSpace V, change its underlying coeff_space (i.e. the space of
     its coefficients) so that it matches the required data type.
 
     Parameters
@@ -64,31 +64,31 @@ def change_dtype(V, dtype):
         The FEM space, which is modified in place.
 
     dtype : float or complex
-        Datatype of the new vector_space.
+        Datatype of the new coeff_space.
 
     Returns
     -------
     FemSpace
         The same FEM space passed as input, which was modified in place.
     """
-    if not V.vector_space.dtype == dtype:
-        if isinstance(V.vector_space, BlockVectorSpace):
+    if not V.coeff_space.dtype == dtype:
+        if isinstance(V.coeff_space, BlockVectorSpace):
             # Recreate the BlockVectorSpace
             new_spaces = []
             for v in V.spaces:
                 change_dtype(v, dtype)
-                new_spaces.append(v.vector_space)
-            V._coeff_space = BlockVectorSpace(*new_spaces, connectivity=V.vector_space.connectivity)
+                new_spaces.append(v.coeff_space)
+            V._coeff_space = BlockVectorSpace(*new_spaces, connectivity=V.coeff_space.connectivity)
 
-        # If the vector_space is a StencilVectorSpace
+        # If the coeff_space is a StencilVectorSpace
         else:
             # Recreate the StencilVectorSpace
-            interfaces = V.vector_space.interfaces
-            V._coeff_space = StencilVectorSpace(V.vector_space.cart, dtype=dtype)
+            interfaces = V.coeff_space.interfaces
+            V._coeff_space = StencilVectorSpace(V.coeff_space.cart, dtype=dtype)
 
             # Recreate the interface in the StencilVectorSpace
             for (axis, ext), interface_space in interfaces.items():
-                V.vector_space.set_interface(axis, ext, interface_space.cart)
+                V.coeff_space.set_interface(axis, ext, interface_space.cart)
 
     return V
 
@@ -417,7 +417,7 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
         else:
             mappings  = [domain_h.mappings[inter.logical_domain.name] for inter in interiors]
 
-        # Get all the FEM spaces from the mapping and convert their vector_space at the dtype needed
+        # Get all the FEM spaces from the mapping and convert their coeff_space at the dtype needed
         spaces    = [change_dtype(m.space, dtype) for m in mappings]
         g_spaces  = dict(zip(interiors, spaces))
         spaces    = [S.spaces for S in spaces]

--- a/psydac/api/discretization.py
+++ b/psydac/api/discretization.py
@@ -34,6 +34,7 @@ from psydac.api.glt          import DiscreteGltExpr
 from psydac.api.expr         import DiscreteExpr
 from psydac.api.equation     import DiscreteEquation
 from psydac.api.utilities    import flatten
+from psydac.fem.basic        import FemSpace
 from psydac.fem.splines      import SplineSpace
 from psydac.fem.tensor       import TensorFemSpace
 from psydac.fem.partitioning import create_cart, construct_connectivity, construct_interface_spaces, construct_reduced_interface_spaces
@@ -505,15 +506,15 @@ def discretize_space(V, domain_h, *, degree=None, multiplicity=None, knots=None,
     construct_reduced_interface_spaces(g_spaces, new_g_spaces, interiors, connectivity)
     spaces = list(new_g_spaces.values())
 
-    if len(connectivity) == 0:
+    if connectivity:
+        assert all((isinstance(Wh, FemSpace) and not Wh.is_multipatch) for Wh in spaces)
+        Vh = MultipatchFemSpace(*spaces, connectivity=connectivity)
+    else:
         assert all(isinstance(Wh, FemSpace) for Wh in spaces)
         if  len(spaces) == 1:
             Vh = spaces[0]
         else:
             Vh = VectorFemSpace(*spaces)
-    else:
-        assert all((isinstance(Wh, FemSpace) and not Wh.is_multipatch) for Wh in spaces)
-        Vh = MultipatchFemSpace(*spaces, connectivity=connectivity)
     
     Vh.symbolic_space = V
 

--- a/psydac/api/expr.py
+++ b/psydac/api/expr.py
@@ -17,7 +17,7 @@ from psydac.cad.geometry      import Geometry
 from psydac.mapping.discrete  import SplineMapping, NurbsMapping
 from psydac.fem.splines       import SplineSpace
 from psydac.fem.tensor        import TensorFemSpace
-from psydac.fem.vector        import ProductFemSpace
+from psydac.fem.vector        import MultipatchFemSpace
 
 __all__ = ('DiscreteExpr',)
 #==============================================================================
@@ -119,7 +119,7 @@ class DiscreteExpr(BasicCodeGen):
             # TODO generalize to use multiple fields
             coeffs = ()
             for F in fields:
-                if isinstance(Vh, ProductFemSpace):
+                if isinstance(Vh, MultipatchFemSpace):
                     basis_values = [CollocationBasisValues(grid, V, nderiv=nderiv) for V in Vh.spaces]
                     basis = [bs.basis for bs in basis_values]
                     spans = [bs.spans for bs in basis_values]

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -26,7 +26,7 @@ from psydac.linalg.basic     import ComposedLinearOperator
 from psydac.linalg.block     import BlockVectorSpace, BlockVector, BlockLinearOperator
 from psydac.cad.geometry     import Geometry
 from psydac.mapping.discrete import NurbsMapping
-from psydac.fem.vector       import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector       import VectorFemSpace
 from psydac.fem.basic        import FemField
 from psydac.fem.projectors   import knot_insertion_projection_operator
 from psydac.core.bsplines    import find_span, basis_funs_all_ders

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -273,10 +273,10 @@ class DiscreteBilinearForm(BasicDiscrete):
         self._is_rational_mapping = is_rational_mapping
         # ...
 
-        if isinstance(test_space.vector_space, BlockVectorSpace):
-            coeff_space = test_space.vector_space.spaces[0]
+        if isinstance(test_space.coeff_space, BlockVectorSpace):
+            coeff_space = test_space.coeff_space.spaces[0]
         else:
-            coeff_space = test_space.vector_space
+            coeff_space = test_space.coeff_space
 
         self._coeff_space = coeff_space
         self._num_threads  = 1
@@ -588,7 +588,7 @@ class DiscreteBilinearForm(BasicDiscrete):
         if len(self.grid)>1:
             quads  = [*quads, *self.grid[1].points]
 
-        pads = self.test_basis.space.vector_space.pads
+        pads = self.test_basis.space.coeff_space.pads
 
         # When self._target is an Interface domain len(self._grid) == 2
         # where grid contains the QuadratureGrid of both sides of the interface
@@ -598,7 +598,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                 map_coeffs = [[e._coeffs._data for e in self.mapping._fields]]
                 spaces     = [self.mapping._fields[0].space]
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans - s for q,s in zip(sp.get_assembly_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_span   = [[q.spans - s for q,s in zip(sp.get_assembly_grids(*self.nquads), sp.coeff_space.starts)] for sp in spaces]
                 map_basis  = [[q.basis for q in sp.get_assembly_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
                 weights    = [self.mapping.weights_field.coeffs._data] if self.is_rational_mapping else []
@@ -639,7 +639,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                         weights_p[0] = weights_p[0]._interface_data[axis, ext]
 
                 map_degree = [sp.degree for sp in spaces]
-                map_span   = [[q.spans - s for q, s in zip(sp.get_assembly_grids(*self.nquads), sp.vector_space.starts)] for sp in spaces]
+                map_span   = [[q.spans - s for q, s in zip(sp.get_assembly_grids(*self.nquads), sp.coeff_space.starts)] for sp in spaces]
                 map_basis  = [[q.basis for q in sp.get_assembly_grids(*self.nquads)] for sp in spaces]
                 points     = [g.points for g in self.grid]
 
@@ -706,8 +706,8 @@ class DiscreteBilinearForm(BasicDiscrete):
         target          = self.kernel_expr.target
         test_degree     = np.array(self.test_basis.space.degree)
         trial_degree    = np.array(self.trial_basis.space.degree)
-        test_space      = self.spaces[1].vector_space
-        trial_space     = self.spaces[0].vector_space
+        test_space      = self.spaces[1].coeff_space
+        trial_space     = self.spaces[0].coeff_space
         test_fem_space  = self.spaces[1]
         trial_fem_space = self.spaces[0]
         domain          = self.domain
@@ -755,11 +755,11 @@ class DiscreteBilinearForm(BasicDiscrete):
 
             if is_broken: #multi patch
                 if not self._matrix[i,j]:
-                    mat = BlockLinearOperator(trial_fem_space.get_refined_space(ncells).vector_space, test_fem_space.get_refined_space(ncells).vector_space)
+                    mat = BlockLinearOperator(trial_fem_space.get_refined_space(ncells).coeff_space, test_fem_space.get_refined_space(ncells).coeff_space)
                     if not is_conformal and not i==j:
                         if use_restriction:
                             Ps  = [knot_insertion_projection_operator(ts.get_refined_space(ncells), ts) for ts in test_fem_space.spaces]
-                            P   = BlockLinearOperator(test_fem_space.get_refined_space(ncells).vector_space, test_fem_space.vector_space)
+                            P   = BlockLinearOperator(test_fem_space.get_refined_space(ncells).coeff_space, test_fem_space.coeff_space)
                             for ni,Pi in enumerate(Ps):
                                 P[ni,ni] = Pi
 
@@ -767,7 +767,7 @@ class DiscreteBilinearForm(BasicDiscrete):
 
                         elif use_prolongation:
                             Ps  = [knot_insertion_projection_operator(trs, trs.get_refined_space(ncells)) for trs in trial_fem_space.spaces]
-                            P   = BlockLinearOperator(trial_fem_space.vector_space, trial_fem_space.get_refined_space(ncells).vector_space)
+                            P   = BlockLinearOperator(trial_fem_space.coeff_space, trial_fem_space.get_refined_space(ncells).coeff_space)
                             for ni,Pi in enumerate(Ps):
                                 P[ni,ni] = Pi
 
@@ -786,14 +786,14 @@ class DiscreteBilinearForm(BasicDiscrete):
                         continue
 
                     if isinstance(test_fem_space, VectorFemSpace):
-                        ts_space = test_fem_space.get_refined_space(ncells).vector_space.spaces[k1]
+                        ts_space = test_fem_space.get_refined_space(ncells).coeff_space.spaces[k1]
                     else:
-                        ts_space = test_fem_space.get_refined_space(ncells).vector_space
+                        ts_space = test_fem_space.get_refined_space(ncells).coeff_space
 
                     if isinstance(trial_fem_space, VectorFemSpace):
-                        tr_space = trial_fem_space.get_refined_space(ncells).vector_space.spaces[k2]
+                        tr_space = trial_fem_space.get_refined_space(ncells).coeff_space.spaces[k2]
                     else:
-                        tr_space = trial_fem_space.get_refined_space(ncells).vector_space
+                        tr_space = trial_fem_space.get_refined_space(ncells).coeff_space
 
                     if is_conformal and matrix[k1, k2]:
                         global_mats[k1, k2] = matrix[k1, k2]
@@ -802,9 +802,9 @@ class DiscreteBilinearForm(BasicDiscrete):
                         ext_d   = self._trial_ext
                         ext_c   = self._test_ext
                         test_n  = self. test_basis.space.spaces[k1].spaces[axis].nbasis
-                        test_s  = self. test_basis.space.spaces[k1].vector_space.starts[axis]
+                        test_s  = self. test_basis.space.spaces[k1].coeff_space.starts[axis]
                         trial_n = self.trial_basis.space.spaces[k2].spaces[axis].nbasis
-                        cart    = self.trial_basis.space.spaces[k2].vector_space.cart
+                        cart    = self.trial_basis.space.spaces[k2].coeff_space.cart
                         trial_s = cart.global_starts[axis][cart._coords[axis]]
 
                         s_d = trial_n - trial_s - trial_degree[k2][axis] - 1 if ext_d == 1 else 0
@@ -847,9 +847,9 @@ class DiscreteBilinearForm(BasicDiscrete):
                     ext_d  = self._trial_ext
                     ext_c  = self._test_ext
                     test_n  = self.test_basis.space.spaces[axis].nbasis
-                    test_s  = self.test_basis.space.vector_space.starts[axis]
+                    test_s  = self.test_basis.space.coeff_space.starts[axis]
                     trial_n = self.trial_basis.space.spaces[axis].nbasis
-                    cart    = self.trial_basis.space.vector_space.cart
+                    cart    = self.trial_basis.space.coeff_space.cart
                     trial_s = cart.global_starts[axis][cart._coords[axis]]
 
                     s_d = trial_n - trial_s - trial_degree[axis] - 1 if ext_d == 1 else 0
@@ -867,8 +867,8 @@ class DiscreteBilinearForm(BasicDiscrete):
                     flip[axis] = 1
 
                     if self._func != do_nothing:
-                        mat = StencilInterfaceMatrix(trial_fem_space.get_refined_space(ncells).vector_space,
-                                                     test_fem_space.get_refined_space(ncells).vector_space,
+                        mat = StencilInterfaceMatrix(trial_fem_space.get_refined_space(ncells).coeff_space,
+                                                     test_fem_space.get_refined_space(ncells).coeff_space,
                                                      s_d, s_c,
                                                      axis, axis,
                                                      ext_d, ext_c,
@@ -1043,12 +1043,12 @@ class DiscreteLinearForm(BasicDiscrete):
             test_space  = self._space
             mapping = list(domain_h.mappings.values())[0]
 
-        if isinstance(test_space.vector_space, BlockVectorSpace):
-            coeff_space = test_space.vector_space.spaces[0]
+        if isinstance(test_space.coeff_space, BlockVectorSpace):
+            coeff_space = test_space.coeff_space.spaces[0]
             if isinstance(coeff_space, BlockVectorSpace):
                 coeff_space = coeff_space.spaces[0]
         else:
-            coeff_space = test_space.vector_space
+            coeff_space = test_space.coeff_space
 
         self._mapping     = mapping
         self._coeff_space = coeff_space
@@ -1270,13 +1270,13 @@ class DiscreteLinearForm(BasicDiscrete):
         tests_basis, tests_degrees, spans, pads = construct_test_space_arguments(self.test_basis)
         n_elements, quads, nquads               = construct_quad_grids_arguments(self.grid, use_weights=False)
 
-        global_pads   = self.space.vector_space.pads
+        global_pads   = self.space.coeff_space.pads
 
         if self.mapping:
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans - s for q, s in zip(space.get_assembly_grids(*self.nquads), space.vector_space.starts)]
+            map_span   = [q.spans - s for q, s in zip(space.get_assembly_grids(*self.nquads), space.coeff_space.starts)]
             map_basis  = [q.basis for q in space.get_assembly_grids(*self.nquads)]
             axis       = self.grid.axis
             ext        = self.grid.ext
@@ -1323,7 +1323,7 @@ class DiscreteLinearForm(BasicDiscrete):
         """
         global_mats   = {}
 
-        test_space  = self.test_basis.space.vector_space
+        test_space  = self.test_basis.space.coeff_space
         test_degree = np.array(self.test_basis.space.degree)
 
         expr        = self.kernel_expr.expr
@@ -1332,7 +1332,7 @@ class DiscreteLinearForm(BasicDiscrete):
         is_broken   = len(domain) > 1
 
         if self._vector is None and (is_broken or isinstance(expr, (ImmutableDenseMatrix, Matrix))):
-            self._vector = BlockVector(self.space.vector_space)
+            self._vector = BlockVector(self.space.coeff_space)
 
         if isinstance(expr, (ImmutableDenseMatrix, Matrix)): # case system of equations
 
@@ -1454,20 +1454,20 @@ class DiscreteFunctional(BasicDiscrete):
         else:
             mapping = list(domain_h.mappings.values())[0]
 
-        if isinstance(self.space.vector_space, BlockVectorSpace):
-            vector_space = self.space.vector_space.spaces[0]
-            if isinstance(vector_space, BlockVectorSpace):
-                vector_space = vector_space.spaces[0]
+        if isinstance(self.space.coeff_space, BlockVectorSpace):
+            coeff_space = self.space.coeff_space.spaces[0]
+            if isinstance(coeff_space, BlockVectorSpace):
+                coeff_space = coeff_space.spaces[0]
         else:
-            vector_space = self.space.vector_space
+            coeff_space = self.space.coeff_space
 
         num_threads = 1
-        if vector_space.parallel and vector_space.cart.num_threads > 1:
-            num_threads = vector_space.cart._num_threads
+        if coeff_space.parallel and coeff_space.cart.num_threads > 1:
+            num_threads = coeff_space.cart._num_threads
 
         # In case of multiple patches, if the communicator is MPI_COMM_NULL, we do not generate the assembly code
         # because the patch is not owned by the MPI rank.
-        if vector_space.parallel and vector_space.cart.is_comm_null:
+        if coeff_space.parallel and coeff_space.cart.is_comm_null:
             self._free_args = ()
             self._func      = do_nothing
             self._args      = ()
@@ -1494,7 +1494,7 @@ class DiscreteFunctional(BasicDiscrete):
         discrete_space            = self._space
 
         # MPI communicator
-        comm = vector_space.cart.comm if vector_space.parallel else None
+        comm = coeff_space.cart.comm if coeff_space.parallel else None
 
         # BasicDiscrete generates the assembly code and sets the following attributes that are used afterwards:
         # self._func, self._free_args, self._max_nderiv and self._backend
@@ -1595,7 +1595,7 @@ class DiscreteFunctional(BasicDiscrete):
             mapping    = [e._coeffs._data for e in self.mapping._fields]
             space      = self.mapping._fields[0].space
             map_degree = space.degree
-            map_span   = [q.spans-s for q,s in zip(space.get_assembly_grids(*self.nquads), space.vector_space.starts)]
+            map_span   = [q.spans-s for q,s in zip(space.get_assembly_grids(*self.nquads), space.coeff_space.starts)]
             map_basis  = [q.basis for q in space.get_assembly_grids(*self.nquads)]
 
             if self.is_rational_mapping:

--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -492,7 +492,8 @@ class DiscreteBilinearForm(BasicDiscrete):
             for key in self._free_args:
                 v = kwargs[key]
 
-                if len(self.domain) > 1 and isinstance(v, FemField) and v.space.is_product:
+                if len(self.domain) > 1 and isinstance(v, FemField) and (v.space.is_multipatch or v.space.is_vector_valued):
+                    assert v.space.is_multipatch ## [MCP 27.03.2025] should hold since len(domain) > 1. If Ok we can simplify above if
                     i, j = self.get_space_indices_from_target(self.domain, self.target)
                     assert i == j
                     v = v[i]
@@ -512,7 +513,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                     spans   += s
                     degrees += [np.int64(a) for a in d]
                     pads    += [np.int64(a) for a in p]
-                    if v.space.is_product:
+                    if v.space.is_multipatch or v.space.is_vector_valued:
                         coeffs += (e._data for e in v.coeffs)
                     else:
                         coeffs += (v.coeffs._data, )
@@ -1185,7 +1186,8 @@ class DiscreteLinearForm(BasicDiscrete):
             consts  = []
             for key in self._free_args:
                 v = kwargs[key]
-                if len(self.domain) > 1 and isinstance(v, FemField) and v.space.is_product:
+                if len(self.domain) > 1 and isinstance(v, FemField) and (v.space.is_multipatch or v.space.is_vector_valued):
+                    assert v.space.is_multipatch ## [MCP 27.03.2025] should hold since len(domain) > 1. If Ok we can simplify above if
                     i = self.get_space_indices_from_target(self.domain, self.target)
                     v = v[i]
                 if isinstance(v, FemField):
@@ -1203,7 +1205,7 @@ class DiscreteLinearForm(BasicDiscrete):
                     spans   += s
                     degrees += [np.int64(a) for a in d]
                     pads    += [np.int64(a) for a in p]
-                    if v.space.is_product:
+                    if v.space.is_multipatch or v.space.is_vector_valued:
                         coeffs += (e._data for e in v.coeffs)
                     else:
                         coeffs += (v.coeffs._data,)
@@ -1630,7 +1632,7 @@ class DiscreteFunctional(BasicDiscrete):
             if isinstance(v, FemField):
                 if not v.coeffs.ghost_regions_in_sync:
                     v.coeffs.update_ghost_regions()
-                if v.space.is_product:
+                if v.space.is_multipatch or v.space.is_vector_valued:
                     coeffs = v.coeffs
                     if self._symbolic_space.is_broken:
                         index = self.get_space_indices_from_target(self._domain, self._target)

--- a/psydac/api/glt.py
+++ b/psydac/api/glt.py
@@ -19,7 +19,7 @@ from psydac.mapping.discrete  import SplineMapping, NurbsMapping
 
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
-from psydac.fem.vector  import ProductFemSpace
+from psydac.fem.vector  import MultipatchFemSpace
 
 from sympde.expr.basic            import BasicForm
 from psydac.api.printing.pycode   import pycode
@@ -556,7 +556,7 @@ class DiscreteGltExpr(GltBasicCodeGen):
 
         Vh = self.spaces[0]
         is_block = False
-        if isinstance(Vh, ProductFemSpace):
+        if isinstance(Vh, MultipatchFemSpace):
             Vh = Vh.spaces[0]
             is_block = True
 
@@ -645,7 +645,7 @@ class DiscreteGltExpr(GltBasicCodeGen):
         the current algorithm is based on a uniform sampling of the glt symbol.
         """
         Vh = self.spaces[0]
-        if isinstance(Vh, ProductFemSpace):
+        if isinstance(Vh, MultipatchFemSpace):
             Vh = Vh.spaces[0]
 
         if not isinstance(Vh, TensorFemSpace):

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -8,7 +8,7 @@ from psydac.core.bsplines import find_span
 from psydac.core.bsplines import basis_funs_all_ders
 from psydac.fem.splines   import SplineSpace
 from psydac.fem.tensor    import TensorFemSpace
-from psydac.fem.vector    import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector    import MultipatchFemSpace, VectorFemSpace
 
 __all__ = (
     'get_points_weights',
@@ -61,16 +61,16 @@ class QuadratureGrid():
         points              = []
         weights             = []
 
-        if isinstance(V, (ProductFemSpace, VectorFemSpace)):
+        if isinstance(V, (MultipatchFemSpace, VectorFemSpace)):
             V1 = V.spaces[0]
             spaces = list(V.spaces)
         else:
             V1 = V
             spaces = [V]
 
-        if trial_space and not isinstance(trial_space, (ProductFemSpace, VectorFemSpace)):
+        if trial_space and not isinstance(trial_space, (MultipatchFemSpace, VectorFemSpace)):
             spaces.append(trial_space)
-        elif isinstance(trial_space, ProductFemSpace):
+        elif isinstance(trial_space, MultipatchFemSpace):
             spaces = spaces + list(trial_space.spaces)
 
         # calculate the union of the indices in quad_grids, and make sure that all the grids match for each space.
@@ -203,7 +203,7 @@ class BasisValues():
 
         self._space = V
         assert grid is not None
-        if isinstance(V, (ProductFemSpace, VectorFemSpace)):
+        if isinstance(V, (MultipatchFemSpace, VectorFemSpace)):
             starts = V.vector_space.starts
             V      = V.spaces
         else:

--- a/psydac/api/grid.py
+++ b/psydac/api/grid.py
@@ -204,10 +204,10 @@ class BasisValues():
         self._space = V
         assert grid is not None
         if isinstance(V, (MultipatchFemSpace, VectorFemSpace)):
-            starts = V.vector_space.starts
+            starts = V.coeff_space.starts
             V      = V.spaces
         else:
-            starts = [V.vector_space.starts]
+            starts = [V.coeff_space.starts]
             V      = [V]
 
         spans = []
@@ -220,7 +220,7 @@ class BasisValues():
             spans_i = []
             basis_i = []
 
-            for sij, g, w, p, vij in zip(si, assembly_grids, weights, Vi.vector_space.pads, Vi.spaces):
+            for sij, g, w, p, vij in zip(si, assembly_grids, weights, Vi.coeff_space.pads, Vi.spaces):
                 sp = g.spans - sij
                 bs = g.basis[:, :, :nderiv+1, :].copy()
                 if not trial:

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -426,7 +426,7 @@ class OutputManager:
         Adds a vector space to the scope.
         Parameters
         ----------
-        vector_space: psydac.fem.vector.VectorFemSpace or psydac.fem.vector.ProductFemSpace
+        vector_space: psydac.fem.vector.VectorFemSpace or psydac.fem.vector.MultipatchFemSpace  # todo [MCP 12.03.2025]: check these types
             Vector/Product FemSpace to add to the scope.
         """
 

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -511,7 +511,8 @@ class OutputManager:
         # Add field coefficients as named datasets
         for name_field, field in fields.items():
             multipatch = hasattr(field.space.symbolic_space.domain.interior, 'as_tuple')
-            assert multipatch == f.space.is_multipatch   ## [MCP 27.03.2025] check: if OK, then simplify
+            
+            assert multipatch == field.space.is_multipatch   ## [MCP 27.03.2025] check: if OK, then simplify
             
             if multipatch:
                 for f in field.fields:
@@ -537,7 +538,7 @@ class OutputManager:
                             mpi_dd_gp.create_dataset(f'{name_patch}', shape=(size, *local_domain.shape), dtype='i')
                             mpi_dd_gp[name_patch][rank] = local_domain
 
-                    assert f.space.is_product ## [MCP 27.03.2025] check: if OK, then simplify
+                    assert f.space.is_product == f.space.is_vector_valued ## [MCP 27.03.2025] check: if OK, then simplify
 
                     if f.space.is_product:  # Vector field case ([MCP 27.03.2025]: I don't understand this comment... why vector ?)
                         for i, field_coeff in enumerate(f.coeffs):

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -433,7 +433,7 @@ class OutputManager:
         Parameters
         ----------
         vector_space: psydac.fem.vector.VectorFemSpace
-            Vector/Product FemSpace to add to the scope.
+            Vector FemSpace to add to the scope.
         """
         assert isinstance(vector_space, VectorFemSpace)
 

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -511,7 +511,8 @@ class OutputManager:
         # Add field coefficients as named datasets
         for name_field, field in fields.items():
             multipatch = hasattr(field.space.symbolic_space.domain.interior, 'as_tuple')
-
+            assert multipatch == f.space.is_multipatch   ## [MCP 27.03.2025] check: if OK, then simplify
+            
             if multipatch:
                 for f in field.fields:
                     i = self._spaces.index(f.space)
@@ -525,7 +526,7 @@ class OutputManager:
                             size = self.comm.Get_size()
 
 
-                            if f.space.is_product:
+                            if f.space.is_product:  # [MCP 27.03.2025] always true if multipatch... todo: simplify
                                 sp = f.space.spaces[0]
                             else:
                                 sp = f.space
@@ -536,7 +537,9 @@ class OutputManager:
                             mpi_dd_gp.create_dataset(f'{name_patch}', shape=(size, *local_domain.shape), dtype='i')
                             mpi_dd_gp[name_patch][rank] = local_domain
 
-                    if f.space.is_product:  # Vector field case
+                    assert f.space.is_product ## [MCP 27.03.2025] check: if OK, then simplify
+
+                    if f.space.is_product:  # Vector field case ([MCP 27.03.2025]: I don't understand this comment... why vector ?)
                         for i, field_coeff in enumerate(f.coeffs):
                             name_field_i = name_field + f'[{i}]'
                             name_space_i = name_space + f'[{i}]'
@@ -554,7 +557,7 @@ class OutputManager:
                                                             shape=Vi.npts, dtype=Vi.dtype)
                             dset.attrs.create('parent_field', data=name_field)
                             dset[index] = field_coeff[index]
-                    else:
+                    else:                        
                         V = f.space.vector_space
                         index = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
                         dset = saving_group.create_dataset(f'{name_patch}/{name_space}/{name_field}', shape=V.npts, dtype=V.dtype)
@@ -570,7 +573,7 @@ class OutputManager:
                         rank = self.comm.Get_rank()
                         size = self.comm.Get_size()
 
-                        if field.space.is_product:
+                        if field.space.is_product:  ## MCP 27.03.2025: simplify if above checks pass
                             sp = field.space.spaces[0]
                         else:
                             sp = field.space
@@ -581,7 +584,7 @@ class OutputManager:
                         mpi_dd_gp.create_dataset(f'{name_patch}', shape=(size, *local_domain.shape), dtype='i')
                         mpi_dd_gp[name_patch][rank] = local_domain
 
-                if field.space.is_product:  # Vector field case
+                if field.space.is_product:  # Vector field case (## MCP 27.03.2025: here indeed I would agree)
                     for i, field_coeff in enumerate(field.coeffs):
                         name_field_i = name_field + f'[{i}]'
                         name_space_i = name_space + f'[{i}]'

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -376,7 +376,9 @@ class OutputManager:
         ldim = scalar_space.ldim
         vector_space = scalar_space.vector_space
         dtype = str(vector_space.dtype)
-        periodic = scalar_space.periodic
+
+        # Use lists in YAML file instead of NumPy arrays or tuples
+        periodic = list(scalar_space.periodic)
         degree = [scalar_space.spaces[i].degree for i in range(ldim)]
         basis = [scalar_space.spaces[i].basis for i in range(ldim)]
         knots = [scalar_space.spaces[i].knots.tolist() for i in range(ldim)]

--- a/psydac/api/postprocessing.py
+++ b/psydac/api/postprocessing.py
@@ -374,8 +374,8 @@ class OutputManager:
             kind = kind
 
         ldim = scalar_space.ldim
-        vector_space = scalar_space.vector_space
-        dtype = str(vector_space.dtype)
+        coeff_space = scalar_space.coeff_space
+        dtype = str(coeff_space.dtype)
 
         # Use lists in YAML file instead of NumPy arrays or tuples
         periodic = list(scalar_space.periodic)
@@ -427,23 +427,23 @@ class OutputManager:
 
         return new_space
 
-    def _add_vector_space(self, vector_space, name=None, patch_name=None):
+    def _add_vector_space(self, coeff_space, name=None, patch_name=None):
         """
         Adds a vector space to the scope.
         Parameters
         ----------
-        vector_space: psydac.fem.vector.VectorFemSpace
+        coeff_space: psydac.fem.vector.VectorFemSpace
             Vector FemSpace to add to the scope.
         """
-        assert isinstance(vector_space, VectorFemSpace)
+        assert isinstance(coeff_space, VectorFemSpace)
 
-        symbolic_space = vector_space.symbolic_space
+        symbolic_space = coeff_space.symbolic_space
         dim = symbolic_space.domain.dim
         patch_name = patch_name
         kind = symbolic_space.kind
 
         scalar_spaces_info = []
-        for i, scalar_space in enumerate(vector_space.spaces):
+        for i, scalar_space in enumerate(coeff_space.spaces):
             sc_space_info = self._add_scalar_space(scalar_space,
                                                    name=name + f'[{i}]',
                                                    dim=dim,
@@ -542,7 +542,7 @@ class OutputManager:
                             name_field_i = name_field + f'[{i}]'
                             name_space_i = name_space + f'[{i}]'
 
-                            Vi = f.space.vector_space.spaces[i]
+                            Vi = f.space.coeff_space.spaces[i]
                             index = tuple(slice(s, e + 1) for s, e in zip(Vi.starts, Vi.ends))
 
                             try:
@@ -556,7 +556,7 @@ class OutputManager:
                             dset.attrs.create('parent_field', data=name_field)
                             dset[index] = field_coeff[index]
                     else:                        
-                        V = f.space.vector_space
+                        V = f.space.coeff_space
                         index = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
                         dset = saving_group.create_dataset(f'{name_patch}/{name_space}/{name_field}', shape=V.npts, dtype=V.dtype)
                         dset[index] = f.coeffs[index]
@@ -590,7 +590,7 @@ class OutputManager:
                         name_field_i = name_field + f'[{i}]'
                         name_space_i = name_space + f'[{i}]'
 
-                        Vi = field.space.vector_space.spaces[i]
+                        Vi = field.space.coeff_space.spaces[i]
                         index = tuple(slice(s, e + 1) for s, e in zip(Vi.starts, Vi.ends))
 
                         try:
@@ -604,7 +604,7 @@ class OutputManager:
                         dset.attrs.create('parent_field', data=name_field)
                         dset[index] = field_coeff[index]
                 else:
-                    V = field.space.vector_space
+                    V = field.space.coeff_space
                     index = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
                     dset = saving_group.create_dataset(f'{name_patch}/{name_space}/{name_field}', shape=V.npts, dtype=V.dtype)
                     dset[index] = field.coeffs[index]
@@ -915,7 +915,7 @@ class PostProcessManager:
 
             # Scalar Spaces
             for sc_sp in scalar_spaces:
-                # Check that it's not a component of a vector_space
+                # Check that it's not a component of a coeff_space
                 if sc_sp['name'] not in already_used_names:
 
                     basis = list(set(sc_sp['basis']))
@@ -1143,11 +1143,11 @@ class PostProcessManager:
                 if i != -1:
                     # Checks for empty spaces
                     if isinstance(femsp.spaces[i], TensorFemSpace):
-                        if femsp.spaces[i].vector_space.cart.comm != mpi4py.MPI.COMM_NULL:
-                            # TODO use space_f.spaces[i].vector_space.cart.is_comm_null
+                        if femsp.spaces[i].coeff_space.cart.comm != mpi4py.MPI.COMM_NULL:
+                            # TODO use space_f.spaces[i].coeff_space.cart.is_comm_null
                             available_patches.add((i_name, i_patch))
                     else:
-                        if femsp.spaces[i].spaces[0].vector_space.cart.comm != mpi4py.MPI.COMM_NULL:
+                        if femsp.spaces[i].spaces[0].coeff_space.cart.comm != mpi4py.MPI.COMM_NULL:
                             available_patches.add((i_name, i_patch))
                 else:
                     available_patches.add((i_name, i_patch))
@@ -1332,12 +1332,12 @@ class PostProcessManager:
             field = field
         if isinstance(coeff, list): # Means vector field
             for i in range(len(coeff)):
-                V = space.spaces[i].vector_space
+                V = space.spaces[i].coeff_space
                 index_coeff = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
                 field.coeffs[i][index_coeff] = coeff[i][index_coeff]
                 field.coeffs[i].update_ghost_regions()
         else:
-            V = space.vector_space
+            V = space.coeff_space
             index_coeff = tuple(slice(s, e + 1) for s, e in zip(V.starts, V.ends))
             field.coeffs[index_coeff] = coeff[index_coeff]
             field.coeffs.update_ghost_regions()
@@ -1928,11 +1928,11 @@ class PostProcessManager:
                     if not self.comm is None: # No empty spaces in serial
                         # Checks for empty spaces
                         if isinstance(space_f.spaces[i], TensorFemSpace):
-                            if space_f.spaces[i].vector_space.cart.comm == mpi4py.MPI.COMM_NULL:
-                                # TODO use space_f.spaces[i].vector_space.cart.is_comm_null
+                            if space_f.spaces[i].coeff_space.cart.comm == mpi4py.MPI.COMM_NULL:
+                                # TODO use space_f.spaces[i].coeff_space.cart.is_comm_null
                                 continue
                         else:
-                            if space_f.spaces[i].spaces[0].vector_space.cart.comm == mpi4py.MPI.COMM_NULL:
+                            if space_f.spaces[i].spaces[0].coeff_space.cart.comm == mpi4py.MPI.COMM_NULL:
                                 continue
 
                     try:

--- a/psydac/api/tests/test_2d_complex.py
+++ b/psydac/api/tests/test_2d_complex.py
@@ -424,8 +424,8 @@ def test_complex_helmholtz_2d(plot_sol=False):
     print('expected errors: l2 = {}, h1 = {}'.format(expected_l2_error, expected_h1_error))
     
     if plot_sol:
-        from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-        from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+        from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_vals
+        from psydac.fem.plotting_utilities import get_patch_knots_gridlines, my_small_plot
         from psydac.feec.pull_push                     import pull_2d_h1
         
         Id_mapping = IdentityMapping('M', 2)
@@ -536,8 +536,8 @@ if __name__ == '__main__':
 
     else:
 
-        from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-        from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+        from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_vals
+        from psydac.fem.plotting_utilities import get_patch_knots_gridlines, my_small_plot
         from psydac.api.tests.build_domain             import build_pretzel
         from psydac.feec.pull_push                     import pull_2d_hcurl
         

--- a/psydac/api/tests/test_2d_multipatch_mapping_maxwell.py
+++ b/psydac/api/tests/test_2d_multipatch_mapping_maxwell.py
@@ -254,8 +254,8 @@ if __name__ == '__main__':
 
     from collections                               import OrderedDict
     from sympy                                     import lambdify
-    from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-    from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+    from psydac.fem.plotting_utilities   import get_plotting_grid, get_grid_vals
+    from psydac.fem.plotting_utilities   import get_patch_knots_gridlines, my_small_plot
 
     domain    = build_pretzel()
     x,y       = domain.coordinates

--- a/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
+++ b/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
@@ -58,12 +58,6 @@ def run_poisson_2d(solution, f, domain, ncells=None, degree=None, filename=None,
 
     kappa  = 10**3
 
-   # expr_I =(
-   #         - dot(grad(plus(u)),nn)*minus(v)  + dot(grad(minus(v)),nn)*plus(u) - kappa*plus(u)*minus(v)
-   #         + dot(grad(minus(u)),nn)*plus(v)  - dot(grad(plus(v)),nn)*minus(u) - kappa*plus(v)*minus(u)
-   #         - dot(grad(plus(v)),nn)*plus(u)   + kappa*plus(u)*plus(v)
-   #         - dot(grad(minus(v)),nn)*minus(u) + kappa*minus(u)*minus(v))
-
     expr_I =- 0.5*dot(grad(plus(u)),nn)*minus(v)  + 0.5*dot(grad(minus(v)),nn)*plus(u)  - kappa*plus(u)*minus(v)\
             + 0.5*dot(grad(minus(u)),nn)*plus(v)  - 0.5*dot(grad(plus(v)),nn)*minus(u)  - kappa*plus(v)*minus(u)\
             - 0.5*dot(grad(minus(v)),nn)*minus(u) - 0.5*dot(grad(minus(u)),nn)*minus(v) + kappa*minus(u)*minus(v)\
@@ -160,8 +154,7 @@ def test_poisson_2d_2_patches_dirichlet_1():
     assert ( abs(h1_error - expected_h1_error) < 1e-7 )
 
 #------------------------------------------------------------------------------
-@pytest.mark.parametrize('do_plot', [False, True])
-def test_poisson_2d_2_patches_dirichlet_2(do_plot):
+def test_poisson_2d_2_patches_dirichlet_2():
 
     mapping_1 = IdentityMapping('M1', 2)
     mapping_2 = PolarMapping   ('M2', 2, c1 = 0., c2 = 0.5, rmin = 0., rmax=1.)
@@ -185,9 +178,8 @@ def test_poisson_2d_2_patches_dirichlet_2(do_plot):
 
     l2_error, h1_error, uh = run_poisson_2d(solution, f, domain, ncells=[2**2,2**2], degree=[2,2])
 
-    if do_plot:
-        plot_fn=f'uh_multi_patch_test.pdf'
-        plot_field(fem_field=uh, Vh=uh.space, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
+    plot_fn=f'uh_multipatch_poisson.pdf'
+    plot_field(fem_field=uh, Vh=uh.space, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
 
     expected_l2_error = 0.0019402242901236006
     expected_h1_error = 0.024759527393621895
@@ -403,8 +395,6 @@ if __name__ == '__main__':
 
     l2_error, h1_error, u_h = run_poisson_2d(solution, f, domain, ncells=[2**2,2**2], degree=[2,2])
 
-    # note: one could use plot_field_2d here
-    
     mappings = OrderedDict([(P.logical_domain, P.mapping) for P in domain.interior])
 
     mappings_list = list(mappings.values())

--- a/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
+++ b/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
@@ -403,9 +403,8 @@ if __name__ == '__main__':
 
     l2_error, h1_error, u_h = run_poisson_2d(solution, f, domain, ncells=[2**2,2**2], degree=[2,2])
 
-    # todo: use plot_field here..
-
-
+    # note: one could use plot_field_2d here
+    
     mappings = OrderedDict([(P.logical_domain, P.mapping) for P in domain.interior])
 
     mappings_list = list(mappings.values())

--- a/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
+++ b/psydac/api/tests/test_2d_multipatch_mapping_poisson.py
@@ -22,6 +22,7 @@ from sympde.expr.equation import find, EssentialBC
 from psydac.api.discretization     import discretize
 from psydac.api.tests.build_domain import build_pretzel
 from psydac.api.settings           import PSYDAC_BACKEND_GPYCCEL
+from psydac.fem.plotting_utilities import plot_field_2d as plot_field
 
 # ... get the mesh directory
 try:
@@ -159,7 +160,8 @@ def test_poisson_2d_2_patches_dirichlet_1():
     assert ( abs(h1_error - expected_h1_error) < 1e-7 )
 
 #------------------------------------------------------------------------------
-def test_poisson_2d_2_patches_dirichlet_2():
+@pytest.mark.parametrize('do_plot', [False, True])
+def test_poisson_2d_2_patches_dirichlet_2(do_plot):
 
     mapping_1 = IdentityMapping('M1', 2)
     mapping_2 = PolarMapping   ('M2', 2, c1 = 0., c2 = 0.5, rmin = 0., rmax=1.)
@@ -182,6 +184,10 @@ def test_poisson_2d_2_patches_dirichlet_2():
     f         = -4
 
     l2_error, h1_error, uh = run_poisson_2d(solution, f, domain, ncells=[2**2,2**2], degree=[2,2])
+
+    if do_plot:
+        plot_fn=f'uh_multi_patch_test.pdf'
+        plot_field(fem_field=uh, Vh=uh.space, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
 
     expected_l2_error = 0.0019402242901236006
     expected_h1_error = 0.024759527393621895
@@ -386,8 +392,8 @@ def teardown_function():
 
 if __name__ == '__main__':
 
-    from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_vals
-    from psydac.feec.multipatch.plotting_utilities import get_patch_knots_gridlines, my_small_plot
+    from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_vals
+    from psydac.fem.plotting_utilities import get_patch_knots_gridlines, my_small_plot
     from collections                               import OrderedDict
 
     domain    = build_pretzel()
@@ -396,6 +402,9 @@ if __name__ == '__main__':
     f         = -4
 
     l2_error, h1_error, u_h = run_poisson_2d(solution, f, domain, ncells=[2**2,2**2], degree=[2,2])
+
+    # todo: use plot_field here..
+
 
     mappings = OrderedDict([(P.logical_domain, P.mapping) for P in domain.interior])
 

--- a/psydac/api/tests/test_2d_navier_stokes.py
+++ b/psydac/api/tests/test_2d_navier_stokes.py
@@ -451,13 +451,19 @@ def teardown_function():
 #------------------------------------------------------------------------------
 if __name__ == '__main__':
 
+    # do some handpicked tests
+
     verify = 'st_navier_stokes_2d'
+    # verify = 'st_navier_stokes_2d_parallel'
 
     if verify == 'st_navier_stokes_2d':
+        print('Running test_st_navier_stokes_2d()')
+        test_st_navier_stokes_2d()
+    
+    elif verify == 'st_navier_stokes_2d_parallel':
         print('Running test_st_navier_stokes_2d_parallel()')
         test_st_navier_stokes_2d_parallel()
-        # test_st_navier_stokes_2d()
-    
+        
     else:
     
         import matplotlib.pyplot as plt

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -21,7 +21,6 @@ from sympde.expr import Norm
 from sympde.expr import find, EssentialBC
 
 from psydac.fem.basic          import FemField
-from psydac.fem.vector         import ProductFemSpace
 from psydac.api.discretization import discretize
 from psydac.linalg.utilities   import array_to_psydac
 from psydac.linalg.solvers     import inverse

--- a/psydac/api/tests/test_api_2d_compatible_spaces.py
+++ b/psydac/api/tests/test_api_2d_compatible_spaces.py
@@ -76,7 +76,7 @@ def run_poisson_mixed_form_2d_dir(f0, sol, ncells, degree):
     rhs = ah.linear_system.rhs.toarray()
 
     x   = spsolve(M, rhs)
-    x   = array_to_psydac(x, Xh.vector_space)
+    x   = array_to_psydac(x, Xh.coeff_space)
     
     # ...
     Fh = FemField( V2h )
@@ -158,7 +158,7 @@ def run_stokes_2d_dir(domain, f, ue, pe, *, homogeneous, ncells, degree, scipy=F
             print('Solution with scipy.sparse: success = {}'.format(info == 0))
 
         # Convert to stencil format
-        x = array_to_psydac(x, Xh.vector_space)
+        x = array_to_psydac(x, Xh.coeff_space)
 
     else:
         equation_h.set_solver('cg', info=True)
@@ -302,7 +302,7 @@ def run_stokes_2d_dir_petsc(domain, f, ue, pe, *, homogeneous, ncells, degree):
         print('Solution with petsc4py: success = {}'.format(ksp.is_converged))
 
 
-    x = petsc_to_psydac(x, Xh.vector_space)
+    x = petsc_to_psydac(x, Xh.coeff_space)
     # Numerical solution: velocity field
     # TODO: allow this: uh = FemField(V1h, coeffs=x[0:2]) or similar
     uh = FemField(V1h)

--- a/psydac/api/tests/test_api_2d_fields.py
+++ b/psydac/api/tests/test_api_2d_fields.py
@@ -107,7 +107,7 @@ def run_field_test(filename, f, do_plot=False):
     a2   = BilinearForm( (u,v), integral(domain, f*u*v))
     a1_h = discretize(a1, domain_h,  [Vh, Vh])
     a2_h = discretize(a2, domain_h,  [Vh, Vh])
-              
+
     x1 = l1_h.assemble(F=uh)
     x2 = l2_h.assemble()
 
@@ -127,7 +127,7 @@ def run_boundary_field_test(domain, boundary, f, ncells):
     F  = element_of(V, name='F')
 
     nn = NormalVector('nn')
-    
+
     # Bilinear form a: V x V --> R
     aF = BilinearForm((u, v), integral(boundary, F * u * v))
     af = BilinearForm((u, v), integral(boundary, f * u * v))
@@ -138,7 +138,7 @@ def run_boundary_field_test(domain, boundary, f, ncells):
     # Linear form l: V --> R
     lF   = LinearForm( v, integral(boundary, F*v))
     lf   = LinearForm( v, integral(boundary, f*v))
-    
+
     l_grad_F   = LinearForm( v, integral(boundary, dot(grad(F), nn) * v))
     l_grad_f   = LinearForm( v, integral(boundary, dot(grad(f), nn) * v))
 
@@ -147,14 +147,14 @@ def run_boundary_field_test(domain, boundary, f, ncells):
 
     x,y = domain.coordinates
     f_lambda = lambdify([x,y], f, 'math')
-    Pi0 = Projector_H1(Vh) 
+    Pi0 = Projector_H1(Vh)
     fh = Pi0(f_lambda)
     fh.coeffs.update_ghost_regions()
 
     aF_h = discretize(aF, domain_h, [Vh, Vh])
     af_h = discretize(af, domain_h, [Vh, Vh])
     aF_x = aF_h.assemble(F=fh)
-    af_x = af_h.assemble()    
+    af_x = af_h.assemble()
 
     a_grad_F_h = discretize(a_grad_F, domain_h, [Vh, Vh])
     a_grad_f_h = discretize(a_grad_f, domain_h, [Vh, Vh])
@@ -269,7 +269,7 @@ TOL = 1e-12
 @pytest.mark.parametrize('axis', [0, 1])
 @pytest.mark.parametrize('ext', [-1, 1])
 def test_boundary_field_identity(n1, axis, ext):
-    
+
     domain = Square('domain', bounds1=(0., 0.5), bounds2=(0., 1.))
     boundary = domain.get_boundary(axis=axis, ext=ext)
 
@@ -282,7 +282,7 @@ def test_boundary_field_identity(n1, axis, ext):
     assert rel_error_BilinearForm_grad < TOL
     assert rel_error_LinearForm < TOL
     assert rel_error_LinearForm_grad < TOL
-    
+
 
 def test_field_identity_1():
 

--- a/psydac/api/tests/test_api_2d_fields.py
+++ b/psydac/api/tests/test_api_2d_fields.py
@@ -94,7 +94,7 @@ def run_field_test(filename, f, do_plot=False):
     uh = equation_h.solve()
 
     if do_plot:
-        plot_fn=f'uh_{filename}_test.pdf'
+        plot_fn=f'uh_single_patch_test.pdf'
         plot_field(fem_field=uh, Vh=Vh, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
 
     #+++++++++++++++++++++++++++++++

--- a/psydac/api/tests/test_api_2d_fields.py
+++ b/psydac/api/tests/test_api_2d_fields.py
@@ -36,7 +36,6 @@ from psydac.fem.basic              import FemField
 from psydac.api.discretization     import discretize
 from psydac.api.settings           import PSYDAC_BACKEND_GPYCCEL
 from psydac.feec.global_projectors import Projector_H1
-from psydac.fem.plotting_utilities import plot_field_2d as plot_field
 
 # ... get the mesh directory
 try:
@@ -50,7 +49,7 @@ except:
 x, y = symbols('x, y', real=True)
 
 #------------------------------------------------------------------------------
-def run_field_test(filename, f, do_plot=False):
+def run_field_test(filename, f):
 
     #+++++++++++++++++++++++++++++++
     # 1. Abstract model
@@ -92,10 +91,6 @@ def run_field_test(filename, f, do_plot=False):
     # Solve linear system
     # uh is the L2-projection of the analytical field "f"
     uh = equation_h.solve()
-
-    if do_plot:
-        plot_fn=f'uh_single_patch_test.pdf'
-        plot_field(fem_field=uh, Vh=Vh, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
 
     #+++++++++++++++++++++++++++++++
     l1   = LinearForm( v, integral(domain, F*v))
@@ -326,15 +321,14 @@ def test_field_collela():
     assert abs(error_2 - expected_error_2) < 1.e-7
 
 #------------------------------------------------------------------------------
-@pytest.mark.parametrize('do_plot', [False, True])
-def test_field_quarter_annulus(do_plot):
+def test_field_quarter_annulus():
 
     filename = os.path.join(mesh_dir, 'quarter_annulus.h5')
     c        = pi / (1. - 0.5**2)
     r2       = 1. - x**2 - y**2
     f        = x*y*sin(c * r2)
 
-    error_1, error_2 = run_field_test(filename, f, do_plot=do_plot)
+    error_1, error_2 = run_field_test(filename, f)
 
     expected_error_1 =  1.1146377538410329e-10
     expected_error_2 =  9.18920469410037e-08
@@ -365,4 +359,4 @@ def teardown_function():
     cache.clear_cache()
 
 if __name__ == '__main__':
-    test_field_quarter_annulus(do_plot=True)
+    test_field_quarter_annulus()

--- a/psydac/api/tests/test_api_2d_fields.py
+++ b/psydac/api/tests/test_api_2d_fields.py
@@ -36,6 +36,8 @@ from psydac.fem.basic              import FemField
 from psydac.api.discretization     import discretize
 from psydac.api.settings           import PSYDAC_BACKEND_GPYCCEL
 from psydac.feec.global_projectors import Projector_H1
+from psydac.fem.plotting_utilities import plot_field_2d as plot_field
+
 # ... get the mesh directory
 try:
     mesh_dir = os.environ['PSYDAC_MESH_DIR']
@@ -48,7 +50,7 @@ except:
 x, y = symbols('x, y', real=True)
 
 #------------------------------------------------------------------------------
-def run_field_test(filename, f):
+def run_field_test(filename, f, do_plot=False):
 
     #+++++++++++++++++++++++++++++++
     # 1. Abstract model
@@ -90,6 +92,10 @@ def run_field_test(filename, f):
     # Solve linear system
     # uh is the L2-projection of the analytical field "f"
     uh = equation_h.solve()
+
+    if do_plot:
+        plot_fn=f'uh_{filename}_test.pdf'
+        plot_field(fem_field=uh, Vh=Vh, domain=domain, title='uh', filename=plot_fn, hide_plot=True)
 
     #+++++++++++++++++++++++++++++++
     l1   = LinearForm( v, integral(domain, F*v))
@@ -320,14 +326,15 @@ def test_field_collela():
     assert abs(error_2 - expected_error_2) < 1.e-7
 
 #------------------------------------------------------------------------------
-def test_field_quarter_annulus():
+@pytest.mark.parametrize('do_plot', [False, True])
+def test_field_quarter_annulus(do_plot):
 
     filename = os.path.join(mesh_dir, 'quarter_annulus.h5')
     c        = pi / (1. - 0.5**2)
     r2       = 1. - x**2 - y**2
     f        = x*y*sin(c * r2)
 
-    error_1, error_2 = run_field_test(filename, f)
+    error_1, error_2 = run_field_test(filename, f, do_plot=do_plot)
 
     expected_error_1 =  1.1146377538410329e-10
     expected_error_2 =  9.18920469410037e-08
@@ -356,3 +363,6 @@ def teardown_module():
 def teardown_function():
     from sympy.core import cache
     cache.clear_cache()
+
+if __name__ == '__main__':
+    test_field_quarter_annulus(do_plot=True)

--- a/psydac/api/tests/test_api_feec_1d.py
+++ b/psydac/api/tests/test_api_feec_1d.py
@@ -344,8 +344,8 @@ def run_maxwell_1d(*, L, eps, ncells, degree, periodic, Cp, nsteps, tend,
 
     half_step_faraday_1d = (dt/2) * D0
 
-    de = derham_h.V0.vector_space.zeros()
-    db = derham_h.V1.vector_space.zeros()
+    de = derham_h.V0.coeff_space.zeros()
+    db = derham_h.V1.coeff_space.zeros()
 
     # Time loop
     for i in range(nsteps):

--- a/psydac/api/tests/test_api_feec_2d.py
+++ b/psydac/api/tests/test_api_feec_2d.py
@@ -529,8 +529,8 @@ def run_maxwell_2d_TE(*, use_spline_mapping,
     half_step_faraday_2d = (dt/2) * D1
     #minus_half_step_faraday_2d = (-dt/2) * D1
 
-    de = derham_h.V1.vector_space.zeros()
-    db = derham_h.V2.vector_space.zeros()
+    de = derham_h.V1.coeff_space.zeros()
+    db = derham_h.V2.coeff_space.zeros()
 
     # Time loop
     for ts in range(1, nsteps+1):

--- a/psydac/api/tests/test_api_feec_3d.py
+++ b/psydac/api/tests/test_api_feec_3d.py
@@ -152,7 +152,7 @@ def run_maxwell_3d_scipy(logical_domain, mapping, e_ex, b_ex, ncells, degree, pe
     e_history, b_history = splitting_integrator_scipy(e0_coeff.toarray(), b0_coeff.toarray(), M1, M2, CURL, dt, niter)
 
     # study of fields
-    b_history = [array_to_psydac(bi, derham_h.V2.vector_space) for bi in b_history]
+    b_history = [array_to_psydac(bi, derham_h.V2.coeff_space) for bi in b_history]
     b_fields  = [FemField(derham_h.V2, bi).fields for bi in b_history]
 
     bx_fields = [bi[0] for bi in b_fields]

--- a/psydac/api/tests/test_api_glt_2d_scalar.py
+++ b/psydac/api/tests/test_api_glt_2d_scalar.py
@@ -119,7 +119,7 @@ def run_field_2d_dir(ncells, degree, comm=None):
     # ...
 
     # ...
-    x = Vh.vector_space.zeros()
+    x = Vh.coeff_space.zeros()
     x[:] = 1.
 
     phi = FemField( Vh, x )

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -508,8 +508,8 @@ def test_assembly_no_synchr_args(backend):
     func  = Functional(rho, domain)
     func_h = discretize(func, domain_h, V1h, **kwargs)
 
-    uh      = array_to_psydac(np.array([i for i in range(nc)]), V0h.vector_space)
-    const_1 = array_to_psydac(np.array([1/nc]*nc), V1h.vector_space)
+    uh      = array_to_psydac(np.array([i for i in range(nc)]), V0h.coeff_space)
+    const_1 = array_to_psydac(np.array([1/nc]*nc), V1h.coeff_space)
 
     rhoh1 = div.dot(uh)
     rhof1 = FemField(V1h, rhoh1)

--- a/psydac/cad/cad.py
+++ b/psydac/cad/cad.py
@@ -28,8 +28,8 @@ def translate(mapping, displ):
     fields = [FemField( space ) for d in range( pdim )]
 
     # Get spline coefficients for each coordinate X_i
-    starts = space.vector_space.starts
-    ends   = space.vector_space.ends
+    starts = space.coeff_space.starts
+    ends   = space.coeff_space.ends
     idx_to = tuple( slice( s, e+1 ) for s,e in zip( starts, ends ) )
     for i,field in enumerate( fields ):
         idx_from = tuple(list(idx_to)+[i])
@@ -82,8 +82,8 @@ def elevate(mapping, axis, times):
     fields = [FemField( space ) for d in range( pdim )]
 
     # Get spline coefficients for each coordinate X_i
-    starts = space.vector_space.starts
-    ends   = space.vector_space.ends
+    starts = space.coeff_space.starts
+    ends   = space.coeff_space.ends
     idx_to = tuple( slice( s, e+1 ) for s,e in zip( starts, ends ) )
     for i,field in enumerate( fields ):
         idx_from = tuple(list(idx_to)+[i])
@@ -160,8 +160,8 @@ def refine(mapping, axis, values):
     fields = [FemField( space ) for d in range( pdim )]
 
     # Get spline coefficients for each coordinate X_i
-    starts = space.vector_space.starts
-    ends   = space.vector_space.ends
+    starts = space.coeff_space.starts
+    ends   = space.coeff_space.ends
     idx_to = tuple( slice( s, e+1 ) for s,e in zip( starts, ends ) )
     for i,field in enumerate( fields ):
         idx_from = tuple(list(idx_to)+[i])

--- a/psydac/cad/geometry.py
+++ b/psydac/cad/geometry.py
@@ -457,7 +457,7 @@ class Geometry( object ):
 
             # Create group for patch 0
             group = h5.create_group( yml['patches'][i_mapping]['mapping_id'] )
-            group.attrs['shape'      ] = space.vector_space.npts
+            group.attrs['shape'      ] = space.coeff_space.npts
             group.attrs['degree'     ] = space.degree
             group.attrs['rational'   ] = False # TODO remove
             group.attrs['periodic'   ] = space.periodic
@@ -465,13 +465,13 @@ class Geometry( object ):
                 group['knots_{}'.format( d )] = space.spaces[d].knots
 
             # Collective: create dataset for control points
-            shape = [n for n in space.vector_space.npts] + [self.pdim]
-            dtype = space.vector_space.dtype
+            shape = [n for n in space.coeff_space.npts] + [self.pdim]
+            dtype = space.coeff_space.dtype
             dset  = group.create_dataset( 'points', shape=shape, dtype=dtype )
 
             # Independent: write control points to dataset
-            starts = space.vector_space.starts
-            ends   = space.vector_space.ends
+            starts = space.coeff_space.starts
+            ends   = space.coeff_space.ends
             index  = [slice(s, e+1) for s, e in zip(starts, ends)] + [slice(None)]
             index  = tuple( index )
             dset[index] = mapping.control_points[index]
@@ -479,13 +479,13 @@ class Geometry( object ):
             # case of NURBS
             if isinstance(mapping, NurbsMapping):
                 # Collective: create dataset for weights
-                shape = [n for n in space.vector_space.npts]
-                dtype = space.vector_space.dtype
+                shape = [n for n in space.coeff_space.npts]
+                dtype = space.coeff_space.dtype
                 dset  = group.create_dataset( 'weights', shape=shape, dtype=dtype )
 
                 # Independent: write weights to dataset
-                starts = space.vector_space.starts
-                ends   = space.vector_space.ends
+                starts = space.coeff_space.starts
+                ends   = space.coeff_space.ends
                 index  = [slice(s, e+1) for s, e in zip(starts, ends)]
                 index  = tuple( index )
                 dset[index] = mapping.weights[index]

--- a/psydac/core/tests/test_field_evaluation_kernel.py
+++ b/psydac/core/tests/test_field_evaluation_kernel.py
@@ -93,7 +93,7 @@ def test_regular_jacobians(geometry, npts_per_cell):
                                             1,
                                             space_h.spaces[i].basis) for i in range(ldim)
                     ]
-    v = space_h.vector_space
+    v = space_h.coeff_space
     global_spans = [elements_spans(knots[i], degree[i]) - v.starts[i] + v.shifts[i] * v.pads[i] for i in range(ldim)]
 
     shape_grid = tuple(ncells[i] * npts_per_cell for i in range(ldim))
@@ -232,7 +232,7 @@ def test_irregular_jacobians(geometry, npts):
                                                  1,
                                                  space_h.spaces[i].basis) for i in range(ldim)
                     ]
-    v = space_h.vector_space
+    v = space_h.coeff_space
     global_spans = [elements_spans(knots[i], degree[i]) - v.starts[i] + v.shifts[i] * v.pads[i] for i in range(ldim)]
 
     npts = (npts,) * ldim
@@ -445,7 +445,7 @@ def test_regular_evaluations(knots, ldim, degree, npts_per_cell):
                                             0,
                                             space_h.spaces[i].basis) for i in range(ldim)
                     ]
-    v = space_h.vector_space
+    v = space_h.coeff_space
     global_spans = [elements_spans(knots[i], degree[i]) - v.starts[i] + v.shifts[i] * v.pads[i] for i in range(ldim)]
 
     n_eval_points = (npts_per_cell,) * ldim
@@ -607,7 +607,7 @@ def test_irregular_evaluations(knots, ldim, degree, npts):
                                                  0,
                                                  space_h.spaces[i].basis) for i in range(ldim)
                     ]
-    v = space_h.vector_space
+    v = space_h.coeff_space
     global_spans = [elements_spans(knots[i], degree[i]) - v.starts[i] + v.shifts[i] * v.pads[i] for i in range(ldim)]
 
     npts = (npts,) * ldim

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -6,7 +6,7 @@ import scipy.sparse as spa
 from psydac.linalg.stencil  import StencilVector, StencilMatrix, StencilVectorSpace
 from psydac.linalg.kron     import KroneckerStencilMatrix
 from psydac.linalg.block    import BlockVector, BlockLinearOperator
-from psydac.fem.vector      import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector      import VectorFemSpace
 from psydac.fem.tensor      import TensorFemSpace
 from psydac.linalg.basic    import IdentityOperator
 from psydac.fem.basic       import FemField, FemSpace

--- a/psydac/feec/derivatives.py
+++ b/psydac/feec/derivatives.py
@@ -366,8 +366,8 @@ class DiffOperator:
         assert isinstance(domain, FemSpace)
         assert isinstance(codomain, FemSpace)
         assert isinstance(matrix, LinearOperator)
-        assert domain.vector_space is matrix.domain
-        assert codomain.vector_space is matrix.codomain
+        assert domain.coeff_space is matrix.domain
+        assert codomain.coeff_space is matrix.codomain
 
         self._domain = domain
         self._codomain = codomain
@@ -415,7 +415,7 @@ class Derivative_1D(DiffOperator):
         assert H1.degree[0] == L2.degree[0] + 1
 
         # Store data in object   
-        super().__init__(H1, L2, DirectionalDerivativeOperator(H1.vector_space, L2.vector_space, 0))
+        super().__init__(H1, L2, DirectionalDerivativeOperator(H1.coeff_space, L2.coeff_space, 0))
 
 #====================================================================================================
 class Gradient_2D(DiffOperator):
@@ -443,15 +443,15 @@ class Gradient_2D(DiffOperator):
         assert tuple(Hcurl.spaces[1].degree) == (H1.degree[0]  , H1.degree[1]-1)
 
         # Tensor-product spaces of coefficients - domain
-        B_B = H1.vector_space
+        B_B = H1.coeff_space
 
         # Tensor-product spaces of coefficients - codomain
-        (M_B, B_M) = Hcurl.vector_space.spaces
+        (M_B, B_M) = Hcurl.coeff_space.spaces
 
         # Build Gradient matrix block by block
         blocks = [[DirectionalDerivativeOperator(B_B, M_B, 0)],
                   [DirectionalDerivativeOperator(B_B, B_M, 1)]]
-        matrix = BlockLinearOperator(H1.vector_space, Hcurl.vector_space, blocks=blocks)
+        matrix = BlockLinearOperator(H1.coeff_space, Hcurl.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(H1, Hcurl, matrix)
@@ -485,16 +485,16 @@ class Gradient_3D(DiffOperator):
         assert tuple(Hcurl.spaces[2].degree) == (H1.degree[0]  , H1.degree[1]  , H1.degree[2]-1)
 
         # Tensor-product spaces of coefficients - domain
-        B_B_B = H1.vector_space
+        B_B_B = H1.coeff_space
 
         # Tensor-product spaces of coefficients - codomain
-        (M_B_B, B_M_B, B_B_M) = Hcurl.vector_space.spaces
+        (M_B_B, B_M_B, B_B_M) = Hcurl.coeff_space.spaces
 
         # Build Gradient matrix block by block
         blocks = [[DirectionalDerivativeOperator(B_B_B, M_B_B, 0)],
                   [DirectionalDerivativeOperator(B_B_B, B_M_B, 1)],
                   [DirectionalDerivativeOperator(B_B_B, B_B_M, 2)]]
-        matrix = BlockLinearOperator(H1.vector_space, Hcurl.vector_space, blocks=blocks)
+        matrix = BlockLinearOperator(H1.coeff_space, Hcurl.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(H1, Hcurl, matrix)
@@ -525,15 +525,15 @@ class ScalarCurl_2D(DiffOperator):
         assert tuple(Hcurl.spaces[1].degree) == (L2.degree[0]+1, L2.degree[1]  )
 
         # Tensor-product spaces of coefficients - domain
-        (M_B, B_M) = Hcurl.vector_space.spaces
+        (M_B, B_M) = Hcurl.coeff_space.spaces
 
         # Tensor-product spaces of coefficients - codomain
-        M_M = L2.vector_space
+        M_M = L2.coeff_space
 
         # Build Curl matrix block by block
         blocks = [[-DirectionalDerivativeOperator(M_B, M_M, 1),
                   DirectionalDerivativeOperator(B_M, M_M, 0)]]
-        matrix = BlockLinearOperator(Hcurl.vector_space, L2.vector_space, blocks=blocks)
+        matrix = BlockLinearOperator(Hcurl.coeff_space, L2.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(Hcurl, L2, matrix)
@@ -565,15 +565,15 @@ class VectorCurl_2D(DiffOperator):
         assert tuple(Hdiv.spaces[1].degree) == (H1.degree[0]-1, H1.degree[1]  )
 
         # Tensor-product spaces of coefficients - domain
-        B_B = H1.vector_space
+        B_B = H1.coeff_space
 
         # Tensor-product spaces of coefficients - codomain
-        (B_M, M_B) = Hdiv.vector_space.spaces
+        (B_M, M_B) = Hdiv.coeff_space.spaces
 
         # Build Curl matrix block by block
         blocks = [[DirectionalDerivativeOperator(B_B, B_M, 1)],
                   [-DirectionalDerivativeOperator(B_B, M_B, 0)]]
-        matrix = BlockLinearOperator(H1.vector_space, Hdiv.vector_space, blocks=blocks)
+        matrix = BlockLinearOperator(H1.coeff_space, Hdiv.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(H1, Hdiv, matrix)
@@ -610,10 +610,10 @@ class Curl_3D(DiffOperator):
         assert tuple(Hcurl.spaces[1].degree) == (Hdiv2.degree[0]+1, Hdiv2.degree[1]  , Hdiv2.degree[2]  )
 
         # Tensor-product spaces of coefficients - domain
-        (M_B_B, B_M_B, B_B_M) = Hcurl.vector_space.spaces
+        (M_B_B, B_M_B, B_B_M) = Hcurl.coeff_space.spaces
 
         # Tensor-product spaces of coefficients - codomain
-        (B_M_M, M_B_M, M_M_B) = Hdiv.vector_space.spaces
+        (B_M_M, M_B_M, M_M_B) = Hdiv.coeff_space.spaces
 
         # ...
         # Build Curl matrix block by block
@@ -622,7 +622,7 @@ class Curl_3D(DiffOperator):
                   [ D(M_B_B, M_B_M, 2) ,        None,          -D(B_B_M, M_B_M, 0)],
                   [-D(M_B_B, M_M_B, 1) ,  D(B_M_B, M_M_B, 0) ,        None        ]]
 
-        matrix = BlockLinearOperator(Hcurl.vector_space, Hdiv.vector_space, blocks=blocks)
+        matrix = BlockLinearOperator(Hcurl.coeff_space, Hdiv.coeff_space, blocks=blocks)
         # ...
 
         # Store data in object        
@@ -654,15 +654,15 @@ class Divergence_2D(DiffOperator):
         assert tuple(Hdiv.spaces[1].degree) == (L2.degree[0]  , L2.degree[1]+1)
 
         # Tensor-product spaces of coefficients - domain
-        (B_M, M_B) = Hdiv.vector_space.spaces
+        (B_M, M_B) = Hdiv.coeff_space.spaces
 
         # Tensor-product spaces of coefficients - codomain
-        M_M = L2.vector_space
+        M_M = L2.coeff_space
 
         # Build Divergence matrix block by block
         f = KroneckerStencilMatrix
         blocks = [[DirectionalDerivativeOperator(B_M, M_M, 0), DirectionalDerivativeOperator(M_B, M_M, 1)]]
-        matrix = BlockLinearOperator(Hdiv.vector_space, L2.vector_space, blocks=blocks) 
+        matrix = BlockLinearOperator(Hdiv.coeff_space, L2.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(Hdiv, L2, matrix)
@@ -695,16 +695,16 @@ class Divergence_3D(DiffOperator):
         assert tuple(Hdiv.spaces[2].degree) == (L2.degree[0]  , L2.degree[1]  , L2.degree[2]+1)
 
         # Tensor-product spaces of coefficients - domain
-        (B_M_M, M_B_M, M_M_B) = Hdiv.vector_space.spaces
+        (B_M_M, M_B_M, M_M_B) = Hdiv.coeff_space.spaces
 
         # Tensor-product spaces of coefficients - codomain
-        M_M_M = L2.vector_space
+        M_M_M = L2.coeff_space
 
         # Build Divergence matrix block by block
         blocks = [[DirectionalDerivativeOperator(B_M_M, M_M_M, 0),
                    DirectionalDerivativeOperator(M_B_M, M_M_M, 1),
                    DirectionalDerivativeOperator(M_M_B, M_M_M, 2)]]
-        matrix = BlockLinearOperator(Hdiv.vector_space, L2.vector_space, blocks=blocks) 
+        matrix = BlockLinearOperator(Hdiv.coeff_space, L2.coeff_space, blocks=blocks)
 
         # Store data in object   
         super().__init__(Hdiv, L2, matrix)

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -659,7 +659,7 @@ class Projector_H1vec(GlobalProjector):
     
     Parameters
     ----------
-    H1vec : FemSpace
+    H1vec : VectorFemSpace
         H1 x H1 x H1-conforming finite element space, codomain of the projection
         operator.
         
@@ -983,4 +983,3 @@ def evaluate_dofs_3d_vec(
         for i2 in range(n2):
             for i3 in range(n3):
                 F3[i1, i2, i3] = f3(intp_x1[i1], intp_x2[i2], intp_x3[i3])
-

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -659,7 +659,7 @@ class Projector_H1vec(GlobalProjector):
     
     Parameters
     ----------
-    H1vec : ProductFemSpace
+    H1vec : FemSpace
         H1 x H1 x H1-conforming finite element space, codomain of the projection
         operator.
         

--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -57,7 +57,7 @@ class GlobalProjector(metaclass=ABCMeta):
 
     def __init__(self, space, nquads = None):
         self._space = space
-        self._rhs = space.vector_space.zeros()
+        self._rhs = space.coeff_space.zeros()
 
         if isinstance(space, TensorFemSpace):
             tensorspaces = [space]
@@ -135,12 +135,12 @@ class GlobalProjector(metaclass=ABCMeta):
                 # for each direction in the tensor space (i.e. each SplineSpace):
 
                 V = tensorspaces[i].spaces[j]
-                s = tensorspaces[i].vector_space.starts[j]
-                e = tensorspaces[i].vector_space.ends[j]
-                p = tensorspaces[i].vector_space.pads[j]
-                n = tensorspaces[i].vector_space.npts[j]
+                s = tensorspaces[i].coeff_space.starts[j]
+                e = tensorspaces[i].coeff_space.ends[j]
+                p = tensorspaces[i].coeff_space.pads[j]
+                n = tensorspaces[i].coeff_space.npts[j]
                 m = tensorspaces[i].multiplicity[j]
-                periodic = tensorspaces[i].vector_space.periods[j]
+                periodic = tensorspaces[i].coeff_space.periods[j]
                 ncells = tensorspaces[i].ncells[j]
                 blocks[-1] += [None] # fill blocks with None, fill the diagonals later
 
@@ -218,9 +218,9 @@ class GlobalProjector(metaclass=ABCMeta):
             
             # build Kronecker out of single directions    
             if isinstance(self.space, TensorFemSpace):
-                matrixblocks += [KroneckerStencilMatrix(self.space.vector_space, self.space.vector_space, *matrixcells)]
+                matrixblocks += [KroneckerStencilMatrix(self.space.coeff_space, self.space.coeff_space, *matrixcells)]
             else:
-                matrixblocks += [KroneckerStencilMatrix(self.space.vector_space[i], self.space.vector_space[i], *matrixcells)]
+                matrixblocks += [KroneckerStencilMatrix(self.space.coeff_space[i], self.space.coeff_space[i], *matrixcells)]
 
             # fill the diagonals for BlockLinearOperator
             blocks[i][i] = matrixblocks[-1]
@@ -229,16 +229,16 @@ class GlobalProjector(metaclass=ABCMeta):
             self._grid_x += [block_x]
             self._grid_w += [block_w]
 
-            solverblocks += [KroneckerLinearSolver(tensorspaces[i].vector_space, tensorspaces[i].vector_space, solvercells)]
+            solverblocks += [KroneckerLinearSolver(tensorspaces[i].coeff_space, tensorspaces[i].coeff_space, solvercells)]
 
-            dataslice = tuple(slice(p*m, -p*m) for p, m in zip(tensorspaces[i].vector_space.pads,tensorspaces[i].vector_space.shifts))
+            dataslice = tuple(slice(p*m, -p*m) for p, m in zip(tensorspaces[i].coeff_space.pads,tensorspaces[i].coeff_space.shifts))
             dofs[i] = rhsblocks[i]._data[dataslice]
             
         # build final Inter-/Histopolation matrix (distributed)        
         if isinstance(self.space, TensorFemSpace):
             self._imat_kronecker = matrixblocks[0]
         else:
-            self._imat_kronecker = BlockLinearOperator(self.space.vector_space, self.space.vector_space, 
+            self._imat_kronecker = BlockLinearOperator(self.space.coeff_space, self.space.coeff_space,
                                                        blocks=blocks)
         
         # finish arguments and create a lambda
@@ -249,7 +249,7 @@ class GlobalProjector(metaclass=ABCMeta):
         if len(solverblocks) == 1:
             self._solver = solverblocks[0]
         else:
-            domain = codomain = self._space.vector_space
+            domain = codomain = self._space.coeff_space
             blocks = {(i, i): B_i for i, B_i in enumerate(solverblocks)}
             self._solver = BlockLinearOperator(domain, codomain, blocks)
     

--- a/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
@@ -217,16 +217,16 @@ def solve_h1_source_pbm(
         OM.add_spaces(V0h=V0h)
         OM.set_static()
 
-        stencil_coeffs = array_to_psydac(uh_c, V0h.vector_space)
+        stencil_coeffs = array_to_psydac(uh_c, V0h.coeff_space)
         vh = FemField(V0h, coeffs=stencil_coeffs)
         OM.export_fields(vh=vh)
 
-        stencil_coeffs = array_to_psydac(f_c, V0h.vector_space)
+        stencil_coeffs = array_to_psydac(f_c, V0h.coeff_space)
         fh = FemField(V0h, coeffs=stencil_coeffs)
         OM.export_fields(fh=fh)
         
         if u_ex:
-            stencil_coeffs = array_to_psydac(u_ex_c, V0h.vector_space)
+            stencil_coeffs = array_to_psydac(u_ex_c, V0h.coeff_space)
             uh_ex = FemField(V0h, coeffs=stencil_coeffs)
             OM.export_fields(uh_ex=uh_ex)
 

--- a/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/h1_source_pbms_conga_2d.py
@@ -35,7 +35,6 @@ from psydac.feec.multipatch.utils_conga_2d import P0_phys
 
 from psydac.feec.multipatch.fem_linear_operators import IdLinearOperator
 from psydac.feec.multipatch.operators import HodgeOperator
-from psydac.feec.multipatch.plotting_utilities import plot_field
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 from psydac.feec.multipatch.examples.ppc_test_cases import get_source_and_solution_h1
 from psydac.feec.multipatch.utilities import time_count

--- a/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
@@ -14,7 +14,6 @@ from psydac.api.settings import PSYDAC_BACKENDS
 from psydac.feec.multipatch.fem_linear_operators import IdLinearOperator
 from psydac.feec.multipatch.operators import HodgeOperator
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
-from psydac.feec.multipatch.plotting_utilities import plot_field
 from psydac.feec.multipatch.utilities import time_count, get_run_dir, get_plot_dir, get_mat_dir, get_sol_dir, diag_fn
 from psydac.feec.multipatch.utils_conga_2d import write_diags_to_file
 

--- a/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
@@ -20,7 +20,6 @@ from psydac.feec.multipatch.utils_conga_2d import write_diags_to_file
 
 from sympde.topology import Square
 from sympde.topology import IdentityMapping, PolarMapping
-from psydac.fem.vector import ProductFemSpace
 
 from scipy.sparse.linalg import spilu, lgmres
 from scipy.sparse.linalg import LinearOperator, eigsh, minres

--- a/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_eigen_pbms_conga_2d.py
@@ -275,7 +275,7 @@ def hcurl_solve_eigen_pbm(ncells=np.array([[8, 4], [4, 4]]), degree=(3, 3), doma
         norm_emode_i = np.dot(emode_i, H1_m.dot(emode_i))
         eh_c = emode_i / norm_emode_i
 
-        stencil_coeffs = array_to_psydac(cP1_m @ eh_c, V1h.vector_space)
+        stencil_coeffs = array_to_psydac(cP1_m @ eh_c, V1h.coeff_space)
         vh = FemField(V1h, coeffs=stencil_coeffs)
         OM.add_snapshot(i, i)
         OM.export_fields(vh=vh)

--- a/psydac/feec/multipatch/examples/hcurl_eigen_pbms_dg_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_eigen_pbms_dg_2d.py
@@ -210,7 +210,7 @@ def hcurl_solve_eigen_pbm_dg(ncells=np.array([[8, 4], [4, 4]]), degree=(3, 3), d
         norm_emode_i = np.dot(emode_i, Bh_m.dot(emode_i))
         eh_c = emode_i / norm_emode_i
 
-        stencil_coeffs = array_to_psydac(eh_c, Vh.vector_space)
+        stencil_coeffs = array_to_psydac(eh_c, Vh.coeff_space)
         vh = FemField(Vh, coeffs=stencil_coeffs)
         OM.add_snapshot(i, i)
         OM.export_fields(vh=vh)

--- a/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
@@ -308,10 +308,10 @@ def solve_hcurl_source_pbm(
         print(' .. adding the lifted boundary condition...')
         uh_c += ubc_c
 
-    uh = FemField(V1h, coeffs=array_to_psydac(uh_c, V1h.vector_space))
+    uh = FemField(V1h, coeffs=array_to_psydac(uh_c, V1h.coeff_space))
     #need cp1 here?
     f_c = dH1_m.dot(tilde_f_c)
-    jh = FemField(V1h, coeffs=array_to_psydac(f_c, V1h.vector_space))
+    jh = FemField(V1h, coeffs=array_to_psydac(f_c, V1h.coeff_space))
 
     t_stamp = time_count(t_stamp)
 

--- a/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/hcurl_source_pbms_conga_2d.py
@@ -34,7 +34,6 @@ from psydac.feec.pull_push import pull_2d_hcurl
 from psydac.feec.multipatch.api import discretize
 from psydac.feec.multipatch.fem_linear_operators import IdLinearOperator
 from psydac.feec.multipatch.operators import HodgeOperator
-from psydac.feec.multipatch.plotting_utilities import plot_field
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 from psydac.feec.multipatch.examples.ppc_test_cases import get_source_and_solution_hcurl
 from psydac.feec.multipatch.utils_conga_2d import DiagGrid, P0_phys, P1_phys, P2_phys, get_Vh_diags_for

--- a/psydac/feec/multipatch/examples/mixed_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/mixed_source_pbms_conga_2d.py
@@ -413,8 +413,9 @@ if __name__ == '__main__':
     # bc_type = 'pseudo-vacuum'
     source_type = 'dipole_J'
 
-    source_proj = 'P_L2_wcurl_J'
-
+    # source_proj = 'P_L2_wcurl_J'
+    source_proj = 'P_geom'
+    
     domain_name = 'pretzel_f'
     dim_harmonic_space = 3
 

--- a/psydac/feec/multipatch/examples/mixed_source_pbms_conga_2d.py
+++ b/psydac/feec/multipatch/examples/mixed_source_pbms_conga_2d.py
@@ -22,7 +22,7 @@ from psydac.feec.pull_push import pull_2d_h1, pull_2d_hcurl, pull_2d_l2
 from psydac.feec.multipatch.api import discretize
 from psydac.feec.multipatch.fem_linear_operators import IdLinearOperator
 from psydac.feec.multipatch.operators import HodgeOperator
-from psydac.feec.multipatch.plotting_utilities import plot_field
+from psydac.fem.plotting_utilities import plot_field_2d as plot_field
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 from psydac.feec.multipatch.examples.ppc_test_cases import get_source_and_sol_for_magnetostatic_pbm
 from psydac.feec.multipatch.examples.hcurl_eigen_pbms_conga_2d import get_eigenvalues

--- a/psydac/feec/multipatch/examples/ppc_test_cases.py
+++ b/psydac/feec/multipatch/examples/ppc_test_cases.py
@@ -13,8 +13,7 @@ from sympde.topology import Derham
 from psydac.fem.basic import FemField
 from psydac.feec.multipatch.api import discretize
 from psydac.feec.multipatch.operators import HodgeOperator
-from psydac.feec.multipatch.plotting_utilities import plot_field
-from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, my_small_plot, my_small_streamplot
+from psydac.fem.plotting_utilities import get_plotting_grid, my_small_plot, my_small_streamplot
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 
 comm = MPI.COMM_WORLD

--- a/psydac/feec/multipatch/examples/timedomain_maxwell.py
+++ b/psydac/feec/multipatch/examples/timedomain_maxwell.py
@@ -37,7 +37,7 @@ from psydac.feec.multipatch.api import discretize
 from psydac.feec.multipatch.fem_linear_operators import IdLinearOperator
 from psydac.feec.multipatch.operators import HodgeOperator, get_K0_and_K0_inv, get_K1_and_K1_inv
 # , write_field_to_diag_grid,
-from psydac.feec.multipatch.plotting_utilities import plot_field
+from psydac.fem.plotting_utilities import plot_field_2d as plot_field
 from psydac.feec.multipatch.multipatch_domain_utilities import build_multipatch_domain
 # , get_praxial_Gaussian_beam_E, get_easy_Gaussian_beam_E, get_easy_Gaussian_beam_B,get_easy_Gaussian_beam_E_2, get_easy_Gaussian_beam_B_2
 from psydac.feec.multipatch.examples.ppc_test_cases import get_source_and_solution_hcurl, get_div_free_pulse, get_curl_free_pulse, get_Delta_phi_pulse, get_Gaussian_beam

--- a/psydac/feec/multipatch/examples/timedomain_maxwell.py
+++ b/psydac/feec/multipatch/examples/timedomain_maxwell.py
@@ -991,12 +991,12 @@ def solve_td_maxwell_pbm(*,
         OM2.add_spaces(V2h=V2h)
         OM2.export_space_info()
 
-        stencil_coeffs_E = array_to_psydac(cP1_m @ E_c, V1h.vector_space)
+        stencil_coeffs_E = array_to_psydac(cP1_m @ E_c, V1h.coeff_space)
         Eh = FemField(V1h, coeffs=stencil_coeffs_E)
         OM1.add_snapshot(t=0, ts=0)
         OM1.export_fields(Eh=Eh)
 
-        stencil_coeffs_B = array_to_psydac(B_c, V2h.vector_space)
+        stencil_coeffs_B = array_to_psydac(B_c, V2h.coeff_space)
         Bh = FemField(V2h, coeffs=stencil_coeffs_B)
         OM2.add_snapshot(t=0, ts=0)
         OM2.export_fields(Bh=Bh)
@@ -1085,12 +1085,12 @@ def solve_td_maxwell_pbm(*,
             # plot_B_field(B_c, nt=nt+1)
             # plot_J_source_nPlusHalf(f_c, nt=nt)
 
-            stencil_coeffs_E = array_to_psydac(cP1_m @ E_c, V1h.vector_space)
+            stencil_coeffs_E = array_to_psydac(cP1_m @ E_c, V1h.coeff_space)
             Eh = FemField(V1h, coeffs=stencil_coeffs_E)
             OM1.add_snapshot(t=nt * dt, ts=nt)
             OM1.export_fields(Eh=Eh)
 
-            stencil_coeffs_B = array_to_psydac(B_c, V2h.vector_space)
+            stencil_coeffs_B = array_to_psydac(B_c, V2h.coeff_space)
             Bh = FemField(V2h, coeffs=stencil_coeffs_B)
             OM2.add_snapshot(t=nt * dt, ts=nt)
             OM2.export_fields(Bh=Bh)
@@ -1137,7 +1137,7 @@ def solve_td_maxwell_pbm(*,
    # GaussErr_norm2_diag=GaussErr_norm2_diag,
    # GaussErrP_norm2_diag=GaussErrP_norm2_diag)
 
-    # Eh = FemField(V1h, coeffs=array_to_stencil(E_c, V1h.vector_space))
+    # Eh = FemField(V1h, coeffs=array_to_stencil(E_c, V1h.coeff_space))
     # t_stamp = time_count(t_stamp)
 
     # if sol_filename:
@@ -1168,7 +1168,7 @@ def solve_td_maxwell_pbm(*,
     #     plot_field(numpy_coeffs=curl_uh_c, Vh=V2h, space_kind='l2', domain=domain, surface_plot=False, title=title, filename=plot_dir+'/'+params_str+'_curl_uh.png',
     # plot_type='amplitude', cb_min=None, cb_max=None, hide_plot=hide_plots)
 
-    #     curl_uh = FemField(V2h, coeffs=array_to_stencil(curl_uh_c, V2h.vector_space))
+    #     curl_uh = FemField(V2h, coeffs=array_to_stencil(curl_uh_c, V2h.coeff_space))
     #     curl_diags = diag_grid.get_diags_for(v=curl_uh, space='V2')
     #     diags['curl_error (to be checked)'] = curl_diags['rel_l2_error']
 
@@ -1177,7 +1177,7 @@ def solve_td_maxwell_pbm(*,
     #     plot_field(numpy_coeffs=div_uh_c, Vh=V0h, space_kind='h1', domain=domain, surface_plot=False, title=title, filename=plot_dir+'/'+params_str+'_div_uh.png',
     # plot_type='amplitude', cb_min=None, cb_max=None, hide_plot=hide_plots)
 
-    #     div_uh = FemField(V0h, coeffs=array_to_stencil(div_uh_c, V0h.vector_space))
+    #     div_uh = FemField(V0h, coeffs=array_to_stencil(div_uh_c, V0h.coeff_space))
     #     div_diags = diag_grid.get_diags_for(v=div_uh, space='V0')
     #     diags['div_error (to be checked)'] = div_diags['rel_l2_error']
 

--- a/psydac/feec/multipatch/fem_linear_operators.py
+++ b/psydac/feec/multipatch/fem_linear_operators.py
@@ -25,8 +25,8 @@ class FemLinearOperator( LinearOperator ):
             self._fem_codomain = fem_codomain
         else:
             self._fem_codomain = fem_domain
-        self._domain   = self._fem_domain.vector_space
-        self._codomain = self._fem_codomain.vector_space
+        self._domain   = self._fem_domain.coeff_space
+        self._codomain = self._fem_codomain.coeff_space
 
         self._matrix = matrix
         self._sparse_matrix = sparse_matrix

--- a/psydac/feec/multipatch/non_matching_operators.py
+++ b/psydac/feec/multipatch/non_matching_operators.py
@@ -583,7 +583,7 @@ def construct_h1_conforming_projection(
     # moment corrections perpendicular to interfaces
     # assume same moments everywhere
     gamma = get_1d_moment_correction(
-        Vh.spaces[0].spaces[0], p_moments=p_moments)
+        Vh.patch_spaces[0].spaces[0], p_moments=p_moments)
 
     domain = Vh.symbolic_space.domain
     ndim = 2
@@ -592,7 +592,7 @@ def construct_h1_conforming_projection(
 
     l2g = Local2GlobalIndexMap(ndim, len(domain), n_components)
     for k in range(n_patches):
-        Vk = Vh.spaces[k]
+        Vk = Vh.patch_spaces[k]
         # T is a TensorFemSpace and S is a 1D SplineSpace
         shapes = [S.nbasis for S in Vk.spaces]
         l2g.set_patch_shapes(k, shapes)
@@ -606,8 +606,8 @@ def construct_h1_conforming_projection(
 
     def get_vertex_index_from_patch(patch, coords):
         # coords = co[patch]
-        nbasis0 = Vh.spaces[patch].spaces[coords[0]].nbasis - 1
-        nbasis1 = Vh.spaces[patch].spaces[coords[1]].nbasis - 1
+        nbasis0 = Vh.patch_spaces[patch].spaces[coords[0]].nbasis - 1
+        nbasis1 = Vh.patch_spaces[patch].spaces[coords[1]].nbasis - 1
 
         # patch local index
         multi_index = [None] * ndim
@@ -621,8 +621,8 @@ def construct_h1_conforming_projection(
         if coords[axis] == 0:
             return range(1, p_moments + 2)
         else:
-            return range(Vh.spaces[patch].spaces[coords[axis]].nbasis - 1 - 1,
-                         Vh.spaces[patch].spaces[coords[axis]].nbasis - 1 - p_moments - 2, -1)
+            return range(Vh.patch_spaces[patch].spaces[coords[axis]].nbasis - 1 - 1,
+                         Vh.patch_spaces[patch].spaces[coords[axis]].nbasis - 1 - p_moments - 2, -1)
 
     # loop over all vertices
     for (bd, co) in corners.items():
@@ -830,8 +830,8 @@ def construct_h1_conforming_projection(
         k_minus = get_patch_index_from_face(domain, I.minus)
         k_plus = get_patch_index_from_face(domain, I.plus)
 
-        I_minus_ncells = Vh.spaces[k_minus].ncells
-        I_plus_ncells = Vh.spaces[k_plus].ncells
+        I_minus_ncells = Vh.patch_spaces[k_minus].ncells
+        I_plus_ncells = Vh.patch_spaces[k_plus].ncells
 
         # logical directions normal to interface
         if I_minus_ncells <= I_plus_ncells:
@@ -848,8 +848,8 @@ def construct_h1_conforming_projection(
         d_fine = 1 - fine_axis
         d_coarse = 1 - coarse_axis
 
-        space_fine = Vh.spaces[k_fine]
-        space_coarse = Vh.spaces[k_coarse]
+        space_fine = Vh.patch_spaces[k_fine]
+        space_coarse = Vh.patch_spaces[k_coarse]
 
         coarse_space_1d = space_coarse.spaces[d_coarse]
         fine_space_1d = space_fine.spaces[d_fine]
@@ -962,7 +962,7 @@ def construct_h1_conforming_projection(
     if hom_bc:
         for bn in domain.boundary:
             k = get_patch_index_from_face(domain, bn)
-            space_k = Vh.spaces[k]
+            space_k = Vh.patch_spaces[k]
             axis = bn.axis
 
             d = 1 - axis
@@ -1038,7 +1038,7 @@ def construct_hcurl_conforming_projection(
 
     # moment corrections perpendicular to interfaces
     gamma = [get_1d_moment_correction(
-        Vh.spaces[0].spaces[1 - d].spaces[d], p_moments=p_moments) for d in range(2)]
+        Vh.patch_spaces[0].spaces[1 - d].spaces[d], p_moments=p_moments) for d in range(2)]
 
     domain = Vh.symbolic_space.domain
     ndim = 2
@@ -1047,7 +1047,7 @@ def construct_hcurl_conforming_projection(
 
     l2g = Local2GlobalIndexMap(ndim, len(domain), n_components)
     for k in range(n_patches):
-        Vk = Vh.spaces[k]
+        Vk = Vh.patch_spaces[k]
         # T is a TensorFemSpace and S is a 1D SplineSpace
         shapes = [[S.nbasis for S in T.spaces] for T in Vk.spaces]
         l2g.set_patch_shapes(k, *shapes)
@@ -1086,8 +1086,8 @@ def construct_hcurl_conforming_projection(
         minus_axis, plus_axis = I.minus.axis, I.plus.axis
         # logical directions along the interface
         d_minus, d_plus = 1 - minus_axis, 1 - plus_axis
-        I_minus_ncells = Vh.spaces[k_minus].spaces[d_minus].ncells[d_minus]
-        I_plus_ncells = Vh.spaces[k_plus].spaces[d_plus].ncells[d_plus]
+        I_minus_ncells = Vh.patch_spaces[k_minus].spaces[d_minus].ncells[d_minus]
+        I_plus_ncells = Vh.patch_spaces[k_plus].spaces[d_plus].ncells[d_plus]
 
         # logical directions normal to interface
         if I_minus_ncells <= I_plus_ncells:
@@ -1104,8 +1104,8 @@ def construct_hcurl_conforming_projection(
         d_fine = 1 - fine_axis
         d_coarse = 1 - coarse_axis
 
-        space_fine = Vh.spaces[k_fine]
-        space_coarse = Vh.spaces[k_coarse]
+        space_fine = Vh.patch_spaces[k_fine]
+        space_coarse = Vh.patch_spaces[k_coarse]
 
         coarse_space_1d = space_coarse.spaces[d_coarse].spaces[d_coarse]
         fine_space_1d = space_fine.spaces[d_fine].spaces[d_fine]
@@ -1164,7 +1164,7 @@ def construct_hcurl_conforming_projection(
     # boundary condition
     for bn in domain.boundary:
         k = get_patch_index_from_face(domain, bn)
-        space_k = Vh.spaces[k]
+        space_k = Vh.patch_spaces[k]
         axis = bn.axis
 
         if not hom_bc:

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -748,7 +748,7 @@ def get_K0_and_K0_inv(V0h, uniform_patches=False):
     if uniform_patches:
         print(' [[WARNING -- hack in get_K0_and_K0_inv: using copies of 1st-patch matrices in every patch ]] ')
 
-    V0 = V0h.symbolic_space   # VOh is ProductFemSpace
+    V0 = V0h.symbolic_space   # VOh is FemSpace
     domain = V0.domain
     K0_blocks = []
     K0_inv_blocks = []
@@ -798,7 +798,7 @@ def get_K1_and_K1_inv(V1h, uniform_patches=False):
     if uniform_patches:
         print(' [[WARNING -- hack in get_K1_and_K1_inv: using copies of 1st-patch matrices in every patch ]] ')
 
-    V1 = V1h.symbolic_space   # V1h is ProductFemSpace
+    V1 = V1h.symbolic_space   # V1h is FemSpace
     domain = V1.domain
     K1_blocks = []
     K1_inv_blocks = []
@@ -808,7 +808,7 @@ def get_K1_and_K1_inv(V1h, uniform_patches=False):
             K1_inv_k = K1_inv_blocks[0].copy()
 
         else:
-            # fem space on patch k: (ProductFemSpace (of TensorFemSpace (s))
+            # fem space on patch k:
             V1_k = V1h.spaces[k]
             K1_k_blocks = []
             for c in [0, 1]:    # dim of component
@@ -858,7 +858,7 @@ def get_K1_and_K1_inv(V1h, uniform_patches=False):
 #     """
 #     from pprint import pprint
 #
-#     V = Vh.symbolic_space   # VOh is ProductFemSpace
+#     V = Vh.symbolic_space   # VOh is FemSpace
 #     domain = V.domain
 #     M_blocks = []
 #     M_inv_blocks = []

--- a/psydac/feec/multipatch/operators.py
+++ b/psydac/feec/multipatch/operators.py
@@ -150,8 +150,8 @@ def get_row_col_index(corner1, corner2, interface, axis, V1, V2):
      The StencilInterfaceMatrix index of the corner, it has the form (i1, i2, k1, k2) in 2D,
      where (i1, i2) identifies the row and (k1, k2) the diagonal.
     """
-    start = V1.vector_space.starts
-    end = V1.vector_space.ends
+    start = V1.coeff_space.starts
+    end = V1.coeff_space.ends
     degree = V2.degree
     start_end = (start, end)
 
@@ -254,8 +254,8 @@ def allocate_interface_matrix(corners, test_space, trial_space):
     )[axis].spans[-1 if ext == 1 else 0] - test_space.degree[axis]
 
     mat = StencilInterfaceMatrix(
-        trial_space.vector_space,
-        test_space.vector_space,
+        trial_space.coeff_space,
+        test_space.coeff_space,
         s,
         s,
         axis,
@@ -580,7 +580,7 @@ class ConformingProjection_V1(FemLinearOperator):
             #
             # # self._A = ah.assemble()
             self._A = ah.forms[0]._matrix
-            # C1 = V1h.vector_space
+            # C1 = V1h.coeff_space
             # self._A = BlockLinearOperator(C1, C1)
 
             for b1 in self._A.blocks:
@@ -1192,7 +1192,7 @@ class Multipatch_Projector_H1:
         """
         u0s = [P(fun) for P, fun, in zip(self._P0s, funs_log)]
 
-        u0_coeffs = BlockVector(self._V0h.vector_space,
+        u0_coeffs = BlockVector(self._V0h.coeff_space,
                                 blocks=[u0j.coeffs for u0j in u0s])
 
         return FemField(self._V0h, coeffs=u0_coeffs)
@@ -1217,7 +1217,7 @@ class Multipatch_Projector_Hcurl:
         """
         E1s = [P(fun) for P, fun, in zip(self._P1s, funs_log)]
 
-        E1_coeffs = BlockVector(self._V1h.vector_space,
+        E1_coeffs = BlockVector(self._V1h.coeff_space,
                                 blocks=[E1j.coeffs for E1j in E1s])
 
         return FemField(self._V1h, coeffs=E1_coeffs)
@@ -1242,7 +1242,7 @@ class Multipatch_Projector_L2:
         """
         B2s = [P(fun) for P, fun, in zip(self._P2s, funs_log)]
 
-        B2_coeffs = BlockVector(self._V2h.vector_space,
+        B2_coeffs = BlockVector(self._V2h.coeff_space,
                                 blocks=[B2j.coeffs for B2j in B2s])
 
         return FemField(self._V2h, coeffs=B2_coeffs)

--- a/psydac/feec/multipatch/tests/test_feec_conf_projectors_cart_2d.py
+++ b/psydac/feec/multipatch/tests/test_feec_conf_projectors_cart_2d.py
@@ -49,6 +49,7 @@ def get_polynomial_function(degree, hom_bc_axes, domain):
 @pytest.mark.parametrize('domain_name', ["4patch_nc", "2patch_nc"])
 @pytest.mark.parametrize("nonconforming, full_mom_pres",
                          [(True, True), (False, True)])
+# NOTE (MCP march 2025): momentum conservation fails for nc = 4 and degree = 3, why?
 def test_conf_projectors_2d(
     V1_type,
     degree,
@@ -104,7 +105,7 @@ def test_conf_projectors_2d(
         elif len(domain) == 4:
             ncells_h = {
                 'M1(A)': [nc, nc],
-                'M2(B)': [2 * nc, 2 * nc],
+                'M2(B)': [nc, nc],
                 'M3(C)': [2 * nc, 2 * nc],
                 'M4(D)': [4 * nc, 4 * nc],
             }
@@ -138,6 +139,7 @@ def test_conf_projectors_2d(
     if full_mom_pres and (nc >= degree[0] + 1):
         mom_pres = degree[0]
     else:
+        raise ValueError(f'nc = {nc} too small for moment preservation')
         mom_pres = -1
     # NOTE: if mom_pres but not full_mom_pres we could test reduced order
     # moment preservation...

--- a/psydac/feec/multipatch/utils_conga_2d.py
+++ b/psydac/feec/multipatch/utils_conga_2d.py
@@ -13,7 +13,7 @@ from psydac.feec.multipatch.api import discretize
 from psydac.feec.multipatch.utilities import time_count  # , export_sol, import_sol
 from psydac.linalg.utilities import array_to_psydac
 from psydac.fem.basic import FemField
-from psydac.feec.multipatch.plotting_utilities import get_plotting_grid, get_grid_quad_weights, get_grid_vals
+from psydac.fem.plotting_utilities import get_plotting_grid, get_grid_quad_weights, get_grid_vals
 
 
 # commuting projections on the physical domain (should probably be in the

--- a/psydac/feec/multipatch/utils_conga_2d.py
+++ b/psydac/feec/multipatch/utils_conga_2d.py
@@ -156,7 +156,7 @@ class DiagGrid():
             print('use refined labels if several solutions are needed in the same space')
         self.sol_ref[space] = FemField(
             Vh, coeffs=array_to_psydac(
-                coeffs, Vh.vector_space))
+                coeffs, Vh.coeff_space))
 
     def write_sol_values(self, v, space='V*'):
         """

--- a/psydac/feec/pull_push.py
+++ b/psydac/feec/pull_push.py
@@ -23,6 +23,7 @@ __all__ = (
     # ----------------------
     'push_1d_h1',
     'push_1d_l2',
+    'push_2d_h1_vec',
     'push_2d_h1',
     'push_2d_hcurl',
     'push_2d_hdiv',
@@ -374,7 +375,10 @@ def push_1d_l2(f, eta, F):
 #==============================================================================
 # 2D PUSH-FORWARDS
 #==============================================================================
-#def push_2d_h1(f, eta):
+def push_2d_h1_vec(f1, f2, eta1, eta2):
+    eta = eta1, eta2
+    return f1(*eta), f2(*eta)
+
 def push_2d_h1(f, eta1, eta2):
     eta = eta1, eta2
     return f(*eta)

--- a/psydac/feec/pushforward.py
+++ b/psydac/feec/pushforward.py
@@ -7,7 +7,7 @@ from sympde.topology.datatype import UndefinedSpaceType, H1SpaceType, HcurlSpace
 
 from psydac.mapping.discrete import SplineMapping
 from psydac.fem.basic import FemField
-from psydac.fem.vector import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector import MultipatchFemSpace, VectorFemSpace
 from psydac.core.bsplines import cell_index
 from psydac.core.field_evaluation_kernels import (pushforward_2d_l2, pushforward_3d_l2,
                                                   pushforward_2d_hdiv, pushforward_3d_hdiv,
@@ -266,7 +266,7 @@ class Pushforward:
 
         fields_eval = getattr(space, self._eval_func)(self.grid, *field_list, overlap=overlap)
 
-        if isinstance(space, (VectorFemSpace, ProductFemSpace)):
+        if isinstance(space, (VectorFemSpace, MultipatchFemSpace)):
             return [tuple(np.ascontiguousarray(fields_eval[i][index_trim[i] + (j,)], dtype=field_list[0].coeffs.dtype) for i in range(self.ldim)) for j in range(len(field_list))]
         else:
             return [np.ascontiguousarray(fields_eval[index_trim + (j,)], dtype=field_list[0].coeffs.dtype) for j in range(len(field_list))]
@@ -288,7 +288,7 @@ class Pushforward:
         if self.sqrt_metric_det_temp is None:
             self.sqrt_metric_det_temp = self.sqrt_metric_det()
 
-        if isinstance(space, (VectorFemSpace, ProductFemSpace)):
+        if isinstance(space, (VectorFemSpace, MultipatchFemSpace)):
 
             fields_to_push = [np.ascontiguousarray(fields_eval[i][index_trim[i]]) for i in range(self.ldim)]
             pushed_fields_list = [np.zeros_like(fields_to_push[i], dtype=fields_eval[i].dtype) for i in range(self.ldim)]
@@ -464,7 +464,7 @@ class Pushforward:
         ----------
         space : FemSpace
         """
-        if isinstance(space, (ProductFemSpace, VectorFemSpace)):
+        if isinstance(space, (MultipatchFemSpace, VectorFemSpace)):
             overlap = []
             index_trim = []
             for i in range(len(space.spaces)):

--- a/psydac/feec/tests/test_axis_projection.py
+++ b/psydac/feec/tests/test_axis_projection.py
@@ -16,7 +16,7 @@ def test_axis_projection():
     Pei = BilinearForm((u,f), integral(domain, expr))
     pei = discretize(Pei, domain_h, (V1h,V2h), backend=PSYDAC_BACKENDS['python'])
     Peih = pei.assemble()
-    uh = V1h.vector_space.zeros()
+    uh = V1h.coeff_space.zeros()
     test = Peih.dot(uh)
 
 if __name__ == '__main__':

--- a/psydac/feec/tests/test_commuting_projections.py
+++ b/psydac/feec/tests/test_commuting_projections.py
@@ -80,13 +80,13 @@ def test_3d_commuting_pro_1(Nel, Nq, p, bc, m):
     #--------------------------
     # check BlockLinearOperator
     #--------------------------
-    Id_0 = IdentityOperator(H1.vector_space)
+    Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
     norm2_e0 = np.sqrt(e0.dot(e0))
     assert norm2_e0 < 1e-12
 
-    Id_1 = IdentityOperator(Hcurl.vector_space)
+    Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
     norm2_e1 = np.sqrt(e1.dot(e1))
@@ -172,13 +172,13 @@ def test_3d_commuting_pro_2(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_1 = IdentityOperator(Hcurl.vector_space)
+    Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
     norm2_e1 = np.sqrt(e1.dot(e1))
     assert norm2_e1 < 1e-12
 
-    Id_2 = IdentityOperator(Hdiv.vector_space)
+    Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs  # random vector could be used as well
     norm2_e2 = np.sqrt(e2.dot(e2))
@@ -255,13 +255,13 @@ def test_3d_commuting_pro_3(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_2 = IdentityOperator(Hdiv.vector_space)
+    Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs  # random vector could be used as well
     norm2_e2 = np.sqrt(e2.dot(e2))
     assert norm2_e2 < 1e-12
 
-    Id_3 = IdentityOperator(L2.vector_space)
+    Id_3 = IdentityOperator(L2.coeff_space)
     Err_3 = P3.solver @ P3.imat_kronecker - Id_3
     e3 = Err_3 @ u3.coeffs  # random vector could be used as well
     norm2_e3 = np.sqrt(e3.dot(e3))
@@ -331,13 +331,13 @@ def test_2d_commuting_pro_1(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_0 = IdentityOperator(H1.vector_space)
+    Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
     norm2_e0 = np.sqrt(e0.dot(e0))
     assert norm2_e0 < 1e-12
 
-    Id_1 = IdentityOperator(Hcurl.vector_space)
+    Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
     norm2_e1 = np.sqrt(e1.dot(e1))
@@ -404,13 +404,13 @@ def test_2d_commuting_pro_2(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_0 = IdentityOperator(H1.vector_space)
+    Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
     norm2_e0 = np.sqrt(e0.dot(e0))
     assert norm2_e0 < 1e-12
 
-    Id_1 = IdentityOperator(Hdiv.vector_space)
+    Id_1 = IdentityOperator(Hdiv.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
     norm2_e1 = np.sqrt(e1.dot(e1))
@@ -484,13 +484,13 @@ def test_2d_commuting_pro_3(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_2 = IdentityOperator(Hdiv.vector_space)
+    Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs
     norm2_e2 = np.sqrt(e2.dot(e2))
     assert norm2_e2 < 1e-12
 
-    Id_3 = IdentityOperator(L2.vector_space)
+    Id_3 = IdentityOperator(L2.coeff_space)
     Err_3 = P3.solver @ P3.imat_kronecker - Id_3
     e3 = Err_3 @ u3.coeffs
     norm2_e3 = np.sqrt(e3.dot(e3))
@@ -564,13 +564,13 @@ def test_2d_commuting_pro_4(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_1 = IdentityOperator(Hcurl.vector_space)
+    Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs
     norm2_e1 = np.sqrt(e1.dot(e1))
     assert norm2_e1 < 1e-12
 
-    Id_2 = IdentityOperator(L2.vector_space)
+    Id_2 = IdentityOperator(L2.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs
     norm2_e2 = np.sqrt(e2.dot(e2))
@@ -634,13 +634,13 @@ def test_1d_commuting_pro_1(Nel, Nq, p, bc, m):
     # check BlockLinearOperator
     #--------------------------
 
-    Id_0 = IdentityOperator(H1.vector_space)
+    Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs
     norm2_e0 = np.sqrt(e0.dot(e0))
     assert norm2_e0 < 1e-12
 
-    Id_1 = IdentityOperator(L2.vector_space)
+    Id_1 = IdentityOperator(L2.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs
     norm2_e1 = np.sqrt(e1.dot(e1))

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -316,7 +316,7 @@ class FemField:
 
     @property
     def patch_fields(self):
-        """ return the patch fields (self if single-patch) as a tuple """
+        """ Return the patch fields (only self if single-patch) as a tuple """
         if self.space.is_multipatch:
             return self.fields
         else:

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -54,7 +54,7 @@ class FemSpace( metaclass=ABCMeta ):
 
     @property
     @abstractmethod
-    def vector_space( self ):
+    def coeff_space( self ):
         """Topologically associated vector space."""
         # question [MCP 03.2025]:
             # rename as coeff_space ?
@@ -263,9 +263,9 @@ class FemField:
 
         if coeffs is not None:
             assert isinstance( coeffs, Vector )
-            assert space.vector_space is coeffs.space
+            assert space.coeff_space is coeffs.space
         else:
-            coeffs = space.vector_space.zeros()
+            coeffs = space.coeff_space.zeros()
 
         # Case of vector-valued or multipatch field, element of a Product Space
         if space.is_multipatch or space.is_vector_valued:
@@ -291,7 +291,7 @@ class FemField:
         the elements of the basis of a Finite element space.
 
         Coefficients are stored into one element of the vector space in
-        'self.space.vector_space', which is topologically associated to
+        'self.space.coeff_space', which is topologically associated to
         the finite element space.
 
         """

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -141,24 +141,24 @@ class FemSpace( metaclass=ABCMeta ):
     # Concrete methods
     #----------------------
     def __mul__(self, a):
-        from psydac.fem.vector import MultipatchFemSpace
+        from psydac.fem.vector import create_product_space
 
         spaces = [*(self.spaces if self.is_product else [self]),
                   *(   a.spaces if    a.is_product else    [a])]
  
-        space = MultipatchFemSpace(*spaces)
+        space = create_product_space(*spaces)
         if a.symbolic_space and self.symbolic_space:
             space._symbolic_space =  self.symbolic_space*a.symbolic_space
         return space
 
     # ...
     def __rmul__(self, a):
-        from psydac.fem.vector import MultipatchFemSpace
+        from psydac.fem.vector import create_product_space
 
         spaces = [*(   a.spaces if    a.is_product else    [a]),
                   *(self.spaces if self.is_product else [self]),]
 
-        space = MultipatchFemSpace(*spaces)
+        space = create_product_space(*spaces)
 
         if a.symbolic_space and self.symbolic_space:
             space._symbolic_space =  a.symbolic_space * self.symbolic_space

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -65,6 +65,22 @@ class FemSpace( metaclass=ABCMeta ):
         If True, an element of this space can be decomposed into separate fields.
 
         """
+        # todo (MCP 4.03.25) try this:
+        # return self.is_vector_valued or self.is_multipatch
+
+    @property
+    @abstractmethod
+    def is_multipatch( self ):
+        """
+        Boolean flag that describes whether the space is a multi-patch space.
+        """
+
+    @property
+    @abstractmethod
+    def is_vector_valued( self ):
+        """
+        Boolean flag that describes whether the space is vector-valued.
+        """
 
     @property
     @abstractmethod
@@ -147,6 +163,27 @@ class FemSpace( metaclass=ABCMeta ):
         if a.symbolic_space and self.symbolic_space:
             space._symbolic_space =  a.symbolic_space * self.symbolic_space
         return space
+
+    @property
+    def patch_spaces(self):
+        """
+        Return the patch spaces (self if single-patch) as a tuple.
+        """
+        if self.is_multipatch:
+            return self._spaces
+        else:
+            return (self,)
+
+    @property
+    def component_spaces(self):
+        """
+        Return the component spaces (self if scalar-valued) as a tuple.
+        """
+        if self.is_vector_valued:
+            return self._spaces
+        else:
+            return (self,)
+
 
 #---------------------------------------
 # OLD STUFF
@@ -264,6 +301,26 @@ class FemField:
     @property
     def fields(self):
         return self._fields
+
+    @property
+    def is_vector_valued(self):
+        return self.space.is_vector_valued
+
+    @property
+    def patch_fields(self):
+        """ return the patch fields (self if single-patch) as a tuple """
+        if self.space.is_multipatch:
+            return self.fields
+        else:
+            return (self,)
+
+    @property
+    def component_fields(self):
+        """ return the component fields (self if scalar-valued) as a tuple """
+        if self.space.is_vector_valued:
+            return self.fields
+        else:
+            return (self,)
 
     # ...
     def __getitem__(self, key):

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -58,7 +58,7 @@ class FemSpace( metaclass=ABCMeta ):
         """Topologically associated vector space."""
 
     @property
-    @abstractmethod
+    # @abstractmethod
     def is_product( self ):
         """
         Boolean flag that describes whether the space is a product space.
@@ -66,7 +66,7 @@ class FemSpace( metaclass=ABCMeta ):
 
         """
         # todo (MCP 4.03.25) try this:
-        # return self.is_vector_valued or self.is_multipatch
+        return self.is_multipatch or self.is_vector_valued
 
     @property
     @abstractmethod

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -180,7 +180,11 @@ class FemSpace( metaclass=ABCMeta ):
         Return the component spaces (self if scalar-valued) as a tuple.
         """
         if self.is_vector_valued:
-            return self._spaces
+            if self.is_multipatch:
+                # should we return here the multipatch scalar-valued space?
+                raise NotImplementedError('Component spaces not implemented for multipatch spaces')
+            else:
+                return self._spaces
         else:
             return (self,)
 

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -281,7 +281,7 @@ class FemField:
             coeffs = space.vector_space.zeros()
 
         # Case of vector-valued or multipatch field, element of a Product Space
-        if space.is_product:
+        if space.is_multipatch or space.is_vector_valued:
             fields = tuple(FemField(V, c) for V, c in zip(space.spaces, coeffs))
         else:
             fields = tuple()

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -31,7 +31,6 @@ class FemSpace( metaclass=ABCMeta ):
         """
         Number of dimensions in logical space,
         i.e. number of scalar logical coordinates.
-
         """
 
     @property
@@ -40,7 +39,6 @@ class FemSpace( metaclass=ABCMeta ):
         """
         Tuple of booleans: along each logical dimension,
         say if domain is periodic.
-
         """
 
     @property
@@ -49,16 +47,15 @@ class FemSpace( metaclass=ABCMeta ):
         """
         Mapping from logical coordinates 'eta' to physical coordinates 'x'.
         If None, we assume identity mapping (hence x=eta).
-
         """
 
     @property
     @abstractmethod
     def coeff_space( self ):
-        """Topologically associated vector space."""
-        # question [MCP 03.2025]:
-            # rename as coeff_space ?
-            # meaning of docstring? see different one in MultipatchFemSpace
+        """
+        Vector space of the coefficients (mapping invariant).
+        :rtype: psydac.linalg.basic.VectorSpace
+        """
 
     @property
     @abstractmethod

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -316,10 +316,6 @@ class FemField:
         return self._fields
 
     @property
-    def is_vector_valued(self):
-        return self.space.is_vector_valued
-
-    @property
     def patch_fields(self):
         """ Return the patch fields (only self if single-patch) as a tuple """
         if self.space.is_multipatch:

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -156,15 +156,16 @@ class FemSpace( metaclass=ABCMeta ):
     #----------------------
     # Concrete methods
     #----------------------
-    @property
-    def is_product( self ):
-        """
-        Boolean flag that describes whether the space is a product space,
-        (eg, a multipatch or vector-valued space).
-        If True, an element of this space can be decomposed into separate fields.
-        """
-        # [MCP 27.03.2025]: do we really need this method ?
-        return self.is_multipatch or self.is_vector_valued
+    
+    # [MCP 27.03.2025]: commented if still needed somewhere, but should be removed in future
+    # @property
+    # def is_product( self ):
+    #     """
+    #     Boolean flag that describes whether the space is a product space,
+    #     (eg, a multipatch or vector-valued space).
+    #     If True, an element of this space can be decomposed into separate fields.
+    #     """     
+    #     return self.is_multipatch or self.is_vector_valued
     
     def __mul__(self, a):
     # [MCP 27.03.2025]: commented because improper implementation. must be rewritten if needed

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -324,7 +324,7 @@ class FemField:
 
     @property
     def component_fields(self):
-        """ return the component fields (self if scalar-valued) as a tuple """
+        """ Return the component fields (only self if scalar-valued) as a tuple """
         if self.space.is_vector_valued:
             return self.fields
         else:

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -275,7 +275,7 @@ class FemField:
         else:
             coeffs = space.vector_space.zeros()
 
-        # Case of a vector field, element of a ProductSpace
+        # Case of vector-valued or multipatch field, element of a Product Space
         if space.is_product:
             fields = tuple(FemField(V, c) for V, c in zip(space.spaces, coeffs))
         else:

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -166,52 +166,31 @@ class FemSpace( metaclass=ABCMeta ):
     # Concrete methods
     #----------------------
     def __mul__(self, a):
-        from psydac.fem.vector import create_product_space
+    #     from psydac.fem.vector import create_product_space
 
-        spaces = [*(self.spaces if self.is_product else [self]),
-                  *(   a.spaces if    a.is_product else    [a])]
- 
-        space = create_product_space(*spaces)
-        if a.symbolic_space and self.symbolic_space:
-            space._symbolic_space =  self.symbolic_space*a.symbolic_space
-        return space
+    #     spaces = [*(self.spaces if self.is_product else [self]),
+    #               *(   a.spaces if    a.is_product else    [a])]
+
+    #     space = create_product_space(*spaces)
+    #     if a.symbolic_space and self.symbolic_space:
+    #         space._symbolic_space =  self.symbolic_space*a.symbolic_space
+    #     return space
+        raise NotImplementedError('if this method __mul__ is used, it should not be implemented like this: TODO')
 
     # ...
     def __rmul__(self, a):
-        from psydac.fem.vector import create_product_space
+    #     from psydac.fem.vector import create_product_space
 
-        spaces = [*(   a.spaces if    a.is_product else    [a]),
-                  *(self.spaces if self.is_product else [self]),]
+    #     spaces = [*(   a.spaces if    a.is_product else    [a]),
+    #               *(self.spaces if self.is_product else [self]),]
 
-        space = create_product_space(*spaces)
+    #     space = create_product_space(*spaces)
 
-        if a.symbolic_space and self.symbolic_space:
-            space._symbolic_space =  a.symbolic_space * self.symbolic_space
-        return space
+    #     if a.symbolic_space and self.symbolic_space:
+    #         space._symbolic_space =  a.symbolic_space * self.symbolic_space
+    #     return space
+        raise NotImplementedError('if this method __rmul__ is used, it should not be implemented like this: TODO')
 
-    @property
-    def patch_spaces(self):
-        """
-        Return the patch spaces (self if single-patch) as a tuple.
-        """
-        if self.is_multipatch:
-            return self._spaces
-        else:
-            return (self,)
-
-    @property
-    def component_spaces(self):
-        """
-        Return the component spaces (self if scalar-valued) as a tuple.
-        """
-        if self.is_vector_valued:
-            if self.is_multipatch:
-                # should we return here the multipatch scalar-valued space?
-                raise NotImplementedError('Component spaces not implemented for multipatch spaces')
-            else:
-                return self._spaces
-        else:
-            return (self,)
 
 
 #---------------------------------------
@@ -252,7 +231,7 @@ class FemSpace( metaclass=ABCMeta ):
 #          """
 #          Number of linearly independent elements in basis.
 #          For a tensor product space this is a tuple of integers.
-#  
+#
 #          """
 #
 #  # NOTE: why is 'degree' part of abstract interface?
@@ -325,7 +304,7 @@ class FemField:
 
         """
         return self._coeffs
-        
+
     # ...
     @property
     def fields(self):
@@ -364,7 +343,7 @@ class FemField:
     def gradient( self, *eta , weights=None):
         """Evaluate gradient of weighted field at location identified by logical coordinates eta."""
         return self._space.eval_field_gradient( self, *eta , weights=weights)
-        
+
     # ...
     def divergence(self, *eta, weights=None):
         """Evaluate divergence of weighted vector field at location identified by logical coordinates eta."""

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -56,23 +56,16 @@ class FemSpace( metaclass=ABCMeta ):
     @abstractmethod
     def vector_space( self ):
         """Topologically associated vector space."""
-
-    @property
-    # @abstractmethod
-    def is_product( self ):
-        """
-        Boolean flag that describes whether the space is a product space.
-        If True, an element of this space can be decomposed into separate fields.
-
-        """
-        # todo (MCP 4.03.25) try this:
-        return self.is_multipatch or self.is_vector_valued
+        # question [MCP 03.2025]:
+            # rename as coeff_space ?
+            # meaning of docstring? see different one in MultipatchFemSpace
 
     @property
     @abstractmethod
     def is_multipatch( self ):
         """
         Boolean flag that describes whether the space is a multi-patch space.
+        :rtype: bool
         """
 
     @property
@@ -80,12 +73,44 @@ class FemSpace( metaclass=ABCMeta ):
     def is_vector_valued( self ):
         """
         Boolean flag that describes whether the space is vector-valued.
+        :rtype: bool
         """
+
+    @property
+    def is_product( self ):
+        """
+        Boolean flag that describes whether the space is a product space.
+        If True, an element of this space can be decomposed into separate fields.
+
+        """
+        return self.is_multipatch or self.is_vector_valued
 
     @property
     @abstractmethod
     def symbolic_space( self ):
         """Symbolic space."""
+
+    @property
+    @abstractmethod
+    def patch_spaces(self):
+        """
+        Return the patch spaces (self if single-patch) as a tuple.
+        """
+
+    @property
+    @abstractmethod
+    def component_spaces(self):
+        """
+        Return the component spaces (self if scalar-valued) as a tuple.
+        """
+
+    @property
+    @abstractmethod
+    def axis_spaces(self):
+        """
+        Return the axis spaces (self if univariate) as a tuple.
+        """
+
 
     #---------------------------------------
     # Abstract interface: evaluation methods

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -156,18 +156,8 @@ class FemSpace( metaclass=ABCMeta ):
     #----------------------
     # Concrete methods
     #----------------------
-    
-    # [MCP 27.03.2025]: commented if still needed somewhere, but should be removed in future
-    # @property
-    # def is_product( self ):
-    #     """
-    #     Boolean flag that describes whether the space is a product space,
-    #     (eg, a multipatch or vector-valued space).
-    #     If True, an element of this space can be decomposed into separate fields.
-    #     """     
-    #     return self.is_multipatch or self.is_vector_valued
-    
     def __mul__(self, a):
+        raise NotImplementedError('if this method __mul__ is used, it should not be implemented like this: TODO')
     # [MCP 27.03.2025]: commented because improper implementation. must be rewritten if needed
                       
     #     from psydac.fem.vector import create_product_space
@@ -179,10 +169,9 @@ class FemSpace( metaclass=ABCMeta ):
     #     if a.symbolic_space and self.symbolic_space:
     #         space._symbolic_space =  self.symbolic_space*a.symbolic_space
     #     return space
-        raise NotImplementedError('if this method __mul__ is used, it should not be implemented like this: TODO')
 
-    # ...
     def __rmul__(self, a):
+        raise NotImplementedError('if this method __rmul__ is used, it should not be implemented like this: TODO')
     # [MCP 27.03.2025]: commented because improper implementation. must be rewritten if needed
     
     #     from psydac.fem.vector import create_product_space
@@ -195,9 +184,6 @@ class FemSpace( metaclass=ABCMeta ):
     #     if a.symbolic_space and self.symbolic_space:
     #         space._symbolic_space =  a.symbolic_space * self.symbolic_space
     #     return space
-        raise NotImplementedError('if this method __rmul__ is used, it should not be implemented like this: TODO')
-
-
 
 #---------------------------------------
 # OLD STUFF

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -77,15 +77,6 @@ class FemSpace( metaclass=ABCMeta ):
         """
 
     @property
-    def is_product( self ):
-        """
-        Boolean flag that describes whether the space is a product space.
-        If True, an element of this space can be decomposed into separate fields.
-
-        """
-        return self.is_multipatch or self.is_vector_valued
-
-    @property
     @abstractmethod
     def symbolic_space( self ):
         """Symbolic space."""
@@ -165,7 +156,19 @@ class FemSpace( metaclass=ABCMeta ):
     #----------------------
     # Concrete methods
     #----------------------
+    @property
+    def is_product( self ):
+        """
+        Boolean flag that describes whether the space is a product space,
+        (eg, a multipatch or vector-valued space).
+        If True, an element of this space can be decomposed into separate fields.
+        """
+        # [MCP 27.03.2025]: do we really need this method ?
+        return self.is_multipatch or self.is_vector_valued
+    
     def __mul__(self, a):
+    # [MCP 27.03.2025]: commented because improper implementation. must be rewritten if needed
+                      
     #     from psydac.fem.vector import create_product_space
 
     #     spaces = [*(self.spaces if self.is_product else [self]),
@@ -179,6 +182,8 @@ class FemSpace( metaclass=ABCMeta ):
 
     # ...
     def __rmul__(self, a):
+    # [MCP 27.03.2025]: commented because improper implementation. must be rewritten if needed
+    
     #     from psydac.fem.vector import create_product_space
 
     #     spaces = [*(   a.spaces if    a.is_product else    [a]),

--- a/psydac/fem/basic.py
+++ b/psydac/fem/basic.py
@@ -141,24 +141,24 @@ class FemSpace( metaclass=ABCMeta ):
     # Concrete methods
     #----------------------
     def __mul__(self, a):
-        from psydac.fem.vector import ProductFemSpace
+        from psydac.fem.vector import MultipatchFemSpace
 
         spaces = [*(self.spaces if self.is_product else [self]),
                   *(   a.spaces if    a.is_product else    [a])]
  
-        space = ProductFemSpace(*spaces)
+        space = MultipatchFemSpace(*spaces)
         if a.symbolic_space and self.symbolic_space:
             space._symbolic_space =  self.symbolic_space*a.symbolic_space
         return space
 
     # ...
     def __rmul__(self, a):
-        from psydac.fem.vector import ProductFemSpace
+        from psydac.fem.vector import MultipatchFemSpace
 
         spaces = [*(   a.spaces if    a.is_product else    [a]),
                   *(self.spaces if self.is_product else [self]),]
 
-        space = ProductFemSpace(*spaces)
+        space = MultipatchFemSpace(*spaces)
 
         if a.symbolic_space and self.symbolic_space:
             space._symbolic_space =  a.symbolic_space * self.symbolic_space

--- a/psydac/fem/partitioning.py
+++ b/psydac/fem/partitioning.py
@@ -8,7 +8,7 @@ from sympde.topology import Interface
 
 from psydac.ddm.cart       import CartDecomposition, InterfaceCartDecomposition, create_interfaces_cart
 from psydac.core.bsplines  import elements_spans
-from psydac.fem.vector     import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector     import VectorFemSpace
 
 
 __all__ = (

--- a/psydac/fem/partitioning.py
+++ b/psydac/fem/partitioning.py
@@ -252,8 +252,8 @@ def construct_interface_spaces(domain_decomposition, g_spaces, carts, interiors,
         g_spaces[interiors[j]].create_interface_space(axis_plus , ext_plus , cart=cart_plus)
 
         max_ncells = tuple(max(ni,nj) for ni,nj in zip(g_spaces[interiors[i]].ncells,g_spaces[interiors[j]].ncells))
-        cart_minus = g_spaces[interiors[i]].get_refined_space(max_ncells).vector_space.cart
-        cart_plus  = g_spaces[interiors[j]].get_refined_space(max_ncells).vector_space.cart
+        cart_minus = g_spaces[interiors[i]].get_refined_space(max_ncells).coeff_space.cart
+        cart_plus  = g_spaces[interiors[j]].get_refined_space(max_ncells).coeff_space.cart
         if isinstance(cart_minus, InterfaceCartDecomposition):
             cart = InterfaceCartDecomposition(cart_minus._cart_minus, cart_plus._cart_plus,
                                               cart_minus._comm, [axis_minus, axis_plus], [ext_minus, ext_plus],
@@ -302,8 +302,8 @@ def construct_reduced_interface_spaces(spaces, reduced_spaces, interiors, connec
 
         if space_i is None or space_j is None: continue
 
-        cart_i  = space_i.vector_space.cart
-        cart_j  = space_j.vector_space.cart
+        cart_i  = space_i.coeff_space.cart
+        cart_j  = space_j.coeff_space.cart
 
         if isinstance(cart_i, InterfaceCartDecomposition):
             assert cart_i is cart_j
@@ -311,13 +311,13 @@ def construct_reduced_interface_spaces(spaces, reduced_spaces, interiors, connec
                 for Vi,Vj in zip(reduced_spaces[patch_i].spaces, reduced_spaces[patch_j].spaces):
                     npts_i = [Vik.nbasis for Vik in Vi.spaces]
                     npts_j = [Vik.nbasis for Vik in Vj.spaces]
-                    global_starts_i = Vi.vector_space.cart.global_starts
-                    global_starts_j = Vj.vector_space.cart.global_starts
-                    global_ends_i   = Vi.vector_space.cart.global_ends
-                    global_ends_j   = Vj.vector_space.cart.global_ends
-                    shifts_i        = Vi.vector_space.cart.shifts
-                    shifts_j        = Vj.vector_space.cart.shifts
-                    cart_ij         = cart_i.reduce_npts(Vi.vector_space.cart, Vj.vector_space.cart)
+                    global_starts_i = Vi.coeff_space.cart.global_starts
+                    global_starts_j = Vj.coeff_space.cart.global_starts
+                    global_ends_i   = Vi.coeff_space.cart.global_ends
+                    global_ends_j   = Vj.coeff_space.cart.global_ends
+                    shifts_i        = Vi.coeff_space.cart.shifts
+                    shifts_j        = Vj.coeff_space.cart.shifts
+                    cart_ij         = cart_i.reduce_npts(Vi.coeff_space.cart, Vj.coeff_space.cart)
                     cart_ij.set_interface_communication_infos(get_minus_starts_ends, get_plus_starts_ends)
                     Vi.create_interface_space(axis_i, ext_i, cart=cart_ij)
                     Vj.create_interface_space(axis_j, ext_j, cart=cart_ij)
@@ -339,7 +339,7 @@ def construct_reduced_interface_spaces(spaces, reduced_spaces, interiors, connec
                 Vj = reduced_spaces[patch_j]
                 npts_i = [Vik.nbasis for Vik in Vi.spaces]
                 npts_j = [Vik.nbasis for Vik in Vj.spaces]
-                cart_ij  = cart_i.reduce_npts(Vi.vector_space.cart, Vj.vector_space.cart)
+                cart_ij  = cart_i.reduce_npts(Vi.coeff_space.cart, Vj.coeff_space.cart)
                 cart_ij.set_interface_communication_infos(get_minus_starts_ends, get_plus_starts_ends)
                 Vi.create_interface_space(axis_i, ext_i, cart=cart_ij)
                 Vj.create_interface_space(axis_j, ext_j, cart=cart_ij)
@@ -359,20 +359,20 @@ def construct_reduced_interface_spaces(spaces, reduced_spaces, interiors, connec
         else:
             if isinstance(reduced_spaces[patch_i], VectorFemSpace):
                 for Vi,Vj in zip(reduced_spaces[patch_i].spaces, reduced_spaces[patch_j].spaces):
-                    Vi.create_interface_space(axis_i, ext_i, cart=Vi.vector_space.cart)
-                    Vj.create_interface_space(axis_j , ext_j , cart=Vj.vector_space.cart)
+                    Vi.create_interface_space(axis_i, ext_i, cart=Vi.coeff_space.cart)
+                    Vj.create_interface_space(axis_j , ext_j , cart=Vj.coeff_space.cart)
                     max_ncells = tuple(max(ni,nj) for ni,nj in zip(Vi.ncells,Vj.ncells))
-                    cart_i = Vi.get_refined_space(max_ncells).vector_space.cart
-                    cart_j = Vj.get_refined_space(max_ncells).vector_space.cart
+                    cart_i = Vi.get_refined_space(max_ncells).coeff_space.cart
+                    cart_j = Vj.get_refined_space(max_ncells).coeff_space.cart
                     Vi.get_refined_space(max_ncells).create_interface_space(axis_i, ext_i, cart=cart_i)
                     Vj.get_refined_space(max_ncells).create_interface_space(axis_j, ext_j, cart=cart_j)
             else:
                 Vi = reduced_spaces[patch_i]
                 Vj = reduced_spaces[patch_j]
-                Vi.create_interface_space(axis_i, ext_i, cart=Vi.vector_space.cart)
-                Vj.create_interface_space(axis_j , ext_j , cart=Vj.vector_space.cart)
+                Vi.create_interface_space(axis_i, ext_i, cart=Vi.coeff_space.cart)
+                Vj.create_interface_space(axis_j , ext_j , cart=Vj.coeff_space.cart)
                 max_ncells = tuple(max(ni,nj) for ni,nj in zip(Vi.ncells,Vj.ncells))
-                cart_i = Vi.get_refined_space(max_ncells).vector_space.cart
-                cart_j = Vj.get_refined_space(max_ncells).vector_space.cart
+                cart_i = Vi.get_refined_space(max_ncells).coeff_space.cart
+                cart_j = Vj.get_refined_space(max_ncells).coeff_space.cart
                 Vi.get_refined_space(max_ncells).create_interface_space(axis_i, ext_i, cart=cart_i)
                 Vj.get_refined_space(max_ncells).create_interface_space(axis_j, ext_j, cart=cart_j)

--- a/psydac/fem/plotting_utilities.py
+++ b/psydac/fem/plotting_utilities.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from psydac.linalg.utilities import array_to_psydac
 from psydac.fem.basic import FemField, FemSpace
 from psydac.utilities.utils import refine_array_1d
-from psydac.feec.pull_push import push_2d_h1, push_2d_hcurl, push_2d_hdiv, push_2d_l2
+from psydac.feec.pull_push import push_2d_h1_vec, push_2d_h1, push_2d_hcurl, push_2d_hdiv, push_2d_l2
 
 __all__ = (
     'get_grid_vals',
@@ -42,10 +42,8 @@ def get_grid_vals(u, etas, mappings_list, space_kind=None):
 
     if space_kind is None:
         # use a simple change of variable
-        if vector_valued:
-            raise NotImplementedError('use simple change of variable for vector fields [todo]')
-        else:
-            space_kind = 'h1'
+        # todo [MCP 26.03.2025]: this information should be stored in the FemSpace object!
+        space_kind = 'h1'
             
     if vector_valued:
         # WARNING: here we assume 2D !
@@ -75,12 +73,16 @@ def get_grid_vals(u, etas, mappings_list, space_kind=None):
 
         # computing the pushed-fwd values on the grid
         if space_kind == 'h1' or space_kind == 'V0':
-            assert not vector_valued
-            # todo (MCP): allow for "h1 push-forward" (single change of variable) of vector-valued fields
 
-            def push_field(
-                eta1, eta2): return push_2d_h1(
-                uk_field_0, eta1, eta2)
+            if vector_valued:
+                def push_field(
+                    eta1, eta2): return push_2d_h1_vec(
+                    uk_field_0, uk_field_1, eta1, eta2)
+            
+            else:
+                def push_field(
+                    eta1, eta2): return push_2d_h1(
+                    uk_field_0, eta1, eta2)
         elif space_kind == 'hcurl' or space_kind == 'V1':
             # todo (MCP): specify 2d_hcurl_scalar in push functions
             def push_field(

--- a/psydac/fem/plotting_utilities.py
+++ b/psydac/fem/plotting_utilities.py
@@ -20,7 +20,7 @@ __all__ = (
     'get_plotting_grid',
     'get_diag_grid',
     'get_patch_knots_gridlines',
-    'plot_field',
+    'plot_field_2d',
     'my_small_plot',
     'my_small_streamplot')
 
@@ -256,7 +256,7 @@ def get_patch_knots_gridlines(Vh, N, mappings, plotted_patch=-1):
 # ------------------------------------------------------------------------------
 
 
-def plot_field(
+def plot_field_2d(
         fem_field=None,
         stencil_coeffs=None,
         numpy_coeffs=None,
@@ -315,7 +315,7 @@ def plot_field(
     vh_vals = grid_vals(vh)
     if plot_type == 'vector_field' and not vh.is_vector_valued:
         print(
-            "WARNING [plot_field]: vector_field plot is not possible with a scalar field, plotting the amplitude instead")
+            "WARNING [plot_field_2d]: vector_field plot is not possible with a scalar field, plotting the amplitude instead")
         plot_type = 'amplitude'
 
     if plot_type == 'vector_field':

--- a/psydac/fem/plotting_utilities.py
+++ b/psydac/fem/plotting_utilities.py
@@ -293,7 +293,7 @@ def plot_field_2d(
     if vh is None:
         if numpy_coeffs is not None:
             assert stencil_coeffs is None
-            stencil_coeffs = array_to_psydac(numpy_coeffs, Vh.vector_space)
+            stencil_coeffs = array_to_psydac(numpy_coeffs, Vh.coeff_space)
         vh = FemField(Vh, coeffs=stencil_coeffs)
 
     mappings = domain.mappings

--- a/psydac/fem/plotting_utilities.py
+++ b/psydac/fem/plotting_utilities.py
@@ -577,7 +577,7 @@ def my_small_streamplot(
     # X, Y = np.meshgrid(x, y)
     max_val = max(np.max(vals_x), np.max(vals_y))
     # print('max_val = {}'.format(max_val))
-    vf_amp = amp_factor / max_val
+    vf_amp = amp_factor / (max_val + 1e-20)
     for k in range(n_patches):
         ax.quiver(xx[k][::skip,
                         ::skip],

--- a/psydac/fem/plotting_utilities.py
+++ b/psydac/fem/plotting_utilities.py
@@ -35,7 +35,7 @@ def get_grid_vals(u, etas, mappings_list, space_kind=None):
     """
     n_patches = len(mappings_list)
     if isinstance(u, FemField):
-        vector_valued = u.is_vector_valued 
+        vector_valued = u.space.is_vector_valued 
     else:
         # then u should be callable
         vector_valued = isinstance(u, (list, tuple)) # [MCP 04.03.25]: this needs to be tested
@@ -304,13 +304,13 @@ def plot_field_2d(
         v, etas, mappings_list, space_kind=space_kind)
 
     vh_vals = grid_vals(vh)
-    if plot_type == 'vector_field' and not vh.is_vector_valued:
+    if plot_type == 'vector_field' and not vh.space.is_vector_valued:
         print(
             "WARNING [plot_field_2d]: vector_field plot is not possible with a scalar field, plotting the amplitude instead")
         plot_type = 'amplitude'
 
     if plot_type == 'vector_field':
-        if vh.is_vector_valued:
+        if vh.space.is_vector_valued:
             my_small_streamplot(
                 title=title,
                 vals_x=vh_vals[0],
@@ -328,7 +328,7 @@ def plot_field_2d(
         # computing plot_vals_list: may have several elements for several plots
         if plot_type == 'amplitude':
 
-            if vh.is_vector_valued:
+            if vh.space.is_vector_valued:
                 # then vh_vals[d] contains the values of the d-component of vh
                 # (as a patch-indexed list)
                 plot_vals = [np.sqrt(abs(v[0])**2 + abs(v[1])**2)
@@ -340,7 +340,7 @@ def plot_field_2d(
             plot_vals_list = [plot_vals]
 
         elif plot_type == 'components':
-            if vh.is_vector_valued:
+            if vh.space.is_vector_valued:
                 # then vh_vals[d] contains the values of the d-component of vh
                 # (as a patch-indexed list)
                 plot_vals_list = vh_vals
@@ -368,27 +368,6 @@ def plot_field_2d(
             cmap=cmap,
             dpi=300,
         )
-
-    # if is_vector_valued(vh):
-    #     # then vh_vals[d] contains the values of the d-component of vh (as a patch-indexed list)
-    #     vh_abs_vals = [np.sqrt(abs(v[0])**2 + abs(v[1])**2) for v in zip(vh_vals[0],vh_vals[1])]
-    # else:
-    #     # then vh_vals just contains the values of vh (as a patch-indexed list)
-    #     vh_abs_vals = np.abs(vh_vals)
-
-    # my_small_plot(
-    #     title=title,
-    #     vals=[vh_abs_vals],
-    #     titles=subtitles,
-    #     xx=xx,
-    #     yy=yy,
-    #     surface_plot=False,
-    #     save_fig=filename,
-    #     save_vals=False,
-    #     hide_plot=hide_plot,
-    #     cmap='hsv',
-    #     dpi = 400,
-    # )
 
 # ------------------------------------------------------------------------------
 

--- a/psydac/fem/projectors.py
+++ b/psydac/fem/projectors.py
@@ -99,4 +99,4 @@ def knot_insertion_projection_operator(domain, codomain):
         else:
             ops.append(np.eye(d.nbasis))
 
-    return KroneckerDenseMatrix(domain.vector_space, codomain.vector_space, *ops)
+    return KroneckerDenseMatrix(domain.coeff_space, codomain.coeff_space, *ops)

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -266,7 +266,7 @@ class SplineSpace( FemSpace ):
         return None
 
     @property
-    def vector_space( self ):
+    def coeff_space( self ):
         """Returns the topological associated vector space."""
         return self._coeff_space
 

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -123,7 +123,7 @@ class SplineSpace( FemSpace ):
         self._degree        = degree
         self._pads          = pads or degree
         self._knots         = knots
-        self._periodic      = periodic
+        self._periodic      = periodic # this is a scalar bool
         self._multiplicity  = multiplicity
         self._dirichlet     = dirichlet
         self._basis         = basis
@@ -246,6 +246,9 @@ class SplineSpace( FemSpace ):
     def periodic( self ):
         """ True if domain is periodic, False otherwise.
         """
+        # [YG, 28.03.2025]: according to the abstract interface of FemSpace,
+        # this property should return a tuple of `ldim` booleans. Instead, this
+        # property returns a single boolean.
         return self._periodic
     
     @property
@@ -258,6 +261,8 @@ class SplineSpace( FemSpace ):
     def mapping( self ):
         """ Assume identity mapping for now.
         """
+        # [YG, 28.03.2025]: not clear why there should be no mapping here...
+        # Clearly this property is never used in Psydac.
         return None
 
     @property
@@ -331,15 +336,6 @@ class SplineSpace( FemSpace ):
     #--------------------------------------------------------------------------
     # Other properties
     #--------------------------------------------------------------------------
-
-    # note [MCP 27.03.2025]: 
-    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
-    # @property
-    # def is_scalar( self ):
-    #     """ Only scalar field is implemented for now.
-    #     """
-    #     return True
-
     @property
     def basis( self ):
         return self._basis

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -265,18 +265,6 @@ class SplineSpace( FemSpace ):
         """Returns the topological associated vector space."""
         return self._vector_space
 
-    # @property
-    # def is_product(self):
-    #     return False
-
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        return False
-
     @property
     def symbolic_space( self ):
         return self._symbolic_space
@@ -324,10 +312,31 @@ class SplineSpace( FemSpace ):
     # Other properties
     #--------------------------------------------------------------------------
     @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
+    # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
+    @property
     def is_scalar( self ):
         """ Only scalar field is implemented for now.
         """
         return True
+
+    @property
+    def patch_spaces(self):
+        return (self,)
+
+    @property
+    def component_spaces(self):
+        return (self,)
+
+    @property
+    def axis_spaces(self):
+        return (self,)
 
     @property
     def basis( self ):

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -270,6 +270,14 @@ class SplineSpace( FemSpace ):
         return False
 
     @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
+    @property
     def symbolic_space( self ):
         return self._symbolic_space
 

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -274,6 +274,14 @@ class SplineSpace( FemSpace ):
         assert isinstance(symbolic_space, BasicFunctionSpace)
         self._symbolic_space = symbolic_space
 
+    @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------
@@ -311,13 +319,6 @@ class SplineSpace( FemSpace ):
     #--------------------------------------------------------------------------
     # Other properties
     #--------------------------------------------------------------------------
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        return False
 
     # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
     @property

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -265,9 +265,9 @@ class SplineSpace( FemSpace ):
         """Returns the topological associated vector space."""
         return self._vector_space
 
-    @property
-    def is_product(self):
-        return False
+    # @property
+    # def is_product(self):
+    #     return False
 
     @property
     def is_multipatch(self):

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -320,12 +320,13 @@ class SplineSpace( FemSpace ):
     # Other properties
     #--------------------------------------------------------------------------
 
-    # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
-    @property
-    def is_scalar( self ):
-        """ Only scalar field is implemented for now.
-        """
-        return True
+    # note [MCP 27.03.2025]: 
+    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
+    # @property
+    # def is_scalar( self ):
+    #     """ Only scalar field is implemented for now.
+    #     """
+    #     return True
 
     @property
     def patch_spaces(self):

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -282,6 +282,18 @@ class SplineSpace( FemSpace ):
     def is_vector_valued(self):
         return False
 
+    @property
+    def patch_spaces(self):
+        return (self,)
+
+    @property
+    def component_spaces(self):
+        return (self,)
+
+    @property
+    def axis_spaces(self):
+        return (self,)
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------
@@ -327,18 +339,6 @@ class SplineSpace( FemSpace ):
     #     """ Only scalar field is implemented for now.
     #     """
     #     return True
-
-    @property
-    def patch_spaces(self):
-        return (self,)
-
-    @property
-    def component_spaces(self):
-        return (self,)
-
-    @property
-    def axis_spaces(self):
-        return (self,)
 
     @property
     def basis( self ):

--- a/psydac/fem/splines.py
+++ b/psydac/fem/splines.py
@@ -139,7 +139,7 @@ class SplineSpace( FemSpace ):
         # Create space of spline coefficients
         domain_decomposition = DomainDecomposition([self._ncells], [periodic])
         cart     = CartDecomposition(domain_decomposition, [nbasis], [np.array([0])],[np.array([nbasis-1])], [self._pads], [multiplicity])
-        self._vector_space = StencilVectorSpace( cart )
+        self._coeff_space = StencilVectorSpace(cart)
 
         # Store flag: object NOT YET prepared for interpolation / histopolation
         self._interpolation_ready = False
@@ -263,7 +263,7 @@ class SplineSpace( FemSpace ):
     @property
     def vector_space( self ):
         """Returns the topological associated vector space."""
-        return self._vector_space
+        return self._coeff_space
 
     @property
     def symbolic_space( self ):

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -158,9 +158,9 @@ class TensorFemSpace(FemSpace):
         """Returns the topological associated vector space."""
         return self._vector_space
 
-    @property
-    def is_product(self):
-        return False
+    # @property
+    # def is_product(self):
+    #     return False
 
     @property
     def is_multipatch(self):

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -183,6 +183,14 @@ class TensorFemSpace(FemSpace):
     def axis_spaces(self):
         return self._spaces
 
+    @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------
@@ -710,14 +718,6 @@ class TensorFemSpace(FemSpace):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
-
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        return False
 
     # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
     @property

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -723,13 +723,6 @@ class TensorFemSpace(FemSpace):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
-
-    # note [MCP 27.03.2025]: 
-    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
-    # @property
-    # def is_scalar(self):
-    #     return True
-
     @property
     def dtype(self):
         return self._dtype

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -143,7 +143,10 @@ class TensorFemSpace(FemSpace):
 
     @property
     def periodic(self):
-        return [V.periodic for V in self.spaces]
+        # [YG, 27.03.2025]: according to the abstract interface of FemSpace,
+        # this property should return a tuple of `ldim` booleans. However, the
+        # spaces in self.spaces seem to be returning a single scalar value.
+        return tuple(V.periodic for V in self.spaces)
 
     @property
     def domain_decomposition(self):

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -163,6 +163,14 @@ class TensorFemSpace(FemSpace):
         return False
 
     @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
+    @property
     def symbolic_space( self ):
         return self._symbolic_space 
 

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -58,7 +58,7 @@ class TensorFemSpace(FemSpace):
     *spaces : psydac.fem.splines.SplineSpace
         1D finite element spaces.
 
-    vector_space : psydac.linalg.stencil.StencilVectorSpace or None
+    coeff_space : psydac.linalg.stencil.StencilVectorSpace or None
         The vector space to which the coefficients belong (optional).
 
     cart : psydac.ddm.CartDecomposition or None
@@ -75,7 +75,7 @@ class TensorFemSpace(FemSpace):
 
     """
 
-    def __init__(self, domain_decomposition, *spaces, vector_space=None, cart=None, dtype=float):
+    def __init__(self, domain_decomposition, *spaces, coeff_space=None, cart=None, dtype=float):
 
         assert isinstance(domain_decomposition, DomainDecomposition)
         assert all(isinstance(s, SplineSpace) for s in spaces)
@@ -83,30 +83,30 @@ class TensorFemSpace(FemSpace):
         # TODO [YG 10.04.2024]: check if dtype test is too restrictive
 
         # Handle optional arguments
-        if cart and vector_space:
-            raise ValueError("Cannot provide both 'vector_space' and 'cart' to constructor")
+        if cart and coeff_space:
+            raise ValueError("Cannot provide both 'coeff_space' and 'cart' to constructor")
         elif cart is not None:
             assert isinstance(cart, CartDecomposition)
-            vector_space = StencilVectorSpace(cart, dtype=dtype)
-        elif vector_space is not None:
-            assert isinstance(vector_space, StencilVectorSpace)
-            cart = vector_space.cart
+            coeff_space = StencilVectorSpace(cart, dtype=dtype)
+        elif coeff_space is not None:
+            assert isinstance(coeff_space, StencilVectorSpace)
+            cart = coeff_space.cart
         else:
             cart = create_cart([domain_decomposition], [spaces])[0]
-            vector_space = StencilVectorSpace(cart, dtype=dtype)
+            coeff_space = StencilVectorSpace(cart, dtype=dtype)
 
         # Store some info
         self._domain_decomposition = domain_decomposition
         self._spaces               = spaces
         self._dtype                = dtype
-        self._coeff_space          = vector_space
+        self._coeff_space          = coeff_space
         self._symbolic_space       = None
         self._refined_space        = {}
         self._interfaces           = {}
         self._interfaces_readonly  = MappingProxyType(self._interfaces)
 
         # If process does not own space, stop here
-        if vector_space.parallel and cart.is_comm_null:
+        if coeff_space.parallel and cart.is_comm_null:
             return
 
         # Determine portion of logical domain local to process.
@@ -159,7 +159,7 @@ class TensorFemSpace(FemSpace):
         return None
 
     @property
-    def vector_space(self):
+    def coeff_space(self):
         """Returns the topological associated vector space."""
         return self._coeff_space
 
@@ -307,7 +307,7 @@ class TensorFemSpace(FemSpace):
         assert len(grid) == self.ldim
 
         # Get the local domain
-        v = self.vector_space
+        v = self.coeff_space
         starts, ends = self.local_domain
 
         # Add the overlap if we are in parallel
@@ -373,7 +373,7 @@ class TensorFemSpace(FemSpace):
         assert len(grid) == self.ldim
 
         # Get the local domain
-        v = self.vector_space
+        v = self.coeff_space
         starts, ends = self.local_domain
 
         # Add the overlap if we are in parallel
@@ -710,8 +710,8 @@ class TensorFemSpace(FemSpace):
                 c += f(*y) * np_prod(v)
 
         # All reduce (MPI_SUM)
-        if self.vector_space.parallel:
-            mpi_comm = self.vector_space.cart.comm
+        if self.coeff_space.parallel:
+            mpi_comm = self.coeff_space.cart.comm
             c = mpi_comm.allreduce(c)
 
         # convert to native python type if numpy to avoid errors with sympify
@@ -754,7 +754,7 @@ class TensorFemSpace(FemSpace):
 
     @property
     def pads(self):
-        return self.vector_space.pads
+        return self.coeff_space.pads
 
     @property
     def ncells(self):
@@ -884,7 +884,7 @@ class TensorFemSpace(FemSpace):
             values.
 
         """
-        assert values.space is self.vector_space
+        assert values.space is self.coeff_space
         assert isinstance( field, FemField )
         assert field.space is self
 
@@ -972,7 +972,7 @@ class TensorFemSpace(FemSpace):
         assert isinstance(filename, str)
         assert all(field.space is self for field in fields.values())
 
-        V    = self.vector_space
+        V    = self.coeff_space
         comm = V.cart.comm if V.parallel else None
 
         # Multi-dimensional index range local to process
@@ -1015,7 +1015,7 @@ class TensorFemSpace(FemSpace):
         assert isinstance(filename, str)
         assert all(isinstance(name, str) for name in field_names)
 
-        V    = self.vector_space
+        V    = self.coeff_space
         comm = V.cart.comm if V.parallel else None
 
         # Multi-dimensional index range local to process
@@ -1158,12 +1158,12 @@ class TensorFemSpace(FemSpace):
             return
 
         spaces      = self.spaces
-        coeff_space = self.vector_space
+        coeff_space = self.coeff_space
 
         coeff_space.set_interface(axis, ext, cart)
 
         space = TensorFemSpace(self._domain_decomposition, *spaces,
-                               vector_space=coeff_space.interfaces[axis, ext],
+                               coeff_space=coeff_space.interfaces[axis, ext],
                                dtype=coeff_space.dtype)
 
         self._interfaces[axis, ext] = space
@@ -1192,7 +1192,7 @@ class TensorFemSpace(FemSpace):
         N = int(refine)
         V1, V2 = self.spaces
 
-        mpi_comm = self.vector_space.cart.comm
+        mpi_comm = self.coeff_space.cart.comm
         mpi_rank = mpi_comm.rank
 
         # Local grid, refined

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -719,10 +719,11 @@ class TensorFemSpace(FemSpace):
     # Other properties and methods
     #--------------------------------------------------------------------------
 
-    # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
-    @property
-    def is_scalar(self):
-        return True
+    # note [MCP 27.03.2025]: 
+    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
+    # @property
+    # def is_scalar(self):
+    #     return True
 
     @property
     def dtype(self):

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -136,13 +136,18 @@ class TensorFemSpace(FemSpace):
     # Abstract interface: read-only attributes
     #--------------------------------------------------------------------------
     @property
-    def ldim( self ):
+    def ldim(self):
         """ Parametric dimension.
         """
         return sum([V.ldim for V in self.spaces])
 
     @property
     def periodic(self):
+        """
+        Tuple of booleans: along each logical dimension,
+        say if domain is periodic.
+        :rtype: tuple[bool]
+        """
         # [YG, 27.03.2025]: according to the abstract interface of FemSpace,
         # this property should return a tuple of `ldim` booleans. However, the
         # spaces in self.spaces seem to be returning a single scalar value.
@@ -160,7 +165,10 @@ class TensorFemSpace(FemSpace):
 
     @property
     def coeff_space(self):
-        """Returns the topological associated vector space."""
+        """
+        Vector space of the coefficients (mapping invariant).
+        :rtype: psydac.linalg.stencil.StencilVectorSpace
+        """
         return self._coeff_space
 
     @property

--- a/psydac/fem/tensor.py
+++ b/psydac/fem/tensor.py
@@ -158,18 +158,6 @@ class TensorFemSpace(FemSpace):
         """Returns the topological associated vector space."""
         return self._vector_space
 
-    # @property
-    # def is_product(self):
-    #     return False
-
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        return False
-
     @property
     def symbolic_space( self ):
         return self._symbolic_space 
@@ -182,6 +170,18 @@ class TensorFemSpace(FemSpace):
     def symbolic_space( self, symbolic_space ):
         assert isinstance(symbolic_space, BasicFunctionSpace)
         self._symbolic_space = symbolic_space
+
+    @property
+    def patch_spaces(self):
+        return (self,)
+
+    @property
+    def component_spaces(self):
+        return (self,)
+
+    @property
+    def axis_spaces(self):
+        return self._spaces
 
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
@@ -710,6 +710,16 @@ class TensorFemSpace(FemSpace):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
+
+    @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return False
+
+    # question [MCP 03.2025]: this is not in the FemSpace interface, redundant with is_vector_valued. keep it ?
     @property
     def is_scalar(self):
         return True

--- a/psydac/fem/tests/test_plot_field_2d.py
+++ b/psydac/fem/tests/test_plot_field_2d.py
@@ -17,9 +17,7 @@ from psydac.fem.plotting_utilities import plot_field_2d as plot_field
 
 
 def plot_some_field(Vh):
-
     uh = FemField(Vh)
-    # uh.coeffs._data[:] = np.random.rand(uh.coeffs._data.size)
 
     domain  = Vh.symbolic_space.domain
     if Vh.is_multipatch:
@@ -40,6 +38,10 @@ def plot_some_field(Vh):
 @pytest.mark.parametrize('use_scalar_field', [True, False])
 @pytest.mark.parametrize('use_multipatch', [True, False])
 def test_plot_field(use_scalar_field, use_multipatch):
+    """
+    tests that plot_field_2d runs for various types of Fem fields
+    (the proper content of the plots is not tested here)
+    """
 
     ncells = [7, 7]
     degree = [2, 2]

--- a/psydac/fem/tests/test_plot_field_2d.py
+++ b/psydac/fem/tests/test_plot_field_2d.py
@@ -23,8 +23,7 @@ def plot_some_field(Vh):
     if Vh.is_multipatch:
         domain_type = 'multi_patch'
     else:
-        domain_type = 'single_patch'
-        '.pdf'    
+        domain_type = 'single_patch'    
     plot_types = ['amplitude']
     if Vh.is_vector_valued:
         values_type = 'vector'

--- a/psydac/fem/tests/test_plot_fields_2d.py
+++ b/psydac/fem/tests/test_plot_fields_2d.py
@@ -1,0 +1,75 @@
+# from mpi4py import MPI
+# from sympy import pi, cos, sin, log, exp, lambdify, symbols
+import pytest
+import numpy as np
+
+from sympde.topology import Domain, Square
+from sympde.topology import PolarMapping
+from sympde.topology import ScalarFunctionSpace, VectorFunctionSpace
+
+from psydac.fem.basic              import FemField
+# from psydac.fem.tensor             import TensorFemSpace
+# from psydac.fem.vector             import VectorFemSpace
+from psydac.api.discretization     import discretize
+from psydac.fem.plotting_utilities import plot_field_2d as plot_field
+
+#------------------------------------------------------------------------------
+
+
+def plot_some_field(Vh):
+
+    uh = FemField(Vh)
+    # uh.coeffs._data[:] = np.random.rand(uh.coeffs._data.size)
+
+    domain  = Vh.symbolic_space.domain
+    if Vh.is_multipatch:
+        domain_type = 'multi_patch'
+    else:
+        domain_type = 'single_patch'
+        '.pdf'    
+    plot_types = ['amplitude']
+    if Vh.is_vector_valued:
+        values_type = 'vector'
+        plot_types.append('vector_field')
+    else:
+        values_type = 'scalar'
+    for plot_type in plot_types:
+        plot_fn=f'uh_{domain_type}_{values_type}_{plot_type}_test.pdf'
+        plot_field(fem_field=uh, Vh=Vh, domain=domain, plot_type=plot_type, title='uh', filename=plot_fn, hide_plot=True)
+
+@pytest.mark.parametrize('use_scalar_field', [True, False])
+@pytest.mark.parametrize('use_multipatch', [True, False])
+def test_plot_field(use_scalar_field, use_multipatch):
+
+    ncells = [7, 7]
+    degree = [2, 2]
+
+    A = Square('A',bounds1=(0.5, 1.), bounds2=(0, np.pi/2))
+    mapping_1 = PolarMapping('M1',2, c1= 0., c2= 0., rmin = 0., rmax=1.)
+    D1     = mapping_1(A)
+    
+    if use_multipatch:
+        B = Square('B',bounds1=(0.5, 1.), bounds2=(np.pi/2, np.pi))
+        mapping_2 = PolarMapping('M2',2, c1= 0., c2= 0., rmin = 0., rmax=1.)
+        D2     = mapping_2(B)
+        
+        connectivity = [((0,1,1),(1,1,-1))]
+        patches = [D1,D2]
+        domain = Domain.join(patches, connectivity, 'domain')
+    else:
+        domain = D1
+
+    if use_scalar_field:
+        V = ScalarFunctionSpace('V', domain=domain)
+    else:
+        V = VectorFunctionSpace('V', domain=domain)
+
+    domain_h = discretize(domain, ncells=ncells)
+    Vh       = discretize(V, domain_h, degree=degree)
+
+    plot_some_field(Vh)
+
+if __name__ == '__main__':
+    for use_scalar_field in [True, False]:
+        for use_multipatch in [True, False]:
+            test_plot_field(use_scalar_field, use_multipatch)

--- a/psydac/fem/tests/test_product.py
+++ b/psydac/fem/tests/test_product.py
@@ -3,7 +3,7 @@
 from psydac.fem.basic   import FemField
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
-from psydac.fem.vector  import create_product_space
+from psydac.fem.vector  import VectorFemSpace
 from psydac.ddm.cart    import DomainDecomposition
 
 from numpy import linspace
@@ -30,7 +30,7 @@ def test_product_space_2d():
     Vy = TensorFemSpace(domain_decomposition, V1, V2)
     # ...
 
-    V = create_product_space(Vx, Vy)
+    V = VectorFemSpace(Vx, Vy)
     F = FemField(V)
 
 def test_product_space_3d():
@@ -67,7 +67,7 @@ def test_product_space_3d():
     Vz = TensorFemSpace(domain_decomposition, V1, V2, V3)
     # ...
 
-    V = create_product_space(Vx, Vy, Vz)
+    V = VectorFemSpace(Vx, Vy, Vz)
     F = FemField(V)
 
 

--- a/psydac/fem/tests/test_product.py
+++ b/psydac/fem/tests/test_product.py
@@ -3,7 +3,7 @@
 from psydac.fem.basic   import FemField
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
-from psydac.fem.vector  import MultipatchFemSpace
+from psydac.fem.vector  import create_product_space
 from psydac.ddm.cart    import DomainDecomposition
 
 from numpy import linspace
@@ -30,7 +30,7 @@ def test_product_space_2d():
     Vy = TensorFemSpace(domain_decomposition, V1, V2)
     # ...
 
-    V = MultipatchFemSpace(Vx, Vy)
+    V = create_product_space(Vx, Vy)
     F = FemField(V)
 
 def test_product_space_3d():
@@ -67,7 +67,7 @@ def test_product_space_3d():
     Vz = TensorFemSpace(domain_decomposition, V1, V2, V3)
     # ...
 
-    V = MultipatchFemSpace(Vx, Vy, Vz)
+    V = create_product_space(Vx, Vy, Vz)
     F = FemField(V)
 
 

--- a/psydac/fem/tests/test_product.py
+++ b/psydac/fem/tests/test_product.py
@@ -3,7 +3,7 @@
 from psydac.fem.basic   import FemField
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
-from psydac.fem.vector  import ProductFemSpace
+from psydac.fem.vector  import MultipatchFemSpace
 from psydac.ddm.cart    import DomainDecomposition
 
 from numpy import linspace
@@ -30,7 +30,7 @@ def test_product_space_2d():
     Vy = TensorFemSpace(domain_decomposition, V1, V2)
     # ...
 
-    V = ProductFemSpace(Vx, Vy)
+    V = MultipatchFemSpace(Vx, Vy)
     F = FemField(V)
 
 def test_product_space_3d():
@@ -67,7 +67,7 @@ def test_product_space_3d():
     Vz = TensorFemSpace(domain_decomposition, V1, V2, V3)
     # ...
 
-    V = ProductFemSpace(Vx, Vy, Vz)
+    V = MultipatchFemSpace(Vx, Vy, Vz)
     F = FemField(V)
 
 

--- a/psydac/fem/tests/test_spline_interpolation.py
+++ b/psydac/fem/tests/test_spline_interpolation.py
@@ -124,7 +124,7 @@ def test_SplineInterpolation2D_parallel_exact( nc1, nc2, deg1, deg2 ):
     x2g = space2.greville
 
     # Interpolation data on Greville points (distributed)
-    V     = tensor_space.vector_space
+    V     = tensor_space.coeff_space
     ug    = V.zeros()
     s1,s2 = V.starts
     e1,e2 = V.ends

--- a/psydac/fem/tests/test_splines_par.py
+++ b/psydac/fem/tests/test_splines_par.py
@@ -27,15 +27,15 @@ def test_2d_1():
     V = TensorFemSpace(domain_decomposition, V1, V2)
 
     if rank == 0:
-        print(V.vector_space.cart.nprocs)
+        print(V.coeff_space.cart.nprocs)
     for i in range(comm.Get_size()):
         if rank == i:
             print('rank ', rank)
             print('TensorFemSpace ', V)
             print('VectorSpace ')
-            print('> npts ::', V.vector_space.npts)
-            print('> starts ::', V.vector_space.starts)
-            print('> ends ::', V.vector_space.ends)
+            print('> npts ::', V.coeff_space.npts)
+            print('> starts ::', V.coeff_space.starts)
+            print('> ends ::', V.coeff_space.ends)
             print('', flush=True)
         comm.Barrier()
 

--- a/psydac/fem/tests/test_vector_spaces.py
+++ b/psydac/fem/tests/test_vector_spaces.py
@@ -12,8 +12,6 @@ from psydac.linalg.block import BlockVector, BlockVectorSpace
 
 
 def test_vector_space_2d():
-    print ('>>> test_vector_space_2d')
-
     p = 2
     grid_1 = linspace(0., 1., 3)
     grid_2 = linspace(0., 1., 5)
@@ -70,9 +68,8 @@ def test_vector_space_2d():
     assert F.patch_fields == (F,)
     assert F.component_fields == F.fields
 
-def test_vector_space_3d():
-    print ('>>> test_vector_space_3d')
 
+def test_vector_space_3d():
     p = 2
     grid_1 = linspace(0., 1., 3)
     grid_2 = linspace(0., 1., 5)
@@ -107,9 +104,47 @@ def test_vector_space_3d():
     V = VectorFemSpace(Vx, Vy, Vz)
     F = FemField(V)
 
+    # Check properties of V from abstract interface
+    assert V.ldim == 3
+    assert V.periodic == (False, False, False)
+    assert V.mapping is None
+    assert isinstance(V.vector_space, BlockVectorSpace)
+    assert not V.is_multipatch
+    assert V.is_vector_valued
+    assert V.symbolic_space is None
+    assert V.patch_spaces == (V,)
+    assert V.component_spaces == (Vx, Vy, Vz)
+    with pytest.raises(NotImplementedError):
+        getattr(V, 'axis_spaces')
+    assert V.is_multipatch == False
+    assert V.is_vector_valued == True
+
+    # Check other properties of V
+    assert V.nbasis == Vx.nbasis + Vy.nbasis + Vz.nbasis
+    assert V.degree == [Vx.degree, Vy.degree, Vz.degree]
+    assert V.multiplicity == [Vx.multiplicity, Vy.multiplicity, Vz.multiplicity]
+    assert V.pads == [Vx.pads, Vy.pads, Vz.pads]
+    assert V.ncells == Vx.ncells == Vy.ncells == Vz.ncells
+    assert V.spaces == (Vx, Vy, Vz)
+
+    # Check properties of F
+    assert F.space == V
+    assert isinstance(F.coeffs, BlockVector)
+    assert len(F.fields) == 3
+    assert isinstance(F.fields[0], FemField)
+    assert isinstance(F.fields[1], FemField)
+    assert isinstance(F.fields[2], FemField)
+    assert F.fields[0].space == Vx
+    assert F.fields[1].space == Vy
+    assert F.fields[2].space == Vz
+    assert F.patch_fields == (F,)
+    assert F.component_fields == F.fields
 
 ###############################################
 if __name__ == '__main__':
 
+    print('>>> test_vector_space_2d')
     test_vector_space_2d()
+
+    print ('>>> test_vector_space_3d')
     test_vector_space_3d()

--- a/psydac/fem/tests/test_vector_spaces.py
+++ b/psydac/fem/tests/test_vector_spaces.py
@@ -1,12 +1,14 @@
 # -*- coding: UTF-8 -*-
 
+from numpy import linspace
+
 from psydac.fem.basic   import FemField
 from psydac.fem.splines import SplineSpace
 from psydac.fem.tensor  import TensorFemSpace
 from psydac.fem.vector  import VectorFemSpace
 from psydac.ddm.cart    import DomainDecomposition
+from psydac.linalg.block import BlockVector, BlockVectorSpace
 
-from numpy import linspace
 
 def test_vector_space_2d():
     print ('>>> test_vector_space_2d')
@@ -32,6 +34,40 @@ def test_vector_space_2d():
 
     V = VectorFemSpace(Vx, Vy)
     F = FemField(V)
+
+    # Check properties of V from abstract interface
+    assert V.ldim == 2
+    assert V.periodic == (False, False)
+    assert V.mapping is None
+    assert isinstance(V.vector_space, BlockVectorSpace)
+    assert not V.is_multipatch
+    assert V.is_vector_valued
+    assert V.symbolic_space is None
+    assert V.patch_spaces == (V,)
+    assert V.component_spaces == (Vx, Vy)
+    with pytest.raises(NotImplementedError):
+        getattr(V, 'axis_spaces')
+    assert V.is_multipatch == False
+    assert V.is_vector_valued == True
+
+    # Check other properties of V
+    assert V.nbasis == Vx.nbasis + Vy.nbasis
+    assert V.degree == [Vx.degree, Vy.degree]
+    assert V.multiplicity == [Vx.multiplicity, Vy.multiplicity]
+    assert V.pads == [Vx.pads, Vy.pads]
+    assert V.ncells == Vx.ncells == Vy.ncells
+    assert V.spaces == (Vx, Vy)
+
+    # Check properties of F
+    assert F.space == V
+    assert isinstance(F.coeffs, BlockVector)
+    assert len(F.fields) == 2
+    assert isinstance(F.fields[0], FemField)
+    assert isinstance(F.fields[1], FemField)
+    assert F.fields[0].space == Vx
+    assert F.fields[1].space == Vy
+    assert F.patch_fields == (F,)
+    assert F.component_fields == F.fields
 
 def test_vector_space_3d():
     print ('>>> test_vector_space_3d')

--- a/psydac/fem/tests/test_vector_spaces.py
+++ b/psydac/fem/tests/test_vector_spaces.py
@@ -38,7 +38,7 @@ def test_vector_space_2d():
     assert V.ldim == 2
     assert V.periodic == (False, False)
     assert V.mapping is None
-    assert isinstance(V.vector_space, BlockVectorSpace)
+    assert isinstance(V.coeff_space, BlockVectorSpace)
     assert not V.is_multipatch
     assert V.is_vector_valued
     assert V.symbolic_space is None
@@ -108,7 +108,7 @@ def test_vector_space_3d():
     assert V.ldim == 3
     assert V.periodic == (False, False, False)
     assert V.mapping is None
-    assert isinstance(V.vector_space, BlockVectorSpace)
+    assert isinstance(V.coeff_space, BlockVectorSpace)
     assert not V.is_multipatch
     assert V.is_vector_valued
     assert V.symbolic_space is None

--- a/psydac/fem/tests/test_vector_spaces.py
+++ b/psydac/fem/tests/test_vector_spaces.py
@@ -1,5 +1,6 @@
 # -*- coding: UTF-8 -*-
 
+import pytest
 from numpy import linspace
 
 from psydac.fem.basic   import FemField

--- a/psydac/fem/tests/test_vector_spaces.py
+++ b/psydac/fem/tests/test_vector_spaces.py
@@ -8,8 +8,8 @@ from psydac.ddm.cart    import DomainDecomposition
 
 from numpy import linspace
 
-def test_product_space_2d():
-    print ('>>> test_product_space_2d')
+def test_vector_space_2d():
+    print ('>>> test_vector_space_2d')
 
     p = 2
     grid_1 = linspace(0., 1., 3)
@@ -33,8 +33,8 @@ def test_product_space_2d():
     V = VectorFemSpace(Vx, Vy)
     F = FemField(V)
 
-def test_product_space_3d():
-    print ('>>> test_product_space_3d')
+def test_vector_space_3d():
+    print ('>>> test_vector_space_3d')
 
     p = 2
     grid_1 = linspace(0., 1., 3)
@@ -74,5 +74,5 @@ def test_product_space_3d():
 ###############################################
 if __name__ == '__main__':
 
-    test_product_space_2d()
-    test_product_space_3d()
+    test_vector_space_2d()
+    test_vector_space_3d()

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -79,7 +79,7 @@ class VectorFemSpace(FemSpace):
         self._ldim           : int              = ldims[0]
         self._periodic       : tuple[bool, ...] = periodic[0]
         self._spaces         : tuple[FemSpace]  = new_spaces
-        self._vector_space   : BlockVectorSpace = coeff_space
+        self._coeff_space    : BlockVectorSpace = coeff_space
         self._ncells         : tuple[int, ...]  = ncells[0] # not used in the abstract interface
         self._mapping        : Optional[BasicCallableMapping] = mappings[0]
         self._symbolic_space : Optional[BasicFunctionSpace] = symbolic_space
@@ -121,7 +121,7 @@ class VectorFemSpace(FemSpace):
     @property
     def vector_space(self):
         """Returns the vector space of the coefficients (mapping invariant)."""
-        return self._vector_space
+        return self._coeff_space
 
     @property
     def symbolic_space( self ):
@@ -434,7 +434,7 @@ class MultipatchFemSpace( FemSpace ):
         self._ldim = ldims[0]
         # ...
 
-        self._vector_space    = BlockVectorSpace(*[V.vector_space for V in self.spaces], connectivity=connectivity)
+        self._coeff_space     = BlockVectorSpace(*[V.vector_space for V in self.spaces], connectivity=connectivity)
         self._symbolic_space  = None
         self._connectivity    = connectivity.copy()
     #--------------------------------------------------------------------------
@@ -457,7 +457,7 @@ class MultipatchFemSpace( FemSpace ):
     @property
     def vector_space(self):
         """Returns the vector space of the coefficients (mapping invariant)."""
-        return self._vector_space
+        return self._coeff_space
 
     @property
     def symbolic_space( self ):

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -18,7 +18,7 @@ from psydac.core.field_evaluation_kernels import (pushforward_2d_hdiv,
                                                   pushforward_2d_hcurl,
                                                   pushforward_3d_hcurl)
 
-__all__ = ('VectorFemSpace', 'ProductFemSpace')
+__all__ = ('VectorFemSpace', 'MultipatchFemSpace')
 
 #===============================================================================
 class VectorFemSpace( FemSpace ):
@@ -360,10 +360,9 @@ class VectorFemSpace( FemSpace ):
         return txt
 
 #===============================================================================
-class ProductFemSpace( FemSpace ):
+class MultipatchFemSpace( FemSpace ):
     """
-    Product of FEM spaces
-    this class is used to represent FEM spaces on a multi-patch domain.
+    Product of single-patch FEM spaces
     """
 
     def __new__(cls, *spaces, connectivity=None):
@@ -623,11 +622,11 @@ class ProductFemSpace( FemSpace ):
 
     # ...
     def eval_field_gradient( self, field, *eta ):
-        raise NotImplementedError( "ProductFemSpace not yet operational" )
+        raise NotImplementedError( "MultipatchFemSpace not yet operational" )
 
     # ...
     def integral( self, f ):
-        raise NotImplementedError( "ProductFemSpace not yet operational" )
+        raise NotImplementedError( "MultipatchFemSpace not yet operational" )
 
     #--------------------------------------------------------------------------
     # Other properties and methods

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -112,18 +112,6 @@ class VectorFemSpace( FemSpace ):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._vector_space
 
-    # @property
-    # def is_product(self):
-    #     return True
-
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        return True
-
     @property
     def symbolic_space( self ):
         return self._symbolic_space
@@ -132,6 +120,18 @@ class VectorFemSpace( FemSpace ):
     def symbolic_space( self, symbolic_space ):
         assert isinstance(symbolic_space, BasicFunctionSpace)
         self._symbolic_space = symbolic_space
+
+    @property
+    def patch_spaces(self):
+        return (self,)
+
+    @property
+    def component_spaces(self):
+        return self._spaces
+
+    @property
+    def axis_spaces(self):
+        raise NotImplementedError('Vector Fem space has no list of axis spaces')
 
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
@@ -334,6 +334,17 @@ class VectorFemSpace( FemSpace ):
     # Other properties and methods
     #--------------------------------------------------------------------------
     @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        # question (MCP 03.2025) do we allow scalar-valued VectorFemSpaces ?
+        return True
+
+    # question [MCP 03.2025]: this is not in the FemSpace interface,
+    # and almost redundant/inconsistent with is_vector_valued. keep it ?
+    @property
     def is_scalar(self):
         return len( self.spaces ) == 1
 
@@ -434,19 +445,6 @@ class MultipatchFemSpace( FemSpace ):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._vector_space
 
-    # @property
-    # def is_product(self):
-    #     return True
-
-    @property
-    def is_multipatch(self):
-        return True
-
-    @property
-    def is_vector_valued(self):
-        """ Returns True if the space is vector-valued, False otherwise. """
-        return self.patch_spaces[0].is_vector_valued
-        
     @property
     def symbolic_space( self ):
         return self._symbolic_space
@@ -455,6 +453,25 @@ class MultipatchFemSpace( FemSpace ):
     def symbolic_space( self, symbolic_space ):
         assert isinstance(symbolic_space, BasicFunctionSpace)
         self._symbolic_space = symbolic_space
+
+    @property
+    def patch_spaces(self):
+        return self._spaces
+
+    @property
+    def component_spaces(self):
+        """
+        Return the component spaces (self if scalar-valued) as a tuple.
+        """
+        if self.is_vector_valued:
+            # should we return here the multipatch scalar-valued space?
+            raise NotImplementedError('Component spaces not implemented for multipatch spaces')
+        else:
+            return self._spaces
+
+    @property
+    def axis_spaces(self):
+        raise NotImplementedError('Multipatch space has no list of axis spaces')
 
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
@@ -647,6 +664,14 @@ class MultipatchFemSpace( FemSpace ):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
+    @property
+    def is_multipatch(self):
+        return True
+
+    @property
+    def is_vector_valued(self):
+        return self.patch_spaces[0].is_vector_valued
+
     @property
     def nbasis(self):
         dims = [V.nbasis for V in self.spaces]

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -117,7 +117,6 @@ class VectorFemSpace( FemSpace ):
 
     @property
     def is_vector_valued(self):
-        # question (MCP 03.2025) do we allow scalar-valued VectorFemSpaces ?
         return True
 
     #--------------------------------------------------------------------------

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -90,9 +90,9 @@ class VectorFemSpace( FemSpace ):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._vector_space
 
-    @property
-    def is_product(self):
-        return True
+    # @property
+    # def is_product(self):
+    #     return True
 
     @property
     def is_multipatch(self):
@@ -418,9 +418,9 @@ class MultipatchFemSpace( FemSpace ):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._vector_space
 
-    @property
-    def is_product(self):
-        return True
+    # @property
+    # def is_product(self):
+    #     return True
 
     @property
     def is_multipatch(self):

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -352,13 +352,6 @@ class VectorFemSpace(FemSpace):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
-    
-    # note [MCP 27.03.2025]: 
-    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
-    #  @property
-    # def is_scalar(self):
-    #     return len( self.spaces ) == 1
-
     @property
     def nbasis(self):
         dims = [V.nbasis for V in self.spaces]

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -429,10 +429,8 @@ class ProductFemSpace( FemSpace ):
 
     @property
     def is_vector_valued(self):
-        return False        
-        # OR ?? should we:
-        # return self.patch_spaces[0].is_vector_valued
-        # (and define the component_spaces of a multi-patch vector-valued space as a scalar-valued multi-patch space ?)
+        """ Returns True if the space is vector-valued, False otherwise. """
+        return self.patch_spaces[0].is_vector_valued
         
     @property
     def symbolic_space( self ):

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -377,7 +377,7 @@ class MultipatchFemSpace( FemSpace ):
     Product of single-patch FEM spaces
     """
 
-    def __init__( self, *spaces, connectivity={}):
+    def __init__( self, *spaces, connectivity=None):
         """
         Parameters
         ----------

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -21,26 +21,26 @@ from psydac.core.field_evaluation_kernels import (pushforward_2d_hdiv,
 __all__ = ('VectorFemSpace', 'MultipatchFemSpace')
 
 #===============================================================================
-def create_product_space(*spaces, connectivity=None):
-    """
-    Factory function that creates a product FemSpace from a list of spaces:
-      - if the list contains a single space, this simply returns the given space as is
-      - otherwise:  
-        - if connectivity is None, returns a VectorFemSpace
-        - otherwise, returns a MultipatchFemSpace with the given connectivity
-    """
+# def create_product_space(*spaces, connectivity=None):
+#     """
+#     Factory function that creates a product FemSpace from a list of spaces:
+#       - if the list contains a single space, this simply returns the given space as is
+#       - otherwise:  
+#         - if connectivity is None, returns a VectorFemSpace
+#         - otherwise, returns a MultipatchFemSpace with the given connectivity
+#     """
 
-    if len(spaces) == 1:
-        return spaces[0]
-    else:
-        # check that all spaces are indeed single-patch Fem spaces
-        if connectivity is None:
-            assert all(isinstance(V, FemSpace) for V in spaces)
-            return VectorFemSpace(*spaces)
+#     if len(spaces) == 1:
+#         return spaces[0]
+#     else:
+#         # check that all spaces are indeed single-patch Fem spaces
+#         if connectivity is None:
+#             assert all(isinstance(V, FemSpace) for V in spaces)
+#             return VectorFemSpace(*spaces)
         
-        else:
-            assert all((isinstance(V, FemSpace) and not V.is_multipatch) for V in spaces)
-            return MultipatchFemSpace(*spaces, connectivity=connectivity)
+#         else:
+#             assert all((isinstance(V, FemSpace) and not V.is_multipatch) for V in spaces)
+#             return MultipatchFemSpace(*spaces, connectivity=connectivity)
 
 #===============================================================================
 class VectorFemSpace( FemSpace ):
@@ -399,13 +399,15 @@ class MultipatchFemSpace( FemSpace ):
     Product of single-patch FEM spaces
     """
 
-    def __init__( self, *spaces, connectivity=None):
+    def __init__( self, *spaces, connectivity={}):
         """
         Parameters
         ----------
         *spaces : 
             single-patch FEM spaces
         """
+        if connectivity is None:
+            connectivity = {}
 
         if len(spaces) == 1:
             return
@@ -419,7 +421,6 @@ class MultipatchFemSpace( FemSpace ):
         self._ldim = ldims[0]
         # ...
 
-        connectivity          = connectivity if connectivity is not None else {}
         self._vector_space    = BlockVectorSpace(*[V.vector_space for V in self.spaces], connectivity=connectivity)
         self._symbolic_space  = None
         self._connectivity    = connectivity.copy()

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -21,6 +21,28 @@ from psydac.core.field_evaluation_kernels import (pushforward_2d_hdiv,
 __all__ = ('VectorFemSpace', 'MultipatchFemSpace')
 
 #===============================================================================
+def create_product_space(*spaces, connectivity=None):
+    """
+    Factory function that creates a product FemSpace from a list of spaces:
+      - if the list contains a single space, this simply returns the given space as is
+      - otherwise:  
+        - if connectivity is None, returns a VectorFemSpace
+        - otherwise, returns a MultipatchFemSpace with the given connectivity
+    """
+
+    if len(spaces) == 1:
+        return spaces[0]
+    else:
+        # check that all spaces are indeed single-patch Fem spaces
+        if connectivity is None:
+            assert all(isinstance(V, FemSpace) for V in spaces)
+            return VectorFemSpace(*spaces)
+        
+        else:
+            assert all((isinstance(V, FemSpace) and not V.is_multipatch) for V in spaces)
+            return MultipatchFemSpace(*spaces, connectivity=connectivity)
+
+#===============================================================================
 class VectorFemSpace( FemSpace ):
     """
     FEM space with a vector basis defined on a single patch
@@ -359,25 +381,19 @@ class VectorFemSpace( FemSpace ):
         txt += '> nbasis :: ({dims})\n'.format(dims=dims)
         return txt
 
+
 #===============================================================================
 class MultipatchFemSpace( FemSpace ):
     """
     Product of single-patch FEM spaces
     """
 
-    def __new__(cls, *spaces, connectivity=None):
-
-        if len(spaces) == 1:
-            return spaces[0]
-        else:
-            return FemSpace.__new__(cls)
-
     def __init__( self, *spaces, connectivity=None):
         """
         Parameters
         ----------
         *spaces : 
-            single-patch FEM spaces                        
+            single-patch FEM spaces
         """
 
         if len(spaces) == 1:

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -321,16 +321,15 @@ class VectorFemSpace( FemSpace ):
     # Other properties and methods
     #--------------------------------------------------------------------------
     
-    # question [MCP 03.2025]: this is not in the FemSpace interface,
-    # and almost redundant/inconsistent with is_vector_valued. keep it ?
-    @property
-    def is_scalar(self):
-        return len( self.spaces ) == 1
+    # note [MCP 27.03.2025]: 
+    # this metod is not in the FemSpace interface and does not seem to be used: commented now and may be removed at some point
+    #  @property
+    # def is_scalar(self):
+    #     return len( self.spaces ) == 1
 
     @property
     def nbasis(self):
         dims = [V.nbasis for V in self.spaces]
-        # TODO [MCP, 08.03.2021]: check if we should return a tuple
         return sum(dims)
 
     @property

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -95,6 +95,14 @@ class VectorFemSpace( FemSpace ):
         return True
 
     @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        return True
+
+    @property
     def symbolic_space( self ):
         return self._symbolic_space
 
@@ -415,6 +423,17 @@ class ProductFemSpace( FemSpace ):
     def is_product(self):
         return True
 
+    @property
+    def is_multipatch(self):
+        return True
+
+    @property
+    def is_vector_valued(self):
+        return False        
+        # OR ?? should we:
+        # return self.patch_spaces[0].is_vector_valued
+        # (and define the component_spaces of a multi-patch vector-valued space as a scalar-valued multi-patch space ?)
+        
     @property
     def symbolic_space( self ):
         return self._symbolic_space

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -73,7 +73,7 @@ class VectorFemSpace(FemSpace):
         symbolic_space = reduce(lambda x, y: x * y, symbolic_spaces) if all(symbolic_spaces) else None
 
         # Compute the VectorSpace of the coefficients
-        coeff_space = BlockVectorSpace(*[V.vector_space for V in new_spaces])
+        coeff_space = BlockVectorSpace(*[V.coeff_space for V in new_spaces])
 
         # Store information in private attributes
         self._ldim           : int              = ldims[0]
@@ -119,7 +119,7 @@ class VectorFemSpace(FemSpace):
         return self._mapping
 
     @property
-    def vector_space(self):
+    def coeff_space(self):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._coeff_space
 
@@ -427,7 +427,7 @@ class MultipatchFemSpace( FemSpace ):
         self._ldim = ldims[0]
         # ...
 
-        self._coeff_space     = BlockVectorSpace(*[V.vector_space for V in self.spaces], connectivity=connectivity)
+        self._coeff_space     = BlockVectorSpace(*[V.coeff_space for V in self.spaces], connectivity=connectivity)
         self._symbolic_space  = None
         self._connectivity    = connectivity.copy()
     #--------------------------------------------------------------------------
@@ -448,7 +448,7 @@ class MultipatchFemSpace( FemSpace ):
         return None
 
     @property
-    def vector_space(self):
+    def coeff_space(self):
         """Returns the vector space of the coefficients (mapping invariant)."""
         return self._coeff_space
 

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -111,6 +111,15 @@ class VectorFemSpace( FemSpace ):
     def axis_spaces(self):
         raise NotImplementedError('Vector Fem space has no list of axis spaces')
 
+    @property
+    def is_multipatch(self):
+        return False
+
+    @property
+    def is_vector_valued(self):
+        # question (MCP 03.2025) do we allow scalar-valued VectorFemSpaces ?
+        return True
+
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
     #--------------------------------------------------------------------------
@@ -311,15 +320,7 @@ class VectorFemSpace( FemSpace ):
     #--------------------------------------------------------------------------
     # Other properties and methods
     #--------------------------------------------------------------------------
-    @property
-    def is_multipatch(self):
-        return False
-
-    @property
-    def is_vector_valued(self):
-        # question (MCP 03.2025) do we allow scalar-valued VectorFemSpaces ?
-        return True
-
+    
     # question [MCP 03.2025]: this is not in the FemSpace interface,
     # and almost redundant/inconsistent with is_vector_valued. keep it ?
     @property
@@ -451,6 +452,14 @@ class MultipatchFemSpace( FemSpace ):
     @property
     def axis_spaces(self):
         raise NotImplementedError('Multipatch space has no list of axis spaces')
+
+    @property
+    def is_multipatch(self):
+        return True
+
+    @property
+    def is_vector_valued(self):
+        return self.patch_spaces[0].is_vector_valued
 
     #--------------------------------------------------------------------------
     # Abstract interface: evaluation methods
@@ -644,17 +653,8 @@ class MultipatchFemSpace( FemSpace ):
     # Other properties and methods
     #--------------------------------------------------------------------------
     @property
-    def is_multipatch(self):
-        return True
-
-    @property
-    def is_vector_valued(self):
-        return self.patch_spaces[0].is_vector_valued
-
-    @property
     def nbasis(self):
         dims = [V.nbasis for V in self.spaces]
-        # TODO [MCP, 08.03.2021]: check if we should return a tuple
         return sum(dims)
 
     @property

--- a/psydac/fem/vector.py
+++ b/psydac/fem/vector.py
@@ -21,28 +21,6 @@ from psydac.core.field_evaluation_kernels import (pushforward_2d_hdiv,
 __all__ = ('VectorFemSpace', 'MultipatchFemSpace')
 
 #===============================================================================
-# def create_product_space(*spaces, connectivity=None):
-#     """
-#     Factory function that creates a product FemSpace from a list of spaces:
-#       - if the list contains a single space, this simply returns the given space as is
-#       - otherwise:  
-#         - if connectivity is None, returns a VectorFemSpace
-#         - otherwise, returns a MultipatchFemSpace with the given connectivity
-#     """
-
-#     if len(spaces) == 1:
-#         return spaces[0]
-#     else:
-#         # check that all spaces are indeed single-patch Fem spaces
-#         if connectivity is None:
-#             assert all(isinstance(V, FemSpace) for V in spaces)
-#             return VectorFemSpace(*spaces)
-        
-#         else:
-#             assert all((isinstance(V, FemSpace) and not V.is_multipatch) for V in spaces)
-#             return MultipatchFemSpace(*spaces, connectivity=connectivity)
-
-#===============================================================================
 class VectorFemSpace( FemSpace ):
     """
     FEM space with a vector basis defined on a single patch

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -291,7 +291,6 @@ class LinearOperator(ABC):
 
         """
         assert np.isscalar(c)
-        assert np.isreal(c)
         if c==0:
             return ZeroOperator(self.domain, self.codomain)
         elif c == 1:
@@ -538,7 +537,7 @@ class IdentityOperator(LinearOperator):
 #===============================================================================
 class ScaledLinearOperator(LinearOperator):
     """
-    A linear operator $A$ scalar multiplied by a real constant $c$. 
+    A linear operator $A$ scalar multiplied by a constant $c$. 
     
     """
 
@@ -547,7 +546,7 @@ class ScaledLinearOperator(LinearOperator):
         assert isinstance(domain, VectorSpace)
         assert isinstance(codomain, VectorSpace)
         assert np.isscalar(c)
-        assert np.isreal(c)
+        assert np.iscomplexobj(c) == (codomain._dtype == complex)
         assert isinstance(A, LinearOperator)
         assert domain   == A.domain
         assert codomain == A.codomain
@@ -594,7 +593,7 @@ class ScaledLinearOperator(LinearOperator):
         return self._scalar*csr_matrix(self._operator.toarray())
 
     def transpose(self, conjugate=False):
-        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=self._scalar, A=self._operator.transpose(conjugate=conjugate))
+        return ScaledLinearOperator(domain=self.codomain, codomain=self.domain, c=self._scalar if not conjugate else np.conjugate(self._scalar), A=self._operator.transpose(conjugate=conjugate))
 
     def __neg__(self):
         return ScaledLinearOperator(domain=self.domain, codomain=self.codomain, c=-1*self._scalar, A=self._operator)

--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -946,7 +946,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
         rp.copy(out=rp0)
 
         # squared residual norm and squared tolerance
-        res_sqr = r.dot(r)
+        res_sqr = r.dot(r).real
         tol_sqr = tol**2
 
         if verbose:

--- a/psydac/linalg/tests/test_kron_direct_solver.py
+++ b/psydac/linalg/tests/test_kron_direct_solver.py
@@ -271,9 +271,9 @@ def get_inverse_mass_matrices(derham_h, domain_h):
     # assert 2D
     # Maybe should add more assert regarding the types and the domain form in case this get used in general context.
     
-    V0h   = derham_h.V0.vector_space
-    V1h   = derham_h.V1.vector_space
-    V2h   = derham_h.V2.vector_space
+    V0h   = derham_h.V0.coeff_space
+    V1h   = derham_h.V1.coeff_space
+    V2h   = derham_h.V2.coeff_space
     
     bounds1 = domain_h.domain.bounds1
     bounds2 = domain_h.domain.bounds2
@@ -569,7 +569,7 @@ def test_3d_m1_solver(ncells, degree, periodic):
     derham = Derham(domain)
     domain_h = discretize(domain, ncells=ncells, periodic=periodic, comm=comm)
     derham_h = discretize(derham, domain_h, degree=degree)
-    V1 = derham_h.V1.vector_space
+    V1 = derham_h.V1.coeff_space
     P0, P1, P2, P3  = derham_h.projectors()
 
     # obtain an iterative M1 solver the usual way

--- a/psydac/linalg/tests/test_linalg.py
+++ b/psydac/linalg/tests/test_linalg.py
@@ -450,29 +450,37 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
 
     # Initiate StencilVectorSpace
     V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-
+    Vc = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    Vc._dtype = complex
     v = StencilVector(V)
+    vc = StencilVector(Vc)
     v_array = np.zeros(n1*n2)
 
     for i in range(n1):
         for j in range(n2):
             v[i,j] = i+1
             v_array[i*n2+j] = i+1
+            vc[i,j] = i+1       
     
     I1 = IdentityOperator(V,V)
     I2 = IdentityOperator(V,V)
     I3 = IdentityOperator(V,V)
+    I4 = IdentityOperator(Vc,Vc)
 
     I1 *= 0
     I2 *= 1
     I3 *= 3
     v3 = I3.dot(v)
+    I4 *= 3j
+    v4 = I4.dot(vc)
 
     assert np.array_equal(v.toarray(), v_array)
     assert isinstance(I1, ZeroOperator)
     assert isinstance(I2, IdentityOperator)
     assert isinstance(I3, ScaledLinearOperator)
     assert np.array_equal(v3.toarray(), np.dot(v_array, 3))
+    assert isinstance(I4, ScaledLinearOperator)
+    assert np.array_equal(v4.toarray(), np.dot(v_array, 3j))
 
     # testing __iadd__ and __isub__ although not explicitly implemented (in the LinearOperator class)
 
@@ -522,7 +530,7 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
     assert isinstance(Z3, StencilMatrix)
     assert isinstance(T, StencilMatrix)
     assert np.array_equal(w2.toarray(), np.dot(np.dot(2, Sa), v_array))
-    
+ 
 #===============================================================================
 @pytest.mark.parametrize('n1', n1array)
 @pytest.mark.parametrize('n2', n2array)

--- a/psydac/linalg/tests/test_stencil_matrix.py
+++ b/psydac/linalg/tests/test_stencil_matrix.py
@@ -2883,10 +2883,10 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     ah = discretize(a, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
     M = ah.assemble()
 
-    x = Vh.vector_space.zeros()
+    x = Vh.coeff_space.zeros()
 
-    s1, s2 = Vh.vector_space.starts
-    e1, e2 = Vh.vector_space.ends
+    s1, s2 = Vh.coeff_space.starts
+    e1, e2 = Vh.coeff_space.ends
 
     # Fill in vector with random values, then update ghost regions
     for i1 in range(s1, e1 + 1):
@@ -2903,7 +2903,7 @@ def test_mass_matrix_2d_parallel_topetsc(n1, n2, p1, p2, P1, P2):
     # Compute dot product
     Mp.mult(x.topetsc(), y_petsc)
     # Cast result back to Psydac StencilVector format
-    y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
+    y_p = petsc_to_psydac(y_petsc, Vh.coeff_space)
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 
@@ -2941,10 +2941,10 @@ def test_mass_matrix_3d_parallel_topetsc(n1, n2, n3, p1, p2, p3, P1, P2, P3):
     ah = discretize(a, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
     M = ah.assemble()
 
-    x = Vh.vector_space.zeros()
+    x = Vh.coeff_space.zeros()
 
-    s1, s2, s3 = Vh.vector_space.starts
-    e1, e2, e3 = Vh.vector_space.ends
+    s1, s2, s3 = Vh.coeff_space.starts
+    e1, e2, e3 = Vh.coeff_space.ends
 
     # Fill in vector with random values, then update ghost regions
     for i1 in range(s1, e1 + 1):
@@ -2962,7 +2962,7 @@ def test_mass_matrix_3d_parallel_topetsc(n1, n2, n3, p1, p2, p3, P1, P2, P3):
     # Compute dot product
     Mp.mult(x.topetsc(), y_petsc)
     # Cast result back to Psydac StencilVector format
-    y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
+    y_p = petsc_to_psydac(y_petsc, Vh.coeff_space)
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
     
@@ -2994,10 +2994,10 @@ def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
     ah = discretize(a, domain_h, [Vh, Vh], backend=PSYDAC_BACKENDS['pyccel-gcc'])    
     M = ah.assemble()
 
-    x = Vh.vector_space.zeros()
+    x = Vh.coeff_space.zeros()
 
-    s1, = Vh.vector_space.starts
-    e1, = Vh.vector_space.ends
+    s1, = Vh.coeff_space.starts
+    e1, = Vh.coeff_space.ends
 
     # Fill in vector with random values, then update ghost regions
     for i1 in range(s1, e1 + 1):
@@ -3016,7 +3016,7 @@ def test_mass_matrix_1d_parallel_topetsc(n1, p1, P1):
     # Compute dot product
     Mp.mult(x_petsc, y_petsc)
     # Cast result back to Psydac StencilVector format
-    y_p = petsc_to_psydac(y_petsc, Vh.vector_space)
+    y_p = petsc_to_psydac(y_petsc, Vh.coeff_space)
 
     assert np.allclose(y_p.toarray(), y.toarray(), rtol=1e-12, atol=1e-12)
 

--- a/psydac/mapping/discrete.py
+++ b/psydac/mapping/discrete.py
@@ -17,7 +17,7 @@ from sympde.topology.datatype import (H1SpaceType, L2SpaceType,
 
 from psydac.fem.basic    import FemField
 from psydac.fem.tensor   import TensorFemSpace
-from psydac.fem.vector   import ProductFemSpace, VectorFemSpace
+from psydac.fem.vector   import VectorFemSpace
 from psydac.core.field_evaluation_kernels import (pushforward_2d_l2, pushforward_3d_l2,
                                                   pushforward_2d_hdiv, pushforward_3d_hdiv,
                                                   pushforward_2d_hcurl, pushforward_3d_hcurl)

--- a/psydac/polar/c1_projections.py
+++ b/psydac/polar/c1_projections.py
@@ -32,7 +32,7 @@ class C1Projector:
 
         assert isinstance(mapping, SplineMapping)
 
-        S = mapping.space.vector_space
+        S = mapping.space.coeff_space
 
         assert isinstance(S, StencilVectorSpace)
 
@@ -46,9 +46,9 @@ class C1Projector:
     # ...
     def compute_lambda(self, mapping):
 
-        s1, s2 = mapping.space.vector_space.starts
-        e1, e2 = mapping.space.vector_space.ends
-        p1, p2 = mapping.space.vector_space.pads
+        s1, s2 = mapping.space.coeff_space.starts
+        e1, e2 = mapping.space.coeff_space.ends
+        p1, p2 = mapping.space.coeff_space.pads
 
         if s1 == 0:
 

--- a/psydac/polar/tests/test_c1_projections.py
+++ b/psydac/polar/tests/test_c1_projections.py
@@ -65,8 +65,8 @@ def test_c1_projections(degrees, ncells, verbose=False):
     #--------------------------------------------
 
     # Matrix and vector in tensor-product basis
-    A = StencilMatrix(V.vector_space, V.vector_space)
-    b = StencilVector(V.vector_space)
+    A = StencilMatrix(V.coeff_space, V.coeff_space)
+    b = StencilVector(V.coeff_space)
 
     # Set values of matrix
     A[:, :, 0, 0] =  4
@@ -76,8 +76,8 @@ def test_c1_projections(degrees, ncells, verbose=False):
     A[:, :,+1, 0] = -2
 
     # Add (symmetric) random perturbation to matrix
-    s1, s2 = V.vector_space.starts
-    e1, e2 = V.vector_space.ends
+    s1, s2 = V.coeff_space.starts
+    e1, e2 = V.coeff_space.ends
     n1, n2 = A.domain.npts
     perturbation = 0.1 * np.random.random((e1-s1+1, e2-s2+1, p1, p2))
     for i1 in range(s1, e1+1):

--- a/psydac/utilities/utils.py
+++ b/psydac/utilities/utils.py
@@ -109,13 +109,14 @@ def split_space(Xh):
          List of fem spaces.
     """
     from sympde.topology.space import VectorFunctionSpace
-    from psydac.fem.vector     import MultipatchFemSpace
+    # from psydac.fem.vector     import create_product_space
     V = Xh.symbolic_space
     spaces = Xh.spaces
     Vh    = []
     for Vi in V.spaces:
         if isinstance(Vi, VectorFunctionSpace):
-            Vh.append(MultipatchFemSpace(*spaces[:Vi.ldim]))
+            # Vh.append(create_product_space(*spaces[:Vi.ldim]))
+            Vh.append(VectorFunctionSpace(*spaces[:Vi.ldim]))
             Vh[-1].symbolic_space = Vi
             spaces = spaces[Vi.ldim:]
         else:

--- a/psydac/utilities/utils.py
+++ b/psydac/utilities/utils.py
@@ -100,7 +100,7 @@ def split_space(Xh):
 
     Parameters
     ----------
-    Xh : ProductFemSpace
+    Xh : MultipatchFemSpace
         The discrete space.
 
     Returns
@@ -109,13 +109,13 @@ def split_space(Xh):
          List of fem spaces.
     """
     from sympde.topology.space import VectorFunctionSpace
-    from psydac.fem.vector     import ProductFemSpace
+    from psydac.fem.vector     import MultipatchFemSpace
     V = Xh.symbolic_space
     spaces = Xh.spaces
     Vh    = []
     for Vi in V.spaces:
         if isinstance(Vi, VectorFunctionSpace):
-            Vh.append(ProductFemSpace(*spaces[:Vi.ldim]))
+            Vh.append(MultipatchFemSpace(*spaces[:Vi.ldim]))
             Vh[-1].symbolic_space = Vi
             spaces = spaces[Vi.ldim:]
         else:

--- a/psydac/utilities/utils.py
+++ b/psydac/utilities/utils.py
@@ -109,14 +109,13 @@ def split_space(Xh):
          List of fem spaces.
     """
     from sympde.topology.space import VectorFunctionSpace
-    # from psydac.fem.vector     import create_product_space
+    from psydac.fem.vector     import VectorFemSpace
     V = Xh.symbolic_space
     spaces = Xh.spaces
     Vh    = []
     for Vi in V.spaces:
         if isinstance(Vi, VectorFunctionSpace):
-            # Vh.append(create_product_space(*spaces[:Vi.ldim]))
-            Vh.append(VectorFunctionSpace(*spaces[:Vi.ldim]))
+            Vh.append(VectorFemSpace(*spaces[:Vi.ldim]))
             Vh[-1].symbolic_space = Vi
             spaces = spaces[Vi.ldim:]
         else:


### PR DESCRIPTION
Improve the FEM API to make it more user-friendly and compatible between single-patch and multi-patch APIs (fix #459 and fix #460):

* Rename abstract property `vector_space` of `FemSpace` as `coeff_space`
* Rename `ProductFemSpace` as `MultipatchFemSpace`
* Do not use class constructors as factories (previously `ProductFemSpace()` could return a `VectorFemSpace` object)
* Provide more specific helper properties for FEM spaces, such as
   - `is_vector_valued` and `is_multipatch` (also remove a method `is_scalar` which was implemented in _some_ FEM spaces but not used)
   - `patch_spaces`, `component_spaces` and `axis_spaces`  which always return tuples of Fem spaces (or an error)
* Provide more specific helper properties for FEM fields, such as
   - `component_fields` and `patch_fields` and `axis_fields` which always return tuples of FEM fields (or an error)
* Improve the `VectorFemSpace` class (in particular its constructor) to better match the `FemSpace` abstract interface.

Since these changes are also motivated by a better compatibility between single-patch and multi-patch APIs (see issue #331), this PR also modifies the `plot_field` function (previously in `psydac.feec.multipatch.plotting_utilities`), which is:

* made compatible with single patch and multi patch fields
* renamed as `plot_field_2d` since it only handles 2d fields
* tested (not the content but the runs) in single and multipatch configurations for scalar and vector-valued FEM fields
* moved with its module `psydac.feec.multipatch.plotting_utilities` to `psydac.fem.plotting_utilities` since it is not specific to FEEC or multipatch

