### PR TITLE
Add a `dot_inner` concrete method to the base class `LinearOperator`

### DIFF
--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -267,32 +267,51 @@ class LinearOperator(ABC):
     @abstractmethod
     def domain(self):
         """ The domain of the linear operator - an element of Vectorspace """
-        pass
 
     @property
     @abstractmethod
     def codomain(self):
         """ The codomain of the linear operator - an element of Vectorspace """
-        pass
 
     @property
     @abstractmethod
     def dtype(self):
-        pass
+        """ The data type of the coefficients of the linear operator,
+        upon convertion to matrix.
+        """
 
     @abstractmethod
     def tosparse(self):
-        pass
+        """ Convert to a sparse matrix in any of the formats supported by scipy.sparse."""
 
     @abstractmethod
     def toarray(self):
         """ Convert to Numpy 2D array. """
-        pass
 
     @abstractmethod
     def dot(self, v, out=None):
-        """ Apply linear operator to Vector v. Result is written to Vector out, if provided."""
-        pass
+        """ Apply the LinearOperator self to the Vector v.
+
+        The result is written to the Vector out, if provided.
+
+        Parameters
+        ----------
+        v : Vector
+            The vector to which the linear operator (self) is applied. It must
+            belong to the domain of self.
+
+        out : Vector
+            The vector in which the result of the operation is stored. It must
+            belong to the codomain of self. If out is None, a new vector is
+            created and returned.
+
+        Returns
+        -------
+        Vector
+            The result of the operation. If out is None, a new vector is
+            returned. Otherwise, the result is stored in out and out is
+            returned.
+        """
 
     @abstractmethod
     def transpose(self, conjugate=False):
@@ -301,7 +320,6 @@ class LinearOperator(ABC):
 
         If conjugate is True, return the Hermitian transpose.
         """
-        pass
 
     # TODO: check if we should add a copy method!!!
 
@@ -335,7 +353,32 @@ class LinearOperator(ABC):
         return self * c
 
     def __matmul__(self, B):
-        """ Creates an object of the class ComposedLinearOperator. """
+        """
+        Matrix multiplication using the @ operator.
+
+        If B is a LinearOperator, create a ComposedLinearOperator object.
+        This is simplified to self if B is an IdentityOperator, and to a
+        ZeroOperator if B is a ZeroOperator.
+
+        If B is a Vector, the @ operator is treated as a matrix-vector
+        multiplication and returns the result of self.dot(B).
+
+        Parameters
+        ----------
+        B : LinearOperator | Vector
+            The object to be multiplied with self. If B is a LinearOperator,
+            its codomain must be equal to the domain of self. If B is a Vector,
+            it must belong to the domain of self.
+
+        Returns
+        -------
+        LinearOperator | Vector
+            If B is a LinearOperator, return a ComposedLinearOperator object,
+            or a simplification to self or a ZeroOperator. In all cases the
+            resulting LinearOperator has the same domain as self and the same
+            codomain as B. If B is a Vector, return the result of self.dot(B),
+            which is a Vector belonging to the codomain of self.
+        """
         assert isinstance(B, (LinearOperator, Vector))
         if isinstance(B, LinearOperator):
             assert self.domain == B.codomain
@@ -380,7 +423,6 @@ class LinearOperator(ABC):
     #-------------------------------------
     # Methods with default implementation
     #-------------------------------------
-
     @property
     def T(self):
         """ Calls transpose method to return the transpose of self. """

--- a/psydac/linalg/basic.py
+++ b/psydac/linalg/basic.py
@@ -445,6 +445,42 @@ class LinearOperator(ABC):
         assert out.space == self.codomain
         out += self.dot(v)
 
+    def dot_inner(self, v, w):
+        """
+        Compute the inner product of (self @ v) with w, without a temporary.
+
+        This is equivalent to self.dot(v).inner(w), but avoids the creation of
+        a temporary vector because the result of self.dot(v) is stored in a
+        local work array. If self is a positive-definite operator, this
+        operation is a (weighted) inner product.
+
+        Parameters
+        ----------
+        v : Vector
+            The vector to which the linear operator (self) is applied. It must
+            belong to the domain of self.
+
+        w : Vector
+            The second vector in the inner product. It must belong to the
+            codomain of self.
+
+        Returns
+        -------
+        float | complex
+            The result of the inner product between (self @ v) and w. If the
+            field of self is real, this is a real number. If the field of self
+            is complex, this is a complex number.
+        """
+        assert isinstance(v, Vector)
+        assert isinstance(w, Vector)
+        assert v.space is self.domain
+        assert w.space is self.codomain
+
+        if not hasattr(self, '_work'):
+            self._work = self.codomain.zeros()
+
+        return self.dot(v, out=self._work).inner(w)
+
 #===============================================================================
 class ZeroOperator(LinearOperator):
     """

--- a/psydac/linalg/tests/test_linalg.py
+++ b/psydac/linalg/tests/test_linalg.py
@@ -40,13 +40,12 @@ def compute_global_starts_ends(domain_decomposition, npts):
 
     return global_starts, global_ends
 
-def get_StencilVectorSpace(n1, n2, p1, p2, P1, P2):
-    npts = [n1, n2]
-    pads = [p1, p2]
-    periods = [P1, P2]
+def get_StencilVectorSpace(npts, pads, periods):
+    assert len(npts) == len(pads) == len(periods)
+    shifts = [1] * len(npts)
     D = DomainDecomposition(npts, periods=periods)
     global_starts, global_ends = compute_global_starts_ends(D, npts)
-    C = CartDecomposition(D, npts, global_starts, global_ends, pads=pads, shifts=[1,1])
+    C = CartDecomposition(D, npts, global_starts, global_ends, pads=pads, shifts=shifts)
     V = StencilVectorSpace(C)
     return V
 
@@ -94,7 +93,7 @@ def test_square_stencil_basic(n1, n2, p1, p2, P1=False, P2=False):
     ###
 
     # Initiate StencilVectorSpace
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     
     # Initiate Linear Operators
     Z = ZeroOperator(V, V)
@@ -280,7 +279,7 @@ def test_square_block_basic(n1, n2, p1, p2, P1=False, P2=False):
     # 3. Test special cases
 
     # Initiate StencilVectorSpace
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
        
     # Initiate Linear Operators
     Z = ZeroOperator(V, V)    
@@ -449,8 +448,8 @@ def test_in_place_operations(n1, n2, p1, p2, P1=False, P2=False):
     # testing __imul__ although not explicitly implemented (in the LinearOperator class)
 
     # Initiate StencilVectorSpace
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-    Vc = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V  = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
+    Vc = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     Vc._dtype = complex
     v = StencilVector(V)
     vc = StencilVector(Vc)
@@ -544,9 +543,9 @@ def test_inverse_transpose_interaction(n1, n2, p1, p2, P1=False, P2=False):
     # 2. For both B and S, check whether all possible combinations of the transpose and the inverse behave as expected
 
     # Initiate StencilVectorSpace
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-    V2 = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-    W = get_StencilVectorSpace(n1+2, n2, p1, p2+1, P1, P2)
+    V  = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
+    V2 = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
+    W  = get_StencilVectorSpace([n1+2, n2], [p1, p2+1], [P1, P2])
     
     # Initiate positive definite StencilMatrices for which the cg inverse works (necessary for certain tests)
     S = StencilMatrix(V, V)
@@ -710,7 +709,7 @@ def test_inverse_transpose_interaction(n1, n2, p1, p2, P1=False, P2=False):
 def test_positive_definite_matrix(n1, n2, p1, p2):
     P1 = False
     P2 = False
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     S = get_positive_definite_StencilMatrix(V)
 
     assert_pos_def(S)
@@ -753,7 +752,7 @@ def test_operator_evaluation(n1, n2, p1, p2):
     P2 = False
 
     # Initiate StencilVectorSpace V
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     
     # Initiate positive definite StencilMatrices for which the cg inverse works (necessary for certain tests)
     S = get_positive_definite_StencilMatrix(V)
@@ -919,7 +918,7 @@ def test_internal_storage():
     p2=1
     P1=False
     P2=False
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     U1 = BlockVectorSpace(V, V)
     U2 = BlockVectorSpace(V, V, V)
 
@@ -970,7 +969,7 @@ def test_x0update(solver):
     p2 = 2
     P1 = False
     P2 = False
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     A = get_positive_definite_StencilMatrix(V)
     assert_pos_def(A)
     b = StencilVector(V)

--- a/psydac/linalg/tests/test_matrix_free.py
+++ b/psydac/linalg/tests/test_matrix_free.py
@@ -63,8 +63,8 @@ def test_fake_matrix_free(n1, n2, p1, p2):
     m2 = n1+1
     q1 = p1 # using same degrees because both spaces must have same padding for now
     q2 = p2 
-    V1 = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
-    V2 = get_StencilVectorSpace(m1, m2, q1, q2, P1, P2)
+    V1 = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
+    V2 = get_StencilVectorSpace([m1, m2], [q1, q2], [P1, P2])
     S = get_random_StencilMatrix(codomain=V2, domain=V1)
     O = MatrixFreeLinearOperator(codomain=V2, domain=V1, dot=lambda v: S @ v)
 
@@ -91,7 +91,7 @@ def test_solvers_matrix_free(solver):
     p2 = 2
     P1 = False
     P2 = False
-    V = get_StencilVectorSpace(n1, n2, p1, p2, P1, P2)
+    V = get_StencilVectorSpace([n1, n2], [p1, p2], [P1, P2])
     A_SM = get_positive_definite_StencilMatrix(V)
     assert_pos_def(A_SM)
     AT_SM = A_SM.transpose()


### PR DESCRIPTION
Implement `M.dot(u).inner(v)`, or `(M @ u).inner(v)`, without creating a temporary vector. The result of the dot product is written to a local work vector stored in the `LinearOperator` object. This work vector is then used to compute the inner product with the vector `v`. The subclasses do not need to override this method, unless a more efficient implementation which avoids writing to the work vector altogether (reducing memory pressure) is needed.

A unit test is added: function `test_dot_inner` in file psydac/linalg/tests/test_linalg.py.

Additionally, the helper function `get_StencilVectorSpace` defined in psydac/linalg/tests/test_linalg.py (only used in the same file and in test_matrix_free.py) has a new signature and now works in any number of dimensions.

Fixes #491.