### PR TITLE
Enable mpi4py 4.0

### DIFF
--- a/psydac/ddm/blocking_data_exchanger.py
+++ b/psydac/ddm/blocking_data_exchanger.py
@@ -146,7 +146,7 @@ class BlockingCartDataExchanger(CartDataExchanger):
             rank_source = info['rank_source']
 
             if self._axis is not None:
-                rank_source = comm.group.Translate_ranks(gcomm.group, np.array([rank_source]), comm.group)[0]
+                rank_source = gcomm.group.Translate_ranks(np.array([rank_source]), comm.group)[0]
             
             recv_buf = (array, 1, recv_typ)
             recv_req = comm.Irecv( recv_buf, rank_source, tag(disp) )
@@ -156,7 +156,7 @@ class BlockingCartDataExchanger(CartDataExchanger):
             rank_dest = info['rank_dest']
 
             if self._axis is not None:
-                rank_dest = comm.group.Translate_ranks(gcomm.group, np.array([rank_dest]), comm.group)[0]
+                rank_dest = gcomm.group.Translate_ranks(np.array([rank_dest]), comm.group)[0]
 
             send_buf = (array, 1, send_typ)
             send_req = comm.Isend( send_buf, rank_dest, tag(disp) )

--- a/psydac/ddm/nonblocking_data_exchanger.py
+++ b/psydac/ddm/nonblocking_data_exchanger.py
@@ -132,7 +132,7 @@ class NonBlockingCartDataExchanger(CartDataExchanger):
             rank_source = info['rank_source']
 
             if self._axis is not None:
-                rank_source = comm.group.Translate_ranks(gcomm.group, np.array([rank_source]), comm.group)[0]
+                rank_source = gcomm.group.Translate_ranks(np.array([rank_source]), comm.group)[0]
             
             recv_buf = (array, 1, recv_typ)
             recv_req = comm.Irecv( recv_buf, rank_source, tag(disp) )
@@ -142,7 +142,7 @@ class NonBlockingCartDataExchanger(CartDataExchanger):
             rank_dest = info['rank_dest']
 
             if self._axis is not None:
-                rank_dest = comm.group.Translate_ranks(gcomm.group, np.array([rank_dest]), comm.group)[0]
+                rank_dest = gcomm.group.Translate_ranks(np.array([rank_dest]), comm.group)[0]
 
             send_buf = (array, 1, send_typ)
             send_req = comm.Isend( send_buf, rank_dest, tag(disp) )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools >= 61, != 67.2.0
 numpy  >= 1.16
 scipy  >= 1.12
 Cython >= 0.25, < 3.0
-mpi4py >= 3.0.0, < 4
+mpi4py >= 3.0.0
 
 # Required to build h5py from source
 pkgconfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools >= 61, != 67.2.0
 numpy  >= 1.16
 scipy  >= 1.12
 Cython >= 0.25, < 3.0
-mpi4py >= 3.0.0
+mpi4py >= 4
 
 # Required to build h5py from source
 pkgconfig


### PR DESCRIPTION
Closes #420.

Fix usage of function `Translate_ranks` which had non-backward-compatible changes in mpi4py version 4.0: https://mpi4py.readthedocs.io/en/stable/changes.html.