### PR TITLE
Install PETSc-3.23.2 (latest version)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,7 +111,7 @@ jobs:
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Download a specific release of PETSc
         run: |
-          git clone --depth 1 --branch v3.22.2 https://gitlab.com/petsc/petsc.git
+          git clone --depth 1 --branch v3.23.2 https://gitlab.com/petsc/petsc.git
 
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Install PETSc with complex support


### PR DESCRIPTION
This should avoid an incompatibility between the newly released `Cython-3.1.1` and the `petsc4py` package shipped with the sources of PETSc-3.22.2.