### PR TITLE
Fix bug in `allocate_matrices` in `DiscreteBilinearForm`

### DIFF
--- a/psydac/api/fem.py
+++ b/psydac/api/fem.py
@@ -728,7 +728,7 @@ class DiscreteBilinearForm(BasicDiscrete):
                     trd = trial_degree[j]
                     pads[i,j][:] = np.array([td, trd]).max(axis=0)
         else:
-            pads = test_degree
+            pads = np.maximum(test_degree, trial_degree)
 
         if self._matrix is None and (is_broken or isinstance(expr, (ImmutableDenseMatrix, Matrix))):
             self._matrix = BlockLinearOperator(trial_space, test_space)


### PR DESCRIPTION
Always use the maximum padding between test and trial spaces in `allocate_matrices` in `DiscreteBilinearForm`. (Earlier this was not done in the case of scalar spaces.) Fixes #504.