### PR TITLE
Expand editable install info in README.md

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches: [ devel ]
     paths:
+      - 'README.md'
       - 'docs/**'
       - 'psydac/**.py'
 
   pull_request:
     branches: [ devel, main ]
     paths:
+      - 'README.md'
       - 'docs/**'
       - 'psydac/**.py'
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,9 +14,6 @@ on:
   pull_request:
     branches: [ devel, main ]
     types:
-      - opened
-      - synchronize
-      - reopened
       - ready_for_review
     paths:
       - 'psydac/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+### Fixed
+
+-   #565 Expand editable install info in `README.md`
+
+### Changed
+
+-   [DEVELOPER] Run documentation workflow whenever `README.md` is modified
+-   [DEVELOPER] Run testing workflow on PRs only when set to "ready for review"
+
+### Deprecated
+
+### Removed
+
 ## [1.0.0] - 2026-01-19
 
 The first official release on PyPI. A complete overhaul since version 0.1.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install "psydac[test]"
 Here `<HDF5-PATH>` is the path to the HDF5 root folder, such that `<HDF5-PATH>/lib/` contains the HDF5 dynamic libraries with MPI support.
 
 The last command above installs the latest version of PSYDAC found on [PyPI](https://pypi.org), the Python Package Index, together with some optional packages needed for running the unit tests.
-A developer wanting to modify the source code should skip that command, and instead clone the PSYDAC repository to perform an **editable install**:
+A developer wanting to modify the latest source code on GitHub should skip that command, and instead clone the PSYDAC repository (by default, in the branch `devel`) to perform an **editable install**:
 
 ```bash
 git clone --recurse-submodules https://github.com/pyccel/psydac.git

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ pip install meson-python "pyccel>=2.1.0"
 pip install --no-build-isolation --editable ".[test]"
 ```
 
+The last install command will create a local `build/` folder, which can be inspected in the case of an error.
+We recommend removing such a folder before running the command again (e.g. when installing PSYDAC in multiple virtual environments) in order to avoid conflicts in library path resolution.
 Again, for more details we refer to our [documentation](https://pyccel.github.io/psydac/installation.html).
 
 > [!TIP]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,9 @@ Tracker       = "https://github.com/pyccel/psydac/issues"
 psydac = "psydac.cmd.main:psydac_command"
 
 [tool.meson-python.args]
-setup=['-Ddefault_library=static']
-dist=['--include-subprojects']
-install=['--only=python-modules']
+setup   = ['--default-library=static']
+dist    = ['--include-subprojects']
+install = ['--only=python-modules']
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
**Relevant changes**
- Explain that `devel` branch is cloned by default
- Explain that `build/` folder should be removed before attempting another editable install

**Additional changes**
- Run documentation workflow whenever `README.md` is modified
- Run testing workflow on PRs only when set to "ready for review"
- Add new `Unreleased` section to `CHANGELOG.md`