### PR TITLE
Resolve warnings in sequential unit tests

### DIFF
--- a/psydac/feec/global_projectors.py
+++ b/psydac/feec/global_projectors.py
@@ -356,7 +356,7 @@ class GlobalProjector(metaclass=ABCMeta):
         pass
     
     def __call__(self, fun):
-        """
+        r"""
         Project vector function onto the given finite element
         space by the instance of this class. This happens in the logical domain $\hat{\Omega}$.
 

--- a/psydac/feec/multipatch/examples/timedomain_maxwell.py
+++ b/psydac/feec/multipatch/examples/timedomain_maxwell.py
@@ -420,9 +420,10 @@ def solve_td_maxwell_pbm(*,
     # Absorbing dC_m
     CH2 = C_m.transpose() @ H2_m
     H1A = H1_m + dt * A_eps
-    dC_m = sp.sparse.linalg.spsolve(H1A, CH2)
 
-    dCH1_m = sp.sparse.linalg.spsolve(H1A, H1_m)
+    H1A_csc = H1A.tocsc()
+    dC_m   = sp.sparse.linalg.spsolve(H1A_csc,  CH2.tocsc())
+    dCH1_m = sp.sparse.linalg.spsolve(H1A_csc, H1_m.tocsc())
 
     print(' .. matrix of the dual div (still in primal bases)...')
     div_m = dH0_m @ cP0_m.transpose() @ bD0_m.transpose() @ H1_m

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -614,7 +614,7 @@ class ScaledLinearOperator(LinearOperator):
 
 #===============================================================================
 class SumLinearOperator(LinearOperator):
-    """
+    r"""
     Sum $\sum_{i=1}^n A_i$ of linear operators $A_1,\dots,A_n$ acting between the same vector spaces V (domain) and W (codomain).
 
     """
@@ -728,7 +728,7 @@ class SumLinearOperator(LinearOperator):
 
 #===============================================================================
 class ComposedLinearOperator(LinearOperator):
-    """
+    r"""
     Composition $A_n\circ\dots\circ A_1$ of two or more linear operators $A_1,\dots,A_n$.
     
     """
@@ -788,7 +788,7 @@ class ComposedLinearOperator(LinearOperator):
 
     @property
     def multiplicants(self):
-        """
+        r"""
         A tuple $(A_1,\dots,A_n)$ containing the multiplicants of the linear operator 
         $self = A_n\circ\dots\circ A_1$.
         
@@ -851,7 +851,7 @@ class ComposedLinearOperator(LinearOperator):
 
 #===============================================================================
 class PowerLinearOperator(LinearOperator):
-    """
+    r"""
     Power $A^n$ of a linear operator $A$ for some integer $n\geq 0$.
     
     """


### PR DESCRIPTION
Changes:

* Use raw strings for docstrings with LaTeX to avoid UTF8 syntax warnings on escape sequences;
* Use CSC matrices to avoid SciPy sparse solver warning.

We do not address the NumPy warnings which arise in our MPI unit tests (see #353).