### PR TITLE
Rename `dot` as `inner` in `Vector`, `VectorSpace`, and subclasses

### DIFF
--- a/psydac/api/ast/linalg.py
+++ b/psydac/api/ast/linalg.py
@@ -428,7 +428,7 @@ class LinearOperatorDot(SplBasic):
         return fmod
 
 #==============================================================================
-class VectorDot(SplBasic):
+class VectorInner(SplBasic):
 
     def __new__(cls, ndim, backend=None):
         tag = random_string(8)

--- a/psydac/api/tests/test_assembly.py
+++ b/psydac/api/tests/test_assembly.py
@@ -78,7 +78,7 @@ def test_field_and_constant(backend, dtype):
     # Test matrix A
     x = fh.coeffs
     #TODO change res into np.conj(res) when the conjugate is applied in the dot product in sympde
-    assert abs(x.dot(A.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A.dot(x)) - res) < 1e-12
 
     # Test vector b
     assert abs(b.toarray().sum() - res) < 1e-12
@@ -138,10 +138,10 @@ def test_bilinearForm_complex(backend):
     x = fh.coeffs
 
     #TODO change res into np.conj(res) when the conjugate is applied in the dot product in sympde
-    assert abs(x.dot(A1.dot(x)) - res) < 1e-12
-    assert abs(x.dot(A2.dot(x)) - res) < 1e-12
-    assert abs(x.dot(A3.dot(x)) - res) < 1e-12
-    assert abs(x.dot(A4.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A1.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A2.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A3.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A4.dot(x)) - res) < 1e-12
 
     print("PASSED")
 
@@ -375,7 +375,7 @@ def test_multiple_fields(backend, dtype):
 
     # Test matrix A
     #TODO change res into np.conj(res) when the conjugate is applied in the dot product in sympde
-    assert abs(x.dot(A.dot(x)) - res) < 1e-12
+    assert abs(x.inner(A.dot(x)) - res) < 1e-12
 
     # Test vector b
     assert abs(b.toarray().sum() - res) < 1e-12
@@ -518,10 +518,10 @@ def test_assembly_no_synchr_args(backend):
     rhoh3 = div.dot(uh)
     rhof3  = FemField(V1h, rhoh3)
     weight_mass_matrix = weight_int_prod_h.assemble(rho=rhof1)
-    inte_bilin = const_1.dot(weight_mass_matrix.dot(const_1))
+    inte_bilin = const_1.inner(weight_mass_matrix.dot(const_1))
 
     int_prod_rho = int_prod_h.assemble(rho=rhof2)
-    inte_lin = int_prod_rho.dot(const_1)
+    inte_lin = int_prod_rho.inner(const_1)
 
     inte_norm = func_h.assemble(rho=rhof3)
 

--- a/psydac/feec/tests/test_commuting_projections.py
+++ b/psydac/feec/tests/test_commuting_projections.py
@@ -1,4 +1,7 @@
 # -*- coding: UTF-8 -*-
+from mpi4py import MPI
+import numpy as np
+import pytest
 
 from psydac.feec.global_projectors import Projector_H1, Projector_L2, Projector_Hcurl, Projector_Hdiv
 from psydac.fem.tensor       import TensorFemSpace, SplineSpace
@@ -11,18 +14,14 @@ from psydac.ddm.cart         import DomainDecomposition
 from psydac.linalg.solvers   import inverse
 from psydac.linalg.basic     import IdentityOperator
 
-from mpi4py import MPI
-import numpy as np
-import pytest
-
 #==============================================================================
 # 3D tests
 #==============================================================================
-@pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [5])
-@pytest.mark.parametrize('p', [2,3])
+@pytest.mark.parametrize('m', [1, 2])
 @pytest.mark.parametrize('bc', [True, False])
-@pytest.mark.parametrize('m', [1,2])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('Nq', [5])
+@pytest.mark.parametrize('Nel', [5, 6])
 def test_3d_commuting_pro_1(Nel, Nq, p, bc, m):
 
     fun1    = lambda xi1, xi2, xi3 : np.sin(xi1)*np.sin(xi2)*np.sin(xi3)
@@ -92,11 +91,11 @@ def test_3d_commuting_pro_1(Nel, Nq, p, bc, m):
     norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
 
-@pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [8])
-@pytest.mark.parametrize('p', [2,3])
+@pytest.mark.parametrize('m', [1, 2])
 @pytest.mark.parametrize('bc', [True, False])
-@pytest.mark.parametrize('m', [1,2])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('Nq', [7])
+@pytest.mark.parametrize('Nel', [5, 6])
 def test_3d_commuting_pro_2(Nel, Nq, p, bc, m):
 
     fun1    = lambda xi1, xi2, xi3 : np.sin(xi1)*np.sin(xi2)*np.sin(xi3)
@@ -184,11 +183,11 @@ def test_3d_commuting_pro_2(Nel, Nq, p, bc, m):
     norm2_e2 = np.sqrt(e2.inner(e2))
     assert norm2_e2 < 1e-12
 
-@pytest.mark.parametrize('Nel', [8, 12])
-@pytest.mark.parametrize('Nq', [8])
-@pytest.mark.parametrize('p', [2,3])
+@pytest.mark.parametrize('m', [1, 2])
 @pytest.mark.parametrize('bc', [True, False])
-@pytest.mark.parametrize('m', [1,2])
+@pytest.mark.parametrize('p', [2, 3])
+@pytest.mark.parametrize('Nq', [7])
+@pytest.mark.parametrize('Nel', [5, 6])
 def test_3d_commuting_pro_3(Nel, Nq, p, bc, m):
 
     fun1    = lambda xi1, xi2, xi3 : np.sin(xi1)*np.sin(xi2)*np.sin(xi3)

--- a/psydac/feec/tests/test_commuting_projections.py
+++ b/psydac/feec/tests/test_commuting_projections.py
@@ -83,13 +83,13 @@ def test_3d_commuting_pro_1(Nel, Nq, p, bc, m):
     Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
-    norm2_e0 = np.sqrt(e0.dot(e0))
+    norm2_e0 = np.sqrt(e0.inner(e0))
     assert norm2_e0 < 1e-12
 
     Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
 
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -175,13 +175,13 @@ def test_3d_commuting_pro_2(Nel, Nq, p, bc, m):
     Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
 
     Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs  # random vector could be used as well
-    norm2_e2 = np.sqrt(e2.dot(e2))
+    norm2_e2 = np.sqrt(e2.inner(e2))
     assert norm2_e2 < 1e-12
 
 @pytest.mark.parametrize('Nel', [8, 12])
@@ -258,13 +258,13 @@ def test_3d_commuting_pro_3(Nel, Nq, p, bc, m):
     Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs  # random vector could be used as well
-    norm2_e2 = np.sqrt(e2.dot(e2))
+    norm2_e2 = np.sqrt(e2.inner(e2))
     assert norm2_e2 < 1e-12
 
     Id_3 = IdentityOperator(L2.coeff_space)
     Err_3 = P3.solver @ P3.imat_kronecker - Id_3
     e3 = Err_3 @ u3.coeffs  # random vector could be used as well
-    norm2_e3 = np.sqrt(e3.dot(e3))
+    norm2_e3 = np.sqrt(e3.inner(e3))
     assert norm2_e3 < 1e-12
 
 #==============================================================================
@@ -334,13 +334,13 @@ def test_2d_commuting_pro_1(Nel, Nq, p, bc, m):
     Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
-    norm2_e0 = np.sqrt(e0.dot(e0))
+    norm2_e0 = np.sqrt(e0.inner(e0))
     assert norm2_e0 < 1e-12
 
     Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
 
 @pytest.mark.parallel
@@ -407,13 +407,13 @@ def test_2d_commuting_pro_2(Nel, Nq, p, bc, m):
     Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs  # random vector could be used as well
-    norm2_e0 = np.sqrt(e0.dot(e0))
+    norm2_e0 = np.sqrt(e0.inner(e0))
     assert norm2_e0 < 1e-12
 
     Id_1 = IdentityOperator(Hdiv.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs  # random vector could be used as well
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e0 < 1e-12
 
 @pytest.mark.parallel
@@ -487,13 +487,13 @@ def test_2d_commuting_pro_3(Nel, Nq, p, bc, m):
     Id_2 = IdentityOperator(Hdiv.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs
-    norm2_e2 = np.sqrt(e2.dot(e2))
+    norm2_e2 = np.sqrt(e2.inner(e2))
     assert norm2_e2 < 1e-12
 
     Id_3 = IdentityOperator(L2.coeff_space)
     Err_3 = P3.solver @ P3.imat_kronecker - Id_3
     e3 = Err_3 @ u3.coeffs
-    norm2_e3 = np.sqrt(e3.dot(e3))
+    norm2_e3 = np.sqrt(e3.inner(e3))
     assert norm2_e3 < 1e-12
 
 @pytest.mark.parallel
@@ -567,13 +567,13 @@ def test_2d_commuting_pro_4(Nel, Nq, p, bc, m):
     Id_1 = IdentityOperator(Hcurl.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
 
     Id_2 = IdentityOperator(L2.coeff_space)
     Err_2 = P2.solver @ P2.imat_kronecker - Id_2
     e2 = Err_2 @ u2.coeffs
-    norm2_e2 = np.sqrt(e2.dot(e2))
+    norm2_e2 = np.sqrt(e2.inner(e2))
     assert norm2_e2 < 1e-12
 
 #==============================================================================
@@ -637,13 +637,13 @@ def test_1d_commuting_pro_1(Nel, Nq, p, bc, m):
     Id_0 = IdentityOperator(H1.coeff_space)
     Err_0 = P0.solver @ P0.imat_kronecker - Id_0
     e0 = Err_0 @ u0.coeffs
-    norm2_e0 = np.sqrt(e0.dot(e0))
+    norm2_e0 = np.sqrt(e0.inner(e0))
     assert norm2_e0 < 1e-12
 
     Id_1 = IdentityOperator(L2.coeff_space)
     Err_1 = P1.solver @ P1.imat_kronecker - Id_1
     e1 = Err_1 @ u1.coeffs
-    norm2_e1 = np.sqrt(e1.dot(e1))
+    norm2_e1 = np.sqrt(e1.inner(e1))
     assert norm2_e1 < 1e-12
     
 #==============================================================================

--- a/psydac/feec/tests/test_global_projectors.py
+++ b/psydac/feec/tests/test_global_projectors.py
@@ -248,7 +248,7 @@ def test_derham_projector_2d_hcurl(ncells, degree, periodic, multiplicity):
     assert maxnorm_error <= 1e-3
     
 #==============================================================================
-@pytest.mark.parametrize('ncells', [[30,30,30]])
+@pytest.mark.parametrize('ncells', [[20,20,20]])
 @pytest.mark.parametrize('degree', [[2,2,2], [2,3,2], [3,3,3]])
 @pytest.mark.parametrize('periodic', [[False, False, False], [True, True, True]])
 @pytest.mark.parametrize('multiplicity', [[1,1,1], [1,2,2], [2,2,2]])
@@ -289,19 +289,23 @@ def test_derham_projector_3d(ncells, degree, periodic, multiplicity):
     # Test if max-norm of error is <= TOL
     maxnorm_error = abs(vals_u0 - vals_f).max()
     print(ncells, maxnorm_error)
-    assert maxnorm_error <= 3e-2
+    assert maxnorm_error <= 0.01
+
     maxnorm_error = abs(vals_u1_1 - vals_f).max()
     print(ncells, maxnorm_error)
-    assert maxnorm_error <= 3e-2
+    assert maxnorm_error <= 0.01
+
     maxnorm_error = abs(vals_u2_1 - vals_f).max()
     print(ncells, maxnorm_error)
-    assert maxnorm_error <= 3e-2
+    assert maxnorm_error <= 0.05
+
     maxnorm_error = abs(vals_u3 - vals_f).max()
     print(ncells, maxnorm_error)
-    assert maxnorm_error <= 3e-2
+    assert maxnorm_error <= 0.05
+
     maxnorm_error = abs(vals_ux_1 - vals_f).max()
     print(ncells, maxnorm_error)
-    assert maxnorm_error <= 3e-2
+    assert maxnorm_error <= 0.02
 
 #==============================================================================
 if __name__ == '__main__':

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -77,7 +77,7 @@ class VectorSpace(ABC):
 
         TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
         want to reverse this behavior in order to align with the convention
-        of Fenix.
+        of FEniCS.
 
         Parameters
         ----------

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -66,10 +66,35 @@ class VectorSpace(ABC):
 
         """
 
-#    @abstractmethod
-    def dot(self, a, b):
+    @abstractmethod
+    def inner(self, x, y):
         """
-        Evaluate the scalar product between two vectors of the same space.
+        Evaluate the inner vector product between two vectors of this space V.
+
+        If the field of V is real, compute the classical scalar product.
+        If the field of V is complex, compute the classical sesquilinear
+        product with linearity on the second vector.
+
+        TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
+        want to reverse this behavior in order to align with the convention
+        of Fenix.
+
+        Parameters
+        ----------
+        x : Vector
+            The first vector in the scalar product. In the case of a complex
+            field, the inner product is antilinear w.r.t. this vector (hence
+            this vector is conjugated).
+
+        y : Vector
+            The second vector in the scalar product. The inner product is
+            linear w.r.t. this vector.
+
+        Returns
+        -------
+        float | complex
+            The scalar product of the two vectors. Note that inner(x, x) is
+            a non-negative real number which is zero if and only if x = 0.
 
         """
 
@@ -108,7 +133,7 @@ class Vector(ABC):
         """ The data type of the vector field V this vector belongs to. """
         return self.space.dtype
 
-    def dot(self, v):
+    def inner(self, v):
         """
         Evaluate the scalar product with the vector v of the same space.
 
@@ -120,7 +145,7 @@ class Vector(ABC):
         """
         assert isinstance(v, Vector)
         assert self.space is v.space
-        return self.space.dot(self, v)
+        return self.space.inner(self, v)
 
     def mul_iadd(self, a, v):
         """
@@ -150,8 +175,26 @@ class Vector(ABC):
 
     @abstractmethod
     def copy(self, out=None):
-        """Ensure x.copy(out=x) returns x and not a new object."""
-        pass
+        """
+        Return an identical copy of this vector.
+        
+        Subclasses must ensure that x.copy(out=x) returns x and not a new
+        object.
+        """
+
+    @abstractmethod
+    def conjugate(self, out=None):
+        """
+        Compute the complex conjugate vector.
+        
+        Please note that x.conjugate(out=x) modifies x in place and returns x.
+
+        If the field is real (i.e. `self.dtype in (np.float32, np.float64)`) this method is equivalent to `copy`.
+        If the field is complex (i.e. `self.dtype in (np.complex64, np.complex128)`) this method returns
+        the complex conjugate of `self`, element-wise.
+
+        The behavior of this function is similar to `numpy.conjugate(self, out=None)`.
+        """
 
     @abstractmethod
     def __neg__(self):
@@ -180,17 +223,6 @@ class Vector(ABC):
     @abstractmethod
     def __isub__(self, v):
         pass
-
-    @abstractmethod
-    def conjugate(self, out=None):
-        """Compute the complex conjugate vector.
-
-        If the field is real (i.e. `self.dtype in (np.float32, np.float64)`) this method is equivalent to `copy`.
-        If the field is complex (i.e. `self.dtype in (np.complex64, np.complex128)`) this method returns
-        the complex conjugate of `self`, element-wise.
-
-        The behavior of this function is similar to `numpy.conjugate(self, out=None)`.
-        """
 
     #-------------------------------------
     # Methods with default implementation

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -34,7 +34,7 @@ __all__ = (
 #===============================================================================
 class VectorSpace(ABC):
     """
-    Finite-dimensional vector space V with a scalar (dot) product.
+    Finite-dimensional vector space V with a scalar (inner) product.
 
     """
     @property

--- a/psydac/linalg/block.py
+++ b/psydac/linalg/block.py
@@ -97,7 +97,7 @@ class BlockVectorSpace(VectorSpace):
 
         TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
         want to reverse this behavior in order to align with the convention
-        of Fenix.
+        of FEniCS.
 
         Parameters
         ----------

--- a/psydac/linalg/solvers.py
+++ b/psydac/linalg/solvers.py
@@ -143,7 +143,7 @@ class ConjugateGradient(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system Ax = b. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
 
         out : psydac.linalg.basic.Vector | NoneType
@@ -190,7 +190,7 @@ class ConjugateGradient(InverseLinearOperator):
         A.dot(x, out=v)
         b.copy(out=r)
         r -= v
-        am = r.dot(r).real
+        am = r.inner(r).real
         r.copy(out=p)
 
         tol_sqr = tol**2
@@ -209,12 +209,12 @@ class ConjugateGradient(InverseLinearOperator):
                 m -= 1
                 break
             A.dot(p, out=v)
-            l   = am / v.dot(p)
+            l   = am / v.inner(p)
 
             x.mul_iadd(l, p)  # this is x += l*p
             r.mul_iadd(-l, v) # this is r -= l*v
 
-            am1 = r.dot(r).real
+            am1 = r.inner(r).real
             p  *= (am1/am)
             p  += r
             am  = am1
@@ -351,9 +351,9 @@ class PConjugateGradient(InverseLinearOperator):
         A.dot(x, out=v)
         b.copy(out=r)
         r       -= v
-        nrmr_sqr = r.dot(r).real
+        nrmr_sqr = r.inner(r).real
         pc.dot(r, out=s)
-        am       = s.dot(r)
+        am       = s.inner(r)
         s.copy(out=p)
 
         tol_sqr  = tol**2
@@ -374,15 +374,15 @@ class PConjugateGradient(InverseLinearOperator):
                 break
 
             v  = A.dot(p, out=v)
-            l  = am / v.dot(p)
+            l  = am / v.inner(p)
 
             x.mul_iadd(l, p) # this is x += l*p
             r.mul_iadd(-l, v) # this is r -= l*v
 
-            nrmr_sqr = r.dot(r).real
+            nrmr_sqr = r.inner(r).real
             pc.dot(r, out=s)
 
-            am1 = s.dot(r)
+            am1 = s.inner(r)
 
             # we are computing p = (am1 / am) * p + s by using axpy on s and exchanging the arrays
             s.mul_iadd((am1/am), p)
@@ -466,7 +466,7 @@ class BiConjugateGradient(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
 
         out : psydac.linalg.basic.Vector | NoneType
@@ -523,7 +523,7 @@ class BiConjugateGradient(InverseLinearOperator):
         p.copy(out=ps)
         v.copy(out=vs)
 
-        res_sqr = r.dot(r).real
+        res_sqr = r.inner(r).real
         tol_sqr = tol**2
 
         if verbose:
@@ -548,10 +548,10 @@ class BiConjugateGradient(InverseLinearOperator):
             #-----------------------
 
             # c := (rs, r)
-            c = rs.dot(r)
+            c = rs.inner(r)
 
             # a := (rs, r) / (ps, v)
-            a = c / ps.dot(v)
+            a = c / ps.inner(v)
 
             #-----------------------
             # SOLUTION UPDATE
@@ -567,10 +567,10 @@ class BiConjugateGradient(InverseLinearOperator):
             rs.mul_iadd(-a.conjugate(), vs)
 
             # ||r||_2 := (r, r)
-            res_sqr = r.dot(r).real
+            res_sqr = r.inner(r).real
 
             # b := (rs, r)_{m+1} / (rs, r)_m
-            b = rs.dot(r) / c
+            b = rs.inner(r) / c
 
             # p := r + b*p
             p *= b
@@ -654,7 +654,7 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
         out : psydac.linalg.basic.Vector | NoneType
             The output vector, or None (optional).
@@ -715,7 +715,7 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
 
         r.copy(out=r0)
 
-        res_sqr = r.dot(r).real
+        res_sqr = r.inner(r).real
         tol_sqr = tol ** 2
 
         if verbose:
@@ -739,10 +739,10 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
             # -----------------------
 
             # c := (r0, r)
-            c = r0.dot(r)
+            c = r0.inner(r)
 
             # a := (r0, r) / (r0, v)
-            a = c / (r0.dot(v))
+            a = c / (r0.inner(v))
 
             # r := r - a*v
             r.mul_iadd(-a, v)
@@ -751,7 +751,7 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
             vr = A.dot(r, out=vr)
 
             # w := (r, A*r) / (A*r, A*r)
-            w = r.dot(vr) / vr.dot(vr)
+            w = r.inner(vr) / vr.inner(vr)
 
             # -----------------------
             # SOLUTION UPDATE
@@ -765,13 +765,13 @@ class BiConjugateGradientStabilized(InverseLinearOperator):
             r.mul_iadd(-w, vr)
 
             # ||r||_2 := (r, r)
-            res_sqr = r.dot(r).real
+            res_sqr = r.inner(r).real
 
             if res_sqr < tol_sqr:
                 break
 
             # b := a / w * (r0, r)_{m+1} / (r0, r)_m
-            b = r0.dot(r) * a / (c * w)
+            b = r0.inner(r) * a / (c * w)
 
             # p := r + b*p- b*w*v
             p *= b
@@ -853,7 +853,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
         out : psydac.linalg.basic.Vector | NoneType
             The output vector, or None (optional).
@@ -939,14 +939,14 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
         pc.dot(r, out=rp)
         rp.copy(out=pp)
 
-        rhop = rp.dot(rp)
+        rhop = rp.inner(rp)
 
         # save initial residual vector rp0
         rp0 = self._tmps['rp0']
         rp.copy(out=rp0)
 
         # squared residual norm and squared tolerance
-        res_sqr = r.dot(r).real
+        res_sqr = r.inner(r).real
         tol_sqr = tol**2
 
         if verbose:
@@ -964,7 +964,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
             # v = A @ pp, vp = PC @ v, alphap = rhop/(vp.rp0)
             A.dot(pp, out=v)
             pc.dot(v, out=vp)
-            alphap = rhop / vp.dot(rp0)
+            alphap = rhop / vp.inner(rp0)
 
             # s = r - alphap*v, sp = PC @ s
             r.copy(out=s)
@@ -976,7 +976,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
             # t = A @ sp, tp = PC @ t, omegap = (tp.sp)/(tp.tp)
             A.dot(sp, out=t)
             pc.dot(t, out=tp)
-            omegap = tp.dot(sp) / tp.dot(tp)
+            omegap = tp.inner(sp) / tp.inner(tp)
 
             # x = x + alphap*pp + omegap*sp
             pp.copy(out=app)
@@ -996,7 +996,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
             rp -= tp
 
             # rhop_new = rp.rp0, betap = (alphap*rhop_new)/(omegap*rhop)
-            rhop_new = rp.dot(rp0)
+            rhop_new = rp.inner(rp0)
             betap = (alphap*rhop_new) / (omegap*rhop)
             rhop = 1*rhop_new
 
@@ -1007,7 +1007,7 @@ class PBiConjugateGradientStabilized(InverseLinearOperator):
             pp += rp
 
             # new residual norm
-            res_sqr = r.dot(r).real
+            res_sqr = r.inner(r).real
 
             niter += 1
 
@@ -1097,7 +1097,7 @@ class MinimumResidual(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
 
         out : psydac.linalg.basic.Vector | NoneType
@@ -1167,7 +1167,7 @@ class MinimumResidual(InverseLinearOperator):
         y *= -1.0
         y.copy(out=res_old)   # res = b - A*x
 
-        beta = sqrt(res_old.dot(res_old))
+        beta = sqrt(res_old.inner(res_old))
 
         # Initialize other quantities
         oldb    = 0
@@ -1211,7 +1211,7 @@ class MinimumResidual(InverseLinearOperator):
             if itn >= 2:
                 y.mul_iadd(-(beta/oldb), res_old)
 
-            alfa = v.dot(y)
+            alfa = v.inner(y)
             y.mul_iadd(-(alfa/beta), res_new)
 
             # We put res_new in res_old and y in res_new
@@ -1219,7 +1219,7 @@ class MinimumResidual(InverseLinearOperator):
             y.copy(out=res_new)
 
             oldb = beta
-            beta = sqrt(res_new.dot(res_new))
+            beta = sqrt(res_new.inner(res_new))
             tnorm2 += alfa**2 + oldb**2 + beta**2
 
             # Apply previous rotation Qk-1 to get
@@ -1266,7 +1266,7 @@ class MinimumResidual(InverseLinearOperator):
             # Estimate various norms and test for convergence.
 
             Anorm = sqrt(tnorm2)
-            ynorm = sqrt(x.dot(x))
+            ynorm = sqrt(x.inner(x))
 
             rnorm  = phibar
             if ynorm == 0 or Anorm == 0:test1 = inf
@@ -1416,7 +1416,7 @@ class LSMR(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
 
         out : psydac.linalg.basic.Vector | NoneType
@@ -1482,16 +1482,16 @@ class LSMR(InverseLinearOperator):
             btol = tol
 
         b.copy(out=u)
-        normb = sqrt(b.dot(b).real)
+        normb = sqrt(b.inner(b).real)
 
         A.dot(x, out=u_work)
         u -= u_work
-        beta = sqrt(u.dot(u).real)
+        beta = sqrt(u.inner(u).real)
 
         if beta > 0:
             u *= (1 / beta)
             At.dot(u, out=v)
-            alpha = sqrt(v.dot(v).real)
+            alpha = sqrt(v.inner(v).real)
         else:
             x.copy(out=v)
             alpha = 0
@@ -1554,14 +1554,14 @@ class LSMR(InverseLinearOperator):
             u *= -alpha
             A.dot(v, out=u_work)
             u += u_work
-            beta = sqrt(u.dot(u).real)
+            beta = sqrt(u.inner(u).real)
 
             if beta > 0:
                 u     *= (1 / beta)
                 v     *= -beta
                 At.dot(u, out=v_work)
                 v     += v_work
-                alpha = sqrt(v.dot(v).real)
+                alpha = sqrt(v.inner(v).real)
                 if alpha > 0:v *= (1 / alpha)
 
             # At this point, beta = beta_{k+1}, alpha = alpha_{k+1}.
@@ -1638,7 +1638,7 @@ class LSMR(InverseLinearOperator):
 
             # Compute norms for convergence testing.
             normar = abs(zetabar)
-            normx  = sqrt(x.dot(x).real)
+            normx  = sqrt(x.inner(x).real)
 
             # Now use these norms to estimate certain other quantities,
             # some of which will be small near a solution.
@@ -1751,7 +1751,7 @@ class GMRES(InverseLinearOperator):
         b : psydac.linalg.basic.Vector
             Right-hand-side vector of linear system Ax = b. Individual entries b[i] need
             not be accessed, but b has 'shape' attribute and provides 'copy()' and
-            'dot(p)' functions (dot(p) is the vector inner product b*p ); moreover,
+            'inner(p)' functions (b.inner(p) is the vector inner product b*p); moreover,
             scalar multiplication and sum operations are available.
 
         out : psydac.linalg.basic.Vector | NoneType
@@ -1803,7 +1803,7 @@ class GMRES(InverseLinearOperator):
         A.dot( x , out=r)
         r -= b
 
-        am = sqrt(r.dot(r).real)
+        am = sqrt(r.inner(r).real)
         if am < tol:
             self._info = {'niter': 1, 'success': am < tol, 'res_norm': am }
             return x
@@ -1877,10 +1877,10 @@ class GMRES(InverseLinearOperator):
         self._A.dot( self._Q[k] , out=p) # Krylov vector
 
         for i in range(k + 1): # Modified Gram-Schmidt, keeping Hessenberg matrix
-            h[i] = p.dot(self._Q[i])
+            h[i] = p.inner(self._Q[i])
             p.mul_iadd(-h[i], self._Q[i])
         
-        h[k+1] = sqrt(p.dot(p).real)
+        h[k+1] = sqrt(p.inner(p).real)
         p /= h[k+1] # Normalize vector
 
         if len(self._Q) > k + 1:

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -225,7 +225,7 @@ class StencilVectorSpace(VectorSpace):
 
         TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
         want to reverse this behavior in order to align with the convention
-        of Fenix.
+        of FEniCS.
 
         Parameters
         ----------

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -214,6 +214,56 @@ class StencilVectorSpace(VectorSpace):
         """
         return StencilVector(self)
 
+    #...
+    def inner(self, x, y):
+        """
+        Evaluate the inner vector product between two vectors of this space V.
+
+        If the field of V is real, compute the classical scalar product.
+        If the field of V is complex, compute the classical sesquilinear
+        product with linearity on the second vector.
+
+        TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
+        want to reverse this behavior in order to align with the convention
+        of Fenix.
+
+        Parameters
+        ----------
+        x : Vector
+            The first vector in the scalar product. In the case of a complex
+            field, the inner product is antilinear w.r.t. this vector (hence
+            this vector is conjugated).
+
+        y : Vector
+            The second vector in the scalar product. The inner product is
+            linear w.r.t. this vector.
+
+        Returns
+        -------
+        float | complex
+            The scalar product of the two vectors. Note that inner(x, x) is
+            a non-negative real number which is zero if and only if x = 0.
+
+        """
+
+        assert isinstance(x, StencilVector)
+        assert isinstance(y, StencilVector)
+        assert x.space is self
+        assert y.space is self
+
+        inner_func = self._inner_func
+        inner_args = (x._data, y._data, *self._inner_consts)
+
+        if self.parallel:
+            # Sometimes in the parallel case, we can get an empty vector that breaks our kernel
+            x._dot_send_data[0] = 0 if x._data.shape[0] == 0 else inner_func(*inner_args)
+            self.cart.global_comm.Allreduce((x._dot_send_data, self.mpi_type),
+                                            (x._dot_recv_data, self.mpi_type),
+                                             op=MPI.SUM )
+            return x._dot_recv_data[0]
+        else:
+            return inner_func(*inner_args)
+
     # ...
     def axpy(self, a, x, y):
         """
@@ -424,46 +474,47 @@ class StencilVector(Vector):
     def space(self):
         return self._space
 
-    #...
-    @property
-    def dtype(self):
-        return self._space.dtype
-
-    #...
-    def dot(self, v):
+    # ...
+    def toarray(self, *, order='C', with_pads=False):
         """
-        Return the inner vector product between self and v.
-
-        If the values are real, it returns the classical scalar product.
-        If the values are complex, it returns the classical sesquilinear product with linearity on the vector v.
+        Return a numpy 1D array corresponding to the given StencilVector,
+        with or without pads.
 
         Parameters
         ----------
-        v : StencilVector
-            Vector of the same space than self needed for the scalar product.
+        with_pads : bool
+            If True, include pads in output array.
+
+        order: {'C','F'}
+             Memory representation of the data ‘C’ for row-major ordering (C-style), ‘F’ column-major ordering (Fortran-style).
 
         Returns
         -------
-        null: self._space.dtype
-            Scalar containing scalar product of v and self.
+        array : numpy.ndarray
+            A copy of the data array collapsed into one dimension.
 
         """
 
-        assert isinstance(v, StencilVector)
-        assert v._space is self._space
+        # In parallel case, call different functions based on 'with_pads' flag
+        if self.space.parallel:
+            if with_pads:
+                return self._toarray_parallel_with_pads(order=order)
+            else:
+                return self._toarray_parallel_no_pads(order=order)
 
-        inner_func = self._space._inner_func
-        inner_args = (self._data, v._data, *self._space._inner_consts)
+        # In serial case, ignore 'with_pads' flag
+        return self.toarray_local(order=order)
 
-        if self._space.parallel:
-            # Sometimes in the parallel case, we can get an empty vector that breaks our kernel
-            self._dot_send_data[0] = 0 if self._data.shape[0] == 0 else inner_func(*inner_args)
-            self._space.cart.global_comm.Allreduce((self._dot_send_data, self._space.mpi_type),
-                                                   (self._dot_recv_data, self._space.mpi_type),
-                                                   op=MPI.SUM )
-            return self._dot_recv_data[0]
-        else:
-            return inner_func(*inner_args)
+    #...
+    def copy(self, out=None):
+        if self is out:
+            return self
+        w = out or StencilVector( self._space )
+        np.copyto(w._data, self._data, casting='no')
+        for axis, ext in self._space.interfaces:
+            np.copyto(w._interface_data[axis, ext], self._interface_data[axis, ext], casting='no')
+        w._sync = self._sync
+        return w
 
     #...
     def conjugate(self, out=None):
@@ -477,17 +528,6 @@ class StencilVector(Vector):
             np.conjugate(self._interface_data[axis, ext], out=out._interface_data[axis, ext], casting='no')
         out._sync = self._sync
         return out
-
-    #...
-    def copy(self, out=None):
-        if self is out:
-            return self
-        w = out or StencilVector( self._space )
-        np.copyto(w._data, self._data, casting='no')
-        for axis, ext in self._space.interfaces:
-            np.copyto(w._interface_data[axis, ext], self._interface_data[axis, ext], casting='no')
-        w._sync = self._sync
-        return w
 
     #...
     def __neg__(self):
@@ -582,38 +622,6 @@ class StencilVector(Vector):
         txt += '> data    :: {data}\n'  .format( data  = self._data  )
         txt += '> sync    :: {sync}\n'  .format( sync  = self._sync  )
         return txt
-
-    # ...
-    def toarray(self, *, order='C', with_pads=False):
-        """
-        Return a numpy 1D array corresponding to the given StencilVector,
-        with or without pads.
-
-        Parameters
-        ----------
-        with_pads : bool
-            If True, include pads in output array.
-
-        order: {'C','F'}
-             Memory representation of the data ‘C’ for row-major ordering (C-style), ‘F’ column-major ordering (Fortran-style).
-
-        Returns
-        -------
-        array : numpy.ndarray
-            A copy of the data array collapsed into one dimension.
-
-        """
-
-
-        # In parallel case, call different functions based on 'with_pads' flag
-        if self.space.parallel:
-            if with_pads:
-                return self._toarray_parallel_with_pads(order=order)
-            else:
-                return self._toarray_parallel_no_pads(order=order)
-
-        # In serial case, ignore 'with_pads' flag
-        return self.toarray_local(order=order)
 
     # ...
     def toarray_local(self , *, order='C'):

--- a/psydac/linalg/stencil.py
+++ b/psydac/linalg/stencil.py
@@ -483,7 +483,7 @@ class StencilVector(Vector):
         Parameters
         ----------
         with_pads : bool
-            If True, include pads in output array.
+            If True, include pads in output array (ignored in serial case).
 
         order: {'C','F'}
              Memory representation of the data ‘C’ for row-major ordering (C-style), ‘F’ column-major ordering (Fortran-style).

--- a/psydac/linalg/tests/test_block.py
+++ b/psydac/linalg/tests/test_block.py
@@ -328,10 +328,10 @@ def test_block_serial_dimension( ndim, p, P1, P2, P3, dtype ):
     Y[1] = y2
 
     # Test dot product
-    exact_dot = x1.dot(y1)+x2.dot(y2)
+    exact_inner = V.inner(x1, y1) + V.inner(x2, y2)
 
     assert X.dtype == dtype
-    assert np.allclose(X.dot(Y), exact_dot,  rtol=1e-14, atol=1e-14 )
+    assert np.allclose(W.inner(X, Y), exact_inner,  rtol=1e-14, atol=1e-14 )
 
     # Test axpy product
     axpy_exact = X + np.pi * cst * Y
@@ -372,8 +372,8 @@ def test_block_serial_dimension( ndim, p, P1, P2, P3, dtype ):
 
     M = BlockLinearOperator(W, W, blocks=[[M1, M2], [M3, None]])
 
-    Y[0]=M1.dot(x1)+M2.dot(x2)
-    Y[1]=M3.dot(x1)
+    Y[0] = M1.dot(x1) + M2.dot(x2)
+    Y[1] = M3.dot(x1)
 
     assert M.dtype == dtype
     assert np.allclose((M.dot(X)).toarray(), Y.toarray(),  rtol=1e-14, atol=1e-14 )

--- a/psydac/linalg/tests/test_linalg.py
+++ b/psydac/linalg/tests/test_linalg.py
@@ -643,26 +643,26 @@ def test_inverse_transpose_interaction(n1, n2, p1, p2, P1=False, P2=False):
     assert isinstance(C_T, ConjugateGradient)
     assert isinstance(inverse(B_T, 'cg', tol=tol), ConjugateGradient)
     diff = C_T @ u - inverse(B_T, 'cg', tol=tol) @ u
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # -1,T,T -> equal -1
     diff = C_T.T @ u - C @ u
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # -1,T,-1 -> equal T
     assert isinstance(inverse(C_T, 'bicg'), BlockLinearOperator)
     diff = inverse(C_T, 'bicg') @ u - B_T @ u
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # T,-1,-1 -> equal T
     assert isinstance(inverse(inverse(B_T, 'cg', tol=tol), 'pcg', pc=P), BlockLinearOperator)
     diff = inverse(inverse(B_T, 'cg', tol=tol), 'pcg', pc=P) @ u - B_T @ u
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # T,-1,T -> equal -1
     assert isinstance(inverse(B_T, 'cg', tol=tol).T, ConjugateGradient)
     diff = inverse(B_T, 'cg', tol=tol) @ u - C @ u
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     ###
     ### StencilMatrix Transpose - Inverse Tests
@@ -680,26 +680,26 @@ def test_inverse_transpose_interaction(n1, n2, p1, p2, P1=False, P2=False):
     assert isinstance(C_T, ConjugateGradient)
     assert isinstance(inverse(S_T, 'cg', tol=tol), ConjugateGradient)
     diff = C_T @ v - inverse(S_T, 'cg', tol=tol) @ v
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # -1,T,T -> equal -1
     diff = C_T.T @ v - C @ v
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # -1,T,-1 -> equal T
     assert isinstance(inverse(C_T, 'bicg'), StencilMatrix)
     diff = inverse(C_T, 'bicg') @ v - S_T @ v
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # T,-1,-1 -> equal T
     assert isinstance(inverse(inverse(S_T, 'cg', tol=tol), 'pcg', pc=P), StencilMatrix)
     diff = inverse(inverse(S_T, 'cg', tol=tol), 'pcg', pc=P) @ v - S_T @ v
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
     # T,-1,T -> equal -1
     assert isinstance(inverse(S_T, 'cg', tol=tol).T, ConjugateGradient)
     diff = inverse(S_T, 'cg', tol=tol) @ v - C @ v
-    assert diff.dot(diff) == 0
+    assert diff.inner(diff) == 0
 
 #===============================================================================
 @pytest.mark.parametrize('n1', [3, 5])

--- a/psydac/linalg/tests/test_stencil_interface_matrix.py
+++ b/psydac/linalg/tests/test_stencil_interface_matrix.py
@@ -369,7 +369,7 @@ def test_stencil_interface_matrix_2d_parallel_dot(n1, n2, p1, p2, expected):
     y = A.dot(x)
 
     # Check the results
-    assert y.dot(y) == expected
+    assert y.inner(y) == expected
 
 #===============================================================================
 # SCRIPT FUNCTIONALITY

--- a/psydac/linalg/tests/test_stencil_vector.py
+++ b/psydac/linalg/tests/test_stencil_vector.py
@@ -288,8 +288,8 @@ def test_stencil_vector_2d_serial_dot(dtype, n1, n2, p1, p2, s1, s2, P1=True, P2
             y[i1, i2] = f2(i1,i2)
 
     # Create inner vector product (x,y) and (y,x)
-    z1 = x.dot(y)
-    z2 = y.dot(x)
+    z1 = x.inner(y)
+    z2 = y.inner(x)
 
     # Exact value by Numpy dot and vdot
     if dtype==complex:
@@ -939,8 +939,8 @@ def test_stencil_vector_2d_parallel_dot(dtype, n1, n2, p1, p2, s1, s2, P1=True, 
             y[i1, i2] = f2(i1,i2)
 
     # Create scalar product (x,y) and (y,x)
-    res1 = x.dot(y)
-    res2 = y.dot(x)
+    res1 = x.inner(y)
+    res2 = y.inner(x)
 
     # Compute exact value with Numpy dot
     if dtype==complex:
@@ -1008,8 +1008,8 @@ def test_stencil_vector_3d_parallel_dot(dtype, n1, n2, n3, p1, p2, p3, s1, s2, s
                 x[i1, i2, i3] = f2(i1,i2,i3)
 
     # Create scalar product (x,y) and (y,x)
-        res1 = x.dot(y)
-        res2 = y.dot(x)
+        res1 = x.inner(y)
+        res2 = y.inner(x)
     # Compute exact value with Numpy dot
 
     if dtype == complex:

--- a/psydac/polar/dense.py
+++ b/psydac/polar/dense.py
@@ -148,7 +148,7 @@ class DenseVectorSpace(VectorSpace):
 
         TODO [YG 01.05.2025]: Currently, the first vector is conjugated. We
         want to reverse this behavior in order to align with the convention
-        of Fenix.
+        of FEniCS.
 
         Parameters
         ----------


### PR DESCRIPTION
Main changes
--------------
* Rename the method `dot` of the base class `VectorSpace` as `inner`, and make it an abstract method (which must be implemented by the subclasses).

* Rename the method `dot` of the base class `Vector` as `inner`. This is a concrete method which calls `self.space.inner` and does not need to be overridden by the subclasses.

* Add `inner` methods to the classes `StencilVector`, `BlockVectorSpace`, and `DenseVectorSpace`. These methods override the abstract method of the base class as required, and are derived from the former functions `Stencil.dot`, `BlockVector.dot`, and `DenseVector.dot`, which have been removed (see next point).

* Remove the property `dtype` and the method `dot` (now `inner`) from the classes `StencilVector`, `BlockVector`, and `DenseVector`, because the default methods of the base class already provide a sufficient implementation.

This fixes #330.

Necessary additional changes
------------------------------
* Update all linear solvers in `linalg.solvers` with the new method calls;
* Update all unit tests with the new method calls, in files:
   - `api/tests/test_assembly.py`
   - `feec/tests/test_commuting_projections.py`
   - `feec/tests/test_global_projectors.py`
   - `linalg/tests/test_block.py`
   - `linalg/tests/test_linalg.py`
   - `linalg/tests/test_stencil_interface_matrix.py`
   - `linalg/tests/test_stencil_vector.py`

Unrelated additional changes
-----------------------------
* Rename the class `VectorDot` as `VectorInner` in module `api.ast.linalg`, although never used in Psydac.
* Speed up 3D unit tests in:
   - `feec/tests/test_commuting_projectors.py`
   - `feec/tests/test_global_projectors.py`