### PR TITLE
Use PETSc version 3.25.5

### DIFF
--- a/.github/actions/install_petsc4py/action.yml
+++ b/.github/actions/install_petsc4py/action.yml
@@ -18,7 +18,7 @@ runs:
       name: Download a specific release of PETSc
       shell: bash
       run: |
-        git clone --depth 1 --branch v3.25.4 https://gitlab.com/petsc/petsc.git
+        git clone --depth 1 --branch v3.25.5 https://gitlab.com/petsc/petsc.git
       # The branch "release" contains work towards the next version of PETSc,
       # and it may not be stable. If necessary, it can be cloned as follows:
       # git clone --depth 1 --branch release https://gitlab.com/petsc/petsc.git
@@ -45,12 +45,6 @@ runs:
         make check
         echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
         echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
-
-    # Use Cython >= 3, < 3.3
-    - name: Patch petsc4py build requirements
-      shell: bash
-      run: |
-        patch petsc/src/binding/petsc4py/pyproject.toml petsc4py.patch
 
     - name: Install petsc4py
       shell: bash

--- a/.github/actions/install_petsc4py/action.yml
+++ b/.github/actions/install_petsc4py/action.yml
@@ -46,6 +46,12 @@ runs:
         echo "PETSC_DIR=$PETSC_DIR" >> $GITHUB_ENV
         echo "PETSC_ARCH=$PETSC_ARCH" >> $GITHUB_ENV
 
+    # Use Cython >= 3, < 3.3
+    - name: Patch petsc4py build requirements
+      shell: bash
+      run: |
+        patch petsc/src/binding/petsc4py/pyproject.toml petsc4py.patch
+
     - name: Install petsc4py
       shell: bash
       working-directory: ./petsc

--- a/.github/actions/install_petsc4py/action.yml
+++ b/.github/actions/install_petsc4py/action.yml
@@ -18,7 +18,7 @@ runs:
       name: Download a specific release of PETSc
       shell: bash
       run: |
-        git clone --depth 1 --branch v3.25.0 https://gitlab.com/petsc/petsc.git
+        git clone --depth 1 --branch v3.25.4 https://gitlab.com/petsc/petsc.git
       # The branch "release" contains work towards the next version of PETSc,
       # and it may not be stable. If necessary, it can be cloned as follows:
       # git clone --depth 1 --branch release https://gitlab.com/petsc/petsc.git

--- a/.github/actions/install_petsc4py/action.yml
+++ b/.github/actions/install_petsc4py/action.yml
@@ -56,5 +56,5 @@ runs:
       shell: bash
       working-directory: ./petsc
       run: | 
-        pip install wheel Cython numpy
+        pip install wheel numpy
         pip install src/binding/petsc4py

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.repository == 'pyccel/psydac' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/deploy_check.yml
+++ b/.github/workflows/deploy_check.yml
@@ -21,13 +21,13 @@ jobs:
           paths: '["psydac/**", "pyproject.toml", ".github/workflows/deploy_check.yml", ".github/actions/**"]'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Checkout repository
         if: steps.duplicate_check.outputs.should_skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,12 +28,15 @@ jobs:
       OMP_NUM_THREADS: 2
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
+      with:
+        submodules: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
+
     - name: Install non-Python dependencies on Ubuntu
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,10 +40,12 @@ jobs:
       OMP_NUM_THREADS: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
--   #593 : Use PETSc 3.25.4 whose Python bindings `petsc4py` install correctly with `cython>=3.3.0`
+-   #593 : Use PETSc 3.25.4 with patch on Python bindings `petsc4py` to build with `cython>=3,<3.3`
 -   #580 : Use PETSc 3.25.0 whose Python bindings `petsc4py` install correctly with `setuptools>=81.0`
 -   #579 : Require `pyccel>=2.2.3` which can compile all kernels with C
 -   #579 : Require `numpy>=2.1` to support Python >= 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+-   #593 : Use PETSc 3.25.4 whose Python bindings `petsc4py` install correctly with `cython>=3.3.0`
 -   #580 : Use PETSc 3.25.0 whose Python bindings `petsc4py` install correctly with `setuptools>=81.0`
 -   #579 : Require `pyccel>=2.2.3` which can compile all kernels with C
 -   #579 : Require `numpy>=2.1` to support Python >= 3.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
--   #593 : Use PETSc 3.25.4 with patch on Python bindings `petsc4py` to build with `cython>=3,<3.3`
+-   #595 : Use PETSc 3.25.5 whose Python bindings `petsc4py` are built correctly with `cython>=3`
 -   #580 : Use PETSc 3.25.0 whose Python bindings `petsc4py` install correctly with `setuptools>=81.0`
 -   #579 : Require `pyccel>=2.2.3` which can compile all kernels with C
 -   #579 : Require `numpy>=2.1` to support Python >= 3.10

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -160,9 +160,9 @@ Although PSYDAC provides several iterative linear solvers which work with our na
 (`petsc4py` is a Python package which provides Python bindings to PETSc.) After solving the linear system with a PETSc solver, the function `petsc_to_psydac` allows converting the solution vector back to the PSYDAC format.
 
 In order to use these additional feature, PETSc and petsc4py must be installed as follows.
-First, we download the latest release of PETSc from its [official Git repository](https://gitlab.com/petsc/petsc):
+First, we download a recent release of PETSc from its [official Git repository](https://gitlab.com/petsc/petsc):
 ```sh
-git clone --depth 1 --branch v3.25.4 https://gitlab.com/petsc/petsc.git
+git clone --depth 1 --branch v3.25.5 https://gitlab.com/petsc/petsc.git
 ```
 Next, we specify a configuration for complex numbers, and install PETSc in a local directory:
 ```sh

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -162,7 +162,7 @@ Although PSYDAC provides several iterative linear solvers which work with our na
 In order to use these additional feature, PETSc and petsc4py must be installed as follows.
 First, we download the latest release of PETSc from its [official Git repository](https://gitlab.com/petsc/petsc):
 ```sh
-git clone --depth 1 --branch v3.25.0 https://gitlab.com/petsc/petsc.git
+git clone --depth 1 --branch v3.25.4 https://gitlab.com/petsc/petsc.git
 ```
 Next, we specify a configuration for complex numbers, and install PETSc in a local directory:
 ```sh

--- a/petsc4py.patch
+++ b/petsc4py.patch
@@ -1,8 +1,0 @@
-@@ -1,6 +1,6 @@
- [build-system]
- requires = [
--  "cython >= 3",
-+  "cython >= 3, < 3.3",
-   "numpy",
-   "setuptools",
- ]

--- a/petsc4py.patch
+++ b/petsc4py.patch
@@ -1,0 +1,8 @@
+@@ -1,6 +1,6 @@
+ [build-system]
+ requires = [
+-  "cython >= 3",
++  "cython >= 3, < 3.3",
+   "numpy",
+   "setuptools",
+ ]


### PR DESCRIPTION
Following the release of PETSc version 3.25.5 on August 30, 2026:

- Update PETSc version in docs/installation.md from 3.25.0 to 3.25.5
- Download PETSc 3.25.5 in GitHub workflows

Additional changes:

- Update GitHub actions `checkout` and `setup-python` to version 6 in all workflows