### PR TITLE
Update CI installation of `h5py` and `petsc4py` after release of `setuptools` 81.0

### DIFF
--- a/.github/actions/parallel_h5py/action.yml
+++ b/.github/actions/parallel_h5py/action.yml
@@ -20,9 +20,18 @@ runs:
       run: |
         export CC="mpicc"
         export HDF5_MPI="ON"
-        pip install 'setuptools<81.0'
-        pip install h5py --no-cache-dir --no-binary h5py
+        git clone https://github.com/h5py/h5py.git
+        cd h5py
+        pip install -v .
         pip list
+
+#    - name: Install h5py in parallel mode
+#      shell: bash
+#      run: |
+#        export CC="mpicc"
+#        export HDF5_MPI="ON"
+#        pip install h5py --no-cache-dir --no-binary h5py
+#        pip list
 
     - name: Check parallel h5py installation
       shell: bash

--- a/.github/actions/parallel_h5py/action.yml
+++ b/.github/actions/parallel_h5py/action.yml
@@ -20,6 +20,7 @@ runs:
       run: |
         export CC="mpicc"
         export HDF5_MPI="ON"
+        pip install 'setuptools<81.0'
         pip install h5py --no-cache-dir --no-binary h5py
         pip list
 

--- a/.github/actions/parallel_h5py/action.yml
+++ b/.github/actions/parallel_h5py/action.yml
@@ -15,6 +15,7 @@ runs:
         echo $HDF5_DIR
         echo "HDF5_DIR=$HDF5_DIR" >> $GITHUB_ENV
 
+# To be deactivated when a new version of h5py is released on PyPI
     - name: Install h5py in parallel mode
       shell: bash
       run: |
@@ -25,6 +26,7 @@ runs:
         pip install -v .
         pip list
 
+# To be reactivated when a new version of h5py is released on PyPI
 #    - name: Install h5py in parallel mode
 #      shell: bash
 #      run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Upgrade pip, setuptools, and wheel
       run: |
-        pip install --upgrade pip 'setuptools<81.0' wheel
+        pip install --upgrade pip setuptools wheel
 
     - name: Cache PETSc
       uses: actions/cache@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: Upgrade pip, setuptools, and wheel
       run: |
-        pip install --upgrade pip setuptools wheel
+        pip install --upgrade pip 'setuptools<81.0' wheel
 
     - name: Cache PETSc
       uses: actions/cache@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,10 +10,8 @@ on:
 
   pull_request:
     branches: [ devel, main ]
-    paths:
-      - 'README.md'
-      - 'docs/**'
-      - 'psydac/**.py'
+    types:
+      - ready_for_review
 
   workflow_dispatch:
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -70,7 +70,9 @@ jobs:
     - if: steps.cache-petsc.outputs.cache-hit != 'true'
       name: Download a specific release of PETSc
       run: |
-        git clone --depth 1 --branch v3.23.2 https://gitlab.com/petsc/petsc.git
+        git clone --depth 1 -b release https://gitlab.com/petsc/petsc.git
+        # when a tag will be available for the latest release we can install with 
+        # git clone --depth 1 --branch v*.**.* https://gitlab.com/petsc/petsc.git
 
     - if: steps.cache-petsc.outputs.cache-hit != 'true'
       name: Install PETSc with complex support

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -80,8 +80,10 @@ jobs:
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Download a specific release of PETSc
         run: |
-          git clone --depth 1 --branch v3.24.2 https://gitlab.com/petsc/petsc.git
-
+          git clone --depth 1 -b release https://gitlab.com/petsc/petsc.git
+        # when a tag will be available for the latest release we can install with 
+        # git clone --depth 1 --branch v*.**.* https://gitlab.com/petsc/petsc.git
+        
       - if: steps.cache-petsc.outputs.cache-hit != 'true'
         name: Install PETSc with complex support
         working-directory: ./petsc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ All notable changes to this project will be documented in this file.
 -   #570 : Optimize PSYDAC logo
 -   #565 : Expand editable install info in `README.md`
 -   #566 : Fix command `psydac test --mpi` on Ubuntu machines
+-   [DEVELOPER] Update CI installation of `h5py` and `petsc4py` after release of `setuptools` 81.0
 
 ### Changed
 
 -   [DEVELOPER] Do not check file changes to trigger testing workflow on PRs
--   [DEVELOPER] Run documentation workflow whenever `README.md` is modified
--   [DEVELOPER] Run testing workflow on PRs only when set to "ready for review"
+-   [DEVELOPER] Run documentation workflow on pushes to `devel` whenever `README.md` is modified
+-   [DEVELOPER] Run testing and documentation workflows on PRs only when set to "ready for review"
 
 ### Deprecated
 


### PR DESCRIPTION
On 06 Feb 2026 [`setuptools v81.0.0`](https://setuptools.pypa.io/en/stable/history.html#v81-0-0) was released with breaking changes, i.e. the support for the parameter `--dry-run` was removed from `setup.py`. As a consequence, our installed versions of `h5py` and `petsc4py` have stopped working. As a temporary fix for our CI workflows, we install the latest package versions from their respective repositories, where the issue has been fixed.

**Detailed list of changes**

- Download `h5py` from GitHub (`master` branch) and build it from sources, instead of installing the latest release from PyPI.
- Change the PETSc `git clone` command to download the 'release' branch instead of a broken version. Hence we install the latest package from the official GitLab repository. (When a new version number is available, we can point the `git clone` command to it.)
- Trigger documentation workflow when PR is set to "Ready for review".

