### PR TITLE
Fix command `psydac test --mpi` on Ubuntu machines

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
         run: |
-          psydac test --mpi --mod psydac.linalg.tests.test_stencil_vector_space
+          psydac test --mpi psydac.linalg.tests.test_stencil_vector_space
 
 #      - name: Run single-process PETSc tests with Pytest
 #        working-directory: ./pytest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,8 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-14 ]
-#        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
-        python-version: [ '3.13', '3.14' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         exclude:
@@ -73,46 +72,46 @@ jobs:
         run: |
           pip install --upgrade pip setuptools wheel
 
-#      - name: Cache PETSc
-#        uses: actions/cache@v4
-#        id: cache-petsc
-#        env:
-#          cache-name: cache-PETSc
-#        with:
-#          path: "./petsc"
-#          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
-#
-#      - if: steps.cache-petsc.outputs.cache-hit != 'true'
-#        name: Download a specific release of PETSc
-#        run: |
-#          git clone --depth 1 --branch v3.24.2 https://gitlab.com/petsc/petsc.git
-#
-#      - if: steps.cache-petsc.outputs.cache-hit != 'true'
-#        name: Install PETSc with complex support
-#        working-directory: ./petsc
-#        run: |
-#          export PETSC_DIR=$(pwd)
-#          export PETSC_ARCH=petsc-cmplx
-#          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
-#          make all
-#          echo "PETSC_DIR=$PETSC_DIR" > petsc.env
-#          echo "PETSC_ARCH=$PETSC_ARCH" >> petsc.env
-#
-#      # This step is not really necessary and could be combined with PETSc install
-#      # step; however it's good to verify if the cached PETSc installation really works!
-#      - name: Test PETSc installation
-#        working-directory: ./petsc
-#        run: |
-#          source petsc.env
-#          make check
-#          echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
-#          echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
-#
-#      - name: Install petsc4py
-#        working-directory: ./petsc
-#        run: | 
-#          pip install wheel Cython numpy
-#          pip install src/binding/petsc4py
+      - name: Cache PETSc
+        uses: actions/cache@v4
+        id: cache-petsc
+        env:
+          cache-name: cache-PETSc
+        with:
+          path: "./petsc"
+          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
+
+      - if: steps.cache-petsc.outputs.cache-hit != 'true'
+        name: Download a specific release of PETSc
+        run: |
+          git clone --depth 1 --branch v3.24.2 https://gitlab.com/petsc/petsc.git
+
+      - if: steps.cache-petsc.outputs.cache-hit != 'true'
+        name: Install PETSc with complex support
+        working-directory: ./petsc
+        run: |
+          export PETSC_DIR=$(pwd)
+          export PETSC_ARCH=petsc-cmplx
+          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
+          make all
+          echo "PETSC_DIR=$PETSC_DIR" > petsc.env
+          echo "PETSC_ARCH=$PETSC_ARCH" >> petsc.env
+
+      # This step is not really necessary and could be combined with PETSc install
+      # step; however it's good to verify if the cached PETSc installation really works!
+      - name: Test PETSc installation
+        working-directory: ./petsc
+        run: |
+          source petsc.env
+          make check
+          echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
+          echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
+
+      - name: Install petsc4py
+        working-directory: ./petsc
+        run: | 
+          pip install wheel Cython numpy
+          pip install src/binding/petsc4py
 
       - name: Install h5py in parallel mode
         uses: ./.github/actions/parallel_h5py
@@ -130,54 +129,54 @@ jobs:
         run: |
           mkdir pytest
 
-#      - name: Run coverage tests on macOS
-#        if: matrix.os == 'macos-14'
-#        working-directory: ./pytest
-#        run: >-
-#          pytest -n auto
-#          --cov psydac
-#          --cov-config $GITHUB_WORKSPACE/pyproject.toml
-#          --cov-report xml
-#          --pyargs psydac -m "not mpi and not petsc" -ra
+      - name: Run coverage tests on macOS
+        if: matrix.os == 'macos-14'
+        working-directory: ./pytest
+        run: >-
+          pytest -n auto
+          --cov psydac
+          --cov-config $GITHUB_WORKSPACE/pyproject.toml
+          --cov-report xml
+          --pyargs psydac -m "not mpi and not petsc" -ra
 
       - name: Run single-process tests with Pytest on Ubuntu
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./pytest
         run: |
-          psydac test --mod psydac.linalg.tests.test_stencil_vector_space
+          psydac test
 
-#      - name: Upload coverage report to Codacy
-#        if: matrix.os == 'macos-14'
-#        uses: codacy/codacy-coverage-reporter-action@v1.3.0
-#        with:
-#          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-#          coverage-reports: ./pytest/coverage.xml
-#
-#      - name: Print detailed coverage results on macOS
-#        if: matrix.os == 'macos-14'
-#        working-directory: ./pytest
-#        run: |
-#          coverage report --ignore-errors --show-missing --sort=cover
+      - name: Upload coverage report to Codacy
+        if: matrix.os == 'macos-14'
+        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: ./pytest/coverage.xml
+
+      - name: Print detailed coverage results on macOS
+        if: matrix.os == 'macos-14'
+        working-directory: ./pytest
+        run: |
+          coverage report --ignore-errors --show-missing --sort=cover
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
         run: |
-          psydac test --mpi psydac.linalg.tests.test_stencil_vector_space
+          psydac test --mpi
 
-#      - name: Run single-process PETSc tests with Pytest
-#        working-directory: ./pytest
-#        run: |
-#          psydac test --petsc
-#
-#      - name: Run MPI PETSc tests with Pytest
-#        working-directory: ./pytest
-#        run: |
-#          psydac test --mpi --petsc
-#
-#      - name: Run single-process example tests with Pytest on Ubuntu
-#        if: matrix.os == 'ubuntu-24.04'
-#        run: |
-#          python -m pytest examples/feec
+      - name: Run single-process PETSc tests with Pytest
+        working-directory: ./pytest
+        run: |
+          psydac test --petsc
+
+      - name: Run MPI PETSc tests with Pytest
+        working-directory: ./pytest
+        run: |
+          psydac test --mpi --petsc
+
+      - name: Run single-process example tests with Pytest on Ubuntu
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          python -m pytest examples/feec
 
       - name: Remove test directory
         if: always()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -140,8 +140,9 @@ jobs:
 #          --cov-report xml
 #          --pyargs psydac -m "not mpi and not petsc" -ra
 
-      - name: Run single-process tests with Pytest on Ubuntu
-        if: matrix.os == 'ubuntu-24.04'
+#      - name: Run single-process tests with Pytest on Ubuntu
+#        if: matrix.os == 'ubuntu-24.04'
+      - name: Run single-process tests with Pytest
         working-directory: ./pytest
         run: |
           psydac test --mod psydac.linalg.tests.test_stencil_vector_space

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -29,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-24.04, macos-14 ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+#        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.13', '3.14' ]
         isMerge:
           - ${{ github.event_name == 'push' && github.ref == 'refs/heads/devel' }}
         exclude:
@@ -72,46 +73,46 @@ jobs:
         run: |
           pip install --upgrade pip setuptools wheel
 
-      - name: Cache PETSc
-        uses: actions/cache@v4
-        id: cache-petsc
-        env:
-          cache-name: cache-PETSc
-        with:
-          path: "./petsc"
-          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
-
-      - if: steps.cache-petsc.outputs.cache-hit != 'true'
-        name: Download a specific release of PETSc
-        run: |
-          git clone --depth 1 --branch v3.24.2 https://gitlab.com/petsc/petsc.git
-
-      - if: steps.cache-petsc.outputs.cache-hit != 'true'
-        name: Install PETSc with complex support
-        working-directory: ./petsc
-        run: |
-          export PETSC_DIR=$(pwd)
-          export PETSC_ARCH=petsc-cmplx
-          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
-          make all
-          echo "PETSC_DIR=$PETSC_DIR" > petsc.env
-          echo "PETSC_ARCH=$PETSC_ARCH" >> petsc.env
-
-      # This step is not really necessary and could be combined with PETSc install
-      # step; however it's good to verify if the cached PETSc installation really works!
-      - name: Test PETSc installation
-        working-directory: ./petsc
-        run: |
-          source petsc.env
-          make check
-          echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
-          echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
-
-      - name: Install petsc4py
-        working-directory: ./petsc
-        run: | 
-          pip install wheel Cython numpy
-          pip install src/binding/petsc4py
+#      - name: Cache PETSc
+#        uses: actions/cache@v4
+#        id: cache-petsc
+#        env:
+#          cache-name: cache-PETSc
+#        with:
+#          path: "./petsc"
+#          key: petsc-${{ matrix.os }}-${{ matrix.python-version }}
+#
+#      - if: steps.cache-petsc.outputs.cache-hit != 'true'
+#        name: Download a specific release of PETSc
+#        run: |
+#          git clone --depth 1 --branch v3.24.2 https://gitlab.com/petsc/petsc.git
+#
+#      - if: steps.cache-petsc.outputs.cache-hit != 'true'
+#        name: Install PETSc with complex support
+#        working-directory: ./petsc
+#        run: |
+#          export PETSC_DIR=$(pwd)
+#          export PETSC_ARCH=petsc-cmplx
+#          ./configure --with-scalar-type=complex --with-fortran-bindings=0 --have-numpy=1         
+#          make all
+#          echo "PETSC_DIR=$PETSC_DIR" > petsc.env
+#          echo "PETSC_ARCH=$PETSC_ARCH" >> petsc.env
+#
+#      # This step is not really necessary and could be combined with PETSc install
+#      # step; however it's good to verify if the cached PETSc installation really works!
+#      - name: Test PETSc installation
+#        working-directory: ./petsc
+#        run: |
+#          source petsc.env
+#          make check
+#          echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
+#          echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
+#
+#      - name: Install petsc4py
+#        working-directory: ./petsc
+#        run: | 
+#          pip install wheel Cython numpy
+#          pip install src/binding/petsc4py
 
       - name: Install h5py in parallel mode
         uses: ./.github/actions/parallel_h5py
@@ -129,54 +130,54 @@ jobs:
         run: |
           mkdir pytest
 
-      - name: Run coverage tests on macOS
-        if: matrix.os == 'macos-14'
-        working-directory: ./pytest
-        run: >-
-          pytest -n auto
-          --cov psydac
-          --cov-config $GITHUB_WORKSPACE/pyproject.toml
-          --cov-report xml
-          --pyargs psydac -m "not mpi and not petsc" -ra
+#      - name: Run coverage tests on macOS
+#        if: matrix.os == 'macos-14'
+#        working-directory: ./pytest
+#        run: >-
+#          pytest -n auto
+#          --cov psydac
+#          --cov-config $GITHUB_WORKSPACE/pyproject.toml
+#          --cov-report xml
+#          --pyargs psydac -m "not mpi and not petsc" -ra
 
       - name: Run single-process tests with Pytest on Ubuntu
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./pytest
         run: |
-          psydac test
+          psydac test --mod psydac.linalg.tests.test_stencil_vector_space
 
-      - name: Upload coverage report to Codacy
-        if: matrix.os == 'macos-14'
-        uses: codacy/codacy-coverage-reporter-action@v1.3.0
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: ./pytest/coverage.xml
-
-      - name: Print detailed coverage results on macOS
-        if: matrix.os == 'macos-14'
-        working-directory: ./pytest
-        run: |
-          coverage report --ignore-errors --show-missing --sort=cover
+#      - name: Upload coverage report to Codacy
+#        if: matrix.os == 'macos-14'
+#        uses: codacy/codacy-coverage-reporter-action@v1.3.0
+#        with:
+#          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+#          coverage-reports: ./pytest/coverage.xml
+#
+#      - name: Print detailed coverage results on macOS
+#        if: matrix.os == 'macos-14'
+#        working-directory: ./pytest
+#        run: |
+#          coverage report --ignore-errors --show-missing --sort=cover
 
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
         run: |
-          psydac test --mpi
+          psydac test --mpi psydac.linalg.tests.test_stencil_vector_space
 
-      - name: Run single-process PETSc tests with Pytest
-        working-directory: ./pytest
-        run: |
-          psydac test --petsc
-
-      - name: Run MPI PETSc tests with Pytest
-        working-directory: ./pytest
-        run: |
-          psydac test --mpi --petsc
-
-      - name: Run single-process example tests with Pytest on Ubuntu
-        if: matrix.os == 'ubuntu-24.04'
-        run: |
-          python -m pytest examples/feec
+#      - name: Run single-process PETSc tests with Pytest
+#        working-directory: ./pytest
+#        run: |
+#          psydac test --petsc
+#
+#      - name: Run MPI PETSc tests with Pytest
+#        working-directory: ./pytest
+#        run: |
+#          psydac test --mpi --petsc
+#
+#      - name: Run single-process example tests with Pytest on Ubuntu
+#        if: matrix.os == 'ubuntu-24.04'
+#        run: |
+#          python -m pytest examples/feec
 
       - name: Remove test directory
         if: always()

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -140,9 +140,8 @@ jobs:
 #          --cov-report xml
 #          --pyargs psydac -m "not mpi and not petsc" -ra
 
-#      - name: Run single-process tests with Pytest on Ubuntu
-#        if: matrix.os == 'ubuntu-24.04'
-      - name: Run single-process tests with Pytest
+      - name: Run single-process tests with Pytest on Ubuntu
+        if: matrix.os == 'ubuntu-24.04'
         working-directory: ./pytest
         run: |
           psydac test --mod psydac.linalg.tests.test_stencil_vector_space

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Run MPI tests with Pytest
         working-directory: ./pytest
         run: |
-          psydac test --mpi psydac.linalg.tests.test_stencil_vector_space
+          psydac test --mpi --mod psydac.linalg.tests.test_stencil_vector_space
 
 #      - name: Run single-process PETSc tests with Pytest
 #        working-directory: ./pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 -   #565 Expand editable install info in `README.md`
+-   #566 Fix command `psydac test --mpi` on Ubuntu machines
 
 ### Changed
 

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -78,7 +78,6 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
             exit_with_error_message(f"module '{mod}' not found")
 
     # Import modules here to speed up parser
-    import os
     import shutil
     import subprocess
 
@@ -124,7 +123,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     flags.extend(['--pyargs', mod])
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
-    flags.extend(['-m', f'"{mpi_mark} and {petsc_mark}"'])
+    flags.extend(['-m', f'({mpi_mark} and {petsc_mark})'])
 
     # Default flags for pytest
     flags.append('-ra')  # show extra test summary info for skipped, failed, etc.
@@ -140,11 +139,12 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
 
     # Print the command
     print('Executing command:')
-    print(f' {" ".join(cmd)}\n')
+    cmd_to_print = [a.replace('(', '"(').replace(')', ')"') for a in cmd]
+    print(f' {" ".join(cmd_to_print)}\n', flush=True)
 
-    # Strip double quotes if zsh is used as shell
-    if os.environ.get('SHELL', '').endswith('zsh'):
-        cmd = [arg.replace('"', '') for arg in cmd]
+#    # Strip double quotes if zsh is used as shell
+#    if os.environ.get('SHELL', '').endswith('zsh'):
+#        cmd = [arg.replace('"', '') for arg in cmd]
 
     # Execute the command
     subprocess.run(cmd, shell=False)

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -81,6 +81,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     import platform
     import shutil
     import subprocess
+    import time
 
     flags = []
 
@@ -145,4 +146,5 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     # Execute the command
     print('Executing command:')
     print(f' {" ".join(cmd)}', end='\n\n', flush=True)
+    time.sleep(0.1)  # ensure the print is shown before subprocess output
     subprocess.run(cmd, shell=False)

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -125,8 +125,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     flags.extend(['--pyargs', mod])
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
-    marker_expr = f'({mpi_mark} and {petsc_mark})'
-    flags.extend(['-m', marker_expr])
+    flags.extend(['-m', f'{mpi_mark} and {petsc_mark}'])
 
     # Default flags for pytest
     flags.append('-ra')  # show extra test summary info for skipped, failed, etc.

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -79,7 +79,6 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
 
     # Import modules here to speed up parser
     import os
-    import platform
     import shutil
     import subprocess
     import time
@@ -127,9 +126,6 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
     marker_expr = f'({mpi_mark} and {petsc_mark})'
-    # Add quotes on Ubuntu when mpirun is used
-    if mpi and platform.system() == 'Linux':
-        marker_expr = f'"{marker_expr}"'
     flags.extend(['-m', marker_expr])
 
     # Default flags for pytest

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -78,6 +78,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
             exit_with_error_message(f"module '{mod}' not found")
 
     # Import modules here to speed up parser
+    import os
     import shutil
     import subprocess
 
@@ -123,7 +124,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     flags.extend(['--pyargs', mod])
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
-    flags.extend(['-m', f'{mpi_mark} and {petsc_mark}'])
+    flags.extend(['-m', f'"{mpi_mark} and {petsc_mark}"'])
 
     # Default flags for pytest
     flags.append('-ra')  # show extra test summary info for skipped, failed, etc.
@@ -137,7 +138,13 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     # Command to be executed
     cmd = [*mpi_exe, shutil.which('pytest'), *flags]
 
-    # Execute the command
+    # Print the command
     print('Executing command:')
     print(f' {" ".join(cmd)}\n')
+
+    # Strip double quotes if zsh is used as shell
+    if os.environ.get('SHELL', '').endswith('zsh'):
+        cmd = [arg.replace('"', '') for arg in cmd]
+
+    # Execute the command
     subprocess.run(cmd, shell=False)

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -125,7 +125,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     flags.extend(['--pyargs', mod])
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
-    flags.extend(['-m', f'{mpi_mark} and {petsc_mark}'])
+    flags.extend(['-m', f'({mpi_mark} and {petsc_mark})'])
 
     # Default flags for pytest
     flags.append('-ra')  # show extra test summary info for skipped, failed, etc.

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -78,6 +78,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
             exit_with_error_message(f"module '{mod}' not found")
 
     # Import modules here to speed up parser
+    import platform
     import shutil
     import subprocess
 
@@ -123,7 +124,11 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     flags.extend(['--pyargs', mod])
     mpi_mark = 'mpi' if mpi else 'not mpi'
     petsc_mark = 'petsc' if petsc else 'not petsc'
-    flags.extend(['-m', f'({mpi_mark} and {petsc_mark})'])
+    marker_expr = f'({mpi_mark} and {petsc_mark})'
+    # Add quotes on Ubuntu when mpirun is used
+    if mpi and platform.system() == 'Linux':
+        marker_expr = f'"{marker_expr}"'
+    flags.extend(['-m', marker_expr])
 
     # Default flags for pytest
     flags.append('-ra')  # show extra test summary info for skipped, failed, etc.

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -140,8 +140,11 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     # Command to be executed
     cmd = [*mpi_exe, shutil.which('pytest'), *flags]
 
-    # Execute the command
+    # Print command
+    cmd_to_print = [a.replace('(', '"(',).replace(')', ')"') for a in cmd]
     print('Executing command:')
-    print(f' {" ".join(cmd)}', end='\n\n', flush=True)
+    print(f' {" ".join(cmd_to_print)}', end='\n\n', flush=True)
     time.sleep(0.1)  # ensure the print is shown before subprocess output
+
+    # Execute the command
     subprocess.run(cmd, shell=False, env=os.environ)

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -142,14 +142,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     # Command to be executed
     cmd = [*mpi_exe, shutil.which('pytest'), *flags]
 
-    # Print the command
-    print('Executing command:')
-    cmd_to_print = [a.replace('(', '"(').replace(')', ')"') for a in cmd]
-    print(f' {" ".join(cmd_to_print)}\n', flush=True)
-
-#    # Strip double quotes if zsh is used as shell
-#    if os.environ.get('SHELL', '').endswith('zsh'):
-#        cmd = [arg.replace('"', '') for arg in cmd]
-
     # Execute the command
+    print('Executing command:')
+    print(f' {" ".join(cmd)}', end='\n\n', flush=True)
     subprocess.run(cmd, shell=False)

--- a/psydac/cmd/psydac_test.py
+++ b/psydac/cmd/psydac_test.py
@@ -78,6 +78,7 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
             exit_with_error_message(f"module '{mod}' not found")
 
     # Import modules here to speed up parser
+    import os
     import platform
     import shutil
     import subprocess
@@ -147,4 +148,4 @@ def psydac_test(*, mod, mpi, petsc, verbose, exitfirst):
     print('Executing command:')
     print(f' {" ".join(cmd)}', end='\n\n', flush=True)
     time.sleep(0.1)  # ensure the print is shown before subprocess output
-    subprocess.run(cmd, shell=False)
+    subprocess.run(cmd, shell=False, env=os.environ)


### PR DESCRIPTION
Make sure that the MPI tests on Ubuntu are collected by Pytest when run through `mpirun`. To this end, pass `env=os.environ` to `subprocess.run()`.

**Other changes**
- Make sure that the full command is printed before being executed
- Print the command with quotes to allow copy & paste to the terminal
- Update `CHANGELOG.md`