### PR TITLE
Fix PSYDAC_BACKEND_GPYCCEL flags on latest Apple silicon

### DIFF
--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -56,7 +56,7 @@ if platform.system() == "Darwin" and platform.machine() == 'arm64' and gfortran_
     cpu_brand = subprocess.check_output(['sysctl','-n','machdep.cpu.brand_string']).decode('utf-8').strip() # nosec B603, B607
     if cpu_brand.startswith("Apple M"):
         # Example: "Apple M3 Pro (virtual)" --> " -mcpu=apple-m3"
-        cpu_flag = cpu_brand.lower().replace(' ','-')[:8]
+        cpu_flag = '-'.join(cpu_brand.lower().split()[:2])
         PSYDAC_BACKEND_GPYCCEL['flags'] += f' -mcpu={cpu_flag}'
     else:
         # TODO: Support later Apple CPU models. Perhaps the CPU naming scheme could be easily guessed

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -53,10 +53,11 @@ if platform.system() == "Darwin" and platform.machine() == 'arm64' and gfortran_
 
     # Apple silicon requires architecture-specific flags (see https://github.com/pyccel/psydac/pull/411)
     # which are only available on GCC version >= 14
-    cpu_brand = subprocess.check_output(['sysctl','-n','machdep.cpu.brand_string']).decode('utf-8') # nosec B603, B607
-    if "Apple M" in cpu_brand:
-        # Example: Apple M1 --> -mcpu=apple-m1
-        PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mcpu=' + cpu_brand.lower().replace(' ','-')
+    cpu_brand = subprocess.check_output(['sysctl','-n','machdep.cpu.brand_string']).decode('utf-8').strip() # nosec B603, B607
+    if cpu_brand.startswith("Apple M"):
+        # Example: "Apple M3 Pro (virtual)" --> " -mcpu=apple-m3"
+        cpu_flag = cpu_brand.lower().replace(' ','-')[:8]
+        PSYDAC_BACKEND_GPYCCEL['flags'] += f' -mcpu={cpu_flag}'
     else:
         # TODO: Support later Apple CPU models. Perhaps the CPU naming scheme could be easily guessed
         # based on the output of 'sysctl -n machdep.cpu.brand_string', but I wouldn't rely on this

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -54,9 +54,9 @@ if platform.system() == "Darwin" and platform.machine() == 'arm64' and gfortran_
     # Apple silicon requires architecture-specific flags (see https://github.com/pyccel/psydac/pull/411)
     # which are only available on GCC version >= 14
     cpu_brand = subprocess.check_output(['sysctl','-n','machdep.cpu.brand_string']).decode('utf-8') # nosec B603, B607
-    if   "Apple M1" in cpu_brand: PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mcpu=apple-m1'
-    elif "Apple M2" in cpu_brand: PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mcpu=apple-m2'
-    elif "Apple M3" in cpu_brand: PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mcpu=apple-m3'
+    if "Apple M" in cpu_brand:
+        # Example: Apple M1 --> -mcpu=apple-m1
+        PSYDAC_BACKEND_GPYCCEL['flags'] += ' -mcpu=' + cpu_brand.lower().replace(' ','-')
     else:
         # TODO: Support later Apple CPU models. Perhaps the CPU naming scheme could be easily guessed
         # based on the output of 'sysctl -n machdep.cpu.brand_string', but I wouldn't rely on this

--- a/psydac/api/settings.py
+++ b/psydac/api/settings.py
@@ -45,7 +45,7 @@ PSYDAC_BACKEND_NVPYCCEL = {'name': 'pyccel',
 
 # Get gfortran version
 gfortran_version_output = subprocess.check_output(['gfortran', '--version']).decode('utf-8') # nosec B603, B607
-gfortran_version_string = re.search("(\d+\.\d+\.\d+)", gfortran_version_output).group()
+gfortran_version_string = re.search(r"(\d+\.\d+\.\d+)", gfortran_version_output).group()
 gfortran_version = Version(gfortran_version_string)
 
 # Platform-dependent flags


### PR DESCRIPTION
Currently, psydac can not be used on Apple M4 computers since the `PSYDAC_BACKEND_GPYCCEL['flags']` is not set correctly.

This change sets the flag for `Apple MX` to `apple-mx`, which I think is a good enough guess for now. I tested it on a Mac with an Apple M4 chip.