### PR TITLE
Allow installation with parametrisable backend language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+-   #577 : Add an installation configuration option to choose the backend language.
+
 ### Fixed
 
 -   #571 : Fix correct application of the sum factorization algorithm
 -   #570 : Optimize PSYDAC logo
 -   #565 : Expand editable install info in `README.md`
 -   #566 : Fix command `psydac test --mpi` on Ubuntu machines
+-   #577 : Fix installation following release of Pyccel v2.1.0.
 -   [DEVELOPER] Update CI installation of `h5py` and `petsc4py` after release of `setuptools` 81.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
--   #577 : Add an installation configuration option to choose the backend language.
+-   #577 : Add an installation configuration option to choose the backend language
 
 ### Fixed
 
+-   #577 : Fix installation following release of Pyccel 2.2
 -   #571 : Fix correct application of the sum factorization algorithm
 -   #570 : Optimize PSYDAC logo
 -   #565 : Expand editable install info in `README.md`
 -   #566 : Fix command `psydac test --mpi` on Ubuntu machines
--   #577 : Fix installation following release of Pyccel v2.1.0.
 -   [DEVELOPER] Update CI installation of `h5py` and `petsc4py` after release of `setuptools` 81.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Again, for more details we refer to our [documentation](https://pyccel.github.io
 > This gives the user access to a wide variety of linear solvers and other algorithms.
 > Instructions for installing [PETSc](https://petsc.org) and `petsc4py` can be found in our [documentation](https://pyccel.github.io/psydac/installation.html#id9).
 
+> [!TIP]
+> PSYDAC is installed with a Fortran backend by default however it is possible to request a different language backend by adding `-Csetup-args="-Dpyccel_language=<language>"` to the pip command (e.g. `-Csetup-args="-Dpyccel_language=c"`).
+> This is particularly useful if you want to use psydac in a project which also uses Pyccel for acceleration.
+
 ## Running Tests
 
 We strongly advice users and developers to run the test suite of PSYDAC to verify the correct installation on their machine (possibly a supercomputer).

--- a/README.md
+++ b/README.md
@@ -73,13 +73,12 @@ We recommend removing such a folder before running the command again (e.g. when 
 Again, for more details we refer to our [documentation](https://pyccel.github.io/psydac/installation.html).
 
 > [!TIP]
+> By default Pyccel provides PSYDAC with a Fortran backend, however it is possible to request a different language as described [below](#speeding-up-psydacs-core).
+
+> [!TIP]
 > PSYDAC provides the functionality to convert its MPI-parallel matrices and vectors to their [PETSc](https://petsc.org) equivalent, and back.
 > This gives the user access to a wide variety of linear solvers and other algorithms.
 > Instructions for installing [PETSc](https://petsc.org) and `petsc4py` can be found in our [documentation](https://pyccel.github.io/psydac/installation.html#id9).
-
-> [!TIP]
-> PSYDAC is installed with a Fortran backend by default however it is possible to request a different language backend by adding `-Csetup-args="-Dpyccel_language=<language>"` to the pip command (e.g. `-Csetup-args="-Dpyccel_language=c"`).
-> This is particularly useful if you want to use psydac in a project which also uses Pyccel for acceleration.
 
 ## Running Tests
 
@@ -105,6 +104,12 @@ Many of PSYDAC's low-level Python functions can be translated to a compiled lang
 Currently, all of those functions are collected in modules which follow the name pattern `[module]_kernels.py`.
 
 For both classical and editable installations, *all kernel files are translated to Fortran __without user intervention__*.
+Another language supported by Pyccel can be chosen by adding the `-Csetup-args="-Dpyccel_language=<language>"` to the `pip install` command.
+For example, a classical installation of PSYDAC with C is obtained by running the command
+```bash
+pip install "psydac[test]" -Csetup-args="-Dpyccel_language=C"
+```
+
 If the user adds or edits a kernel file within an editable install, they should use the command `psydac compile` in order to be able to see the changes at runtime.
 This command applies Pyccel to all the kernel files in the source directory.
 The default language is Fortran, and C is also available.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A developer wanting to modify the latest source code on GitHub should skip that 
 git clone --recurse-submodules https://github.com/pyccel/psydac.git
 cd psydac
 
-pip install meson-python "pyccel>=2.1.0"
+pip install meson-python "pyccel>=2.2.2"
 pip install --no-build-isolation --editable ".[test]"
 ```
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,13 @@ project(
   meson_version: '>=1.1.0',
 )
 
-run_command('pyccel', 'make', '-g', 'psydac/**/*_kernels.py', '--convert-only',
+pyccel_main_language = get_option('pyccel_language')
+
+message('Translating kernels to ' + pyccel_main_language)
+
+language_flag = '--language=' + pyccel_main_language
+
+run_command('pyccel', 'make', '-g', 'psydac/**/*_kernels.py', '--convert-only', '--language=' + pyccel_main_language,
     check: true)
 
 find = find_program('find', required: true)

--- a/meson.build
+++ b/meson.build
@@ -13,8 +13,9 @@ run_command('pyccel', 'make', '-g', 'psydac/**/*_kernels.py', '--convert-only', 
 
 find = find_program('find', required: true)
 
-# Python dependencies
-py = import('python').find_installation('/usr/bin/python3.13', modules: ['numpy'])
+py = import('python').find_installation(modules: ['numpy'], pure: false)
+
+# Math dependencies
 cc = meson.get_compiler('c')
 m_dep = cc.find_library('m', required : false)
 
@@ -42,8 +43,6 @@ endforeach
 
 
 igakit_proj = subproject('igakit')
-
-py = import('python').find_installation(modules: ['numpy'], pure: false)
 
 subdir('__pyccel__/math')
 subdir('__pyccel__/cwrapper')

--- a/meson.build
+++ b/meson.build
@@ -8,8 +8,6 @@ pyccel_main_language = get_option('pyccel_language')
 
 message('Translating kernels to ' + pyccel_main_language)
 
-language_flag = '--language=' + pyccel_main_language
-
 run_command('pyccel', 'make', '-g', 'psydac/**/*_kernels.py', '--convert-only', '--language=' + pyccel_main_language,
     check: true)
 

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,11 @@ run_command('pyccel', 'make', '-g', 'psydac/**/*_kernels.py', '--convert-only', 
 
 find = find_program('find', required: true)
 
+# Python dependencies
+py = import('python').find_installation('/usr/bin/python3.13', modules: ['numpy'])
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required : false)
+
 pyccel_meson_math_file = run_command(find, '__pyccel__/math', '-name', 'meson.build',
     check: true).stdout().strip()
 pyccel_meson_cwrapper_file = run_command(find, '__pyccel__/cwrapper', '-name', 'meson.build',

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,2 @@
+option('pyccel_language', type : 'string', value : 'fortran', description : 'The language that Pyccel translates to [default: Fortran].')
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["meson-python", "pyccel >= 2.1.0"]
+requires = ["meson-python", "pyccel >= 2.2.2"]
 build-backend = "mesonpy"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
     # Our packages from PyPi
     'sympde == 0.19.2',
-    'pyccel >= 2.1.0',
+    'pyccel >= 2.2.2',
     'gelato == 0.12',
 
     # MPI for Python provides Python bindings for the


### PR DESCRIPTION
Allow Psydac to be installed with a parametrisable backend (C or Fortran). Following changes to the meson files generated by Pyccel the root `meson.build` file is updated to define `py` and `m_dep`.